### PR TITLE
Remove enforcement of eager mode when loading 8bit/4bit BnB models

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -353,13 +353,6 @@ class ModelConfig:
             raise ValueError(
                 "BitAndBytes quantization with TP or PP is not supported yet.")
 
-        # Remove the constraint after the bitsandbytes issue is fixed:
-        # https://github.com/bitsandbytes-foundation/bitsandbytes/issues/1308
-        if self.quantization == "bitsandbytes" and self.enforce_eager is False:
-            logger.warning("CUDA graph is not supported on BitAndBytes yet, "
-                           "fallback to the eager mode.")
-            self.enforce_eager = True
-
     def get_hf_config_sliding_window(self) -> Optional[int]:
         """Get the sliding window size, or None if disabled."""
 


### PR DESCRIPTION
Removes enforcement of eager mode when loading 8bit/4bit BnB models