### PR TITLE
improve vllm latency in PD disagg

### DIFF
--- a/vllm/attention/backends/abstract.py
+++ b/vllm/attention/backends/abstract.py
@@ -124,6 +124,8 @@ class AttentionMetadata:
     multi_modal_placeholder_index_maps: Optional[Dict[
         str, MultiModalPlaceholderMap.IndexMap]]
 
+    token_hashes: List[str]
+
     @property
     @abstractmethod
     def prefill_metadata(self) -> Optional["AttentionMetadata"]:

--- a/vllm/attention/backends/utils.py
+++ b/vllm/attention/backends/utils.py
@@ -276,6 +276,7 @@ class CommonMetadataBuilder(AttentionMetadataBuilder[TAttentionMetadata]):
             context_lens_tensor=context_lens_tensor,
             block_tables=block_tables,
             use_cuda_graph=use_captured_graph,
+            token_hashes=[],
         )
 
 

--- a/vllm/attention/backends/xformers.py
+++ b/vllm/attention/backends/xformers.py
@@ -229,7 +229,8 @@ class XFormersMetadata(AttentionMetadata, PagedAttentionMetadata):
             encoder_seq_lens_tensor=self.encoder_seq_lens_tensor,
             max_encoder_seq_len=self.max_encoder_seq_len,
             cross_slot_mapping=self.cross_slot_mapping,
-            cross_block_tables=self.cross_block_tables)
+            cross_block_tables=self.cross_block_tables,
+            token_hashes=self.token_hashes)
         return self._cached_prefill_metadata
 
     @property
@@ -269,7 +270,9 @@ class XFormersMetadata(AttentionMetadata, PagedAttentionMetadata):
             encoder_seq_lens_tensor=self.encoder_seq_lens_tensor,
             max_encoder_seq_len=self.max_encoder_seq_len,
             cross_slot_mapping=self.cross_slot_mapping,
-            cross_block_tables=self.cross_block_tables)
+            cross_block_tables=self.cross_block_tables,
+            token_hashes=[],
+        )
 
         # Batch may be composed of prefill|decodes, adjust query start indices
         # to refer to the start of decodes when the two are split apart.

--- a/vllm/distributed/kv_transfer/base.py
+++ b/vllm/distributed/kv_transfer/base.py
@@ -14,16 +14,16 @@ class KVCacheTransporterBase(ABC):
 
     @abstractmethod
     def read_kv_cache(self, prompt_token_page_hashes: List[str],
-                      prompt_seq_lengths: List[int],
-                      offsets: List[Tuple[int, int]], layer_idx: int,
-                      kv_cache: torch.Tensor) -> None:
+                      prompt_seq_lengths: List[int], offsets: List[Tuple[int,
+                                                                         int]],
+                      layer_idx: int, kv_cache: torch.Tensor) -> None:
 
         raise NotImplementedError
 
     @abstractmethod
     def save_hidden_states(self, prompt_token_page_hashes: List[str],
                            prompt_seq_lengths: List[int],
-                           hidden_states: torch.Tensor) ->None:
+                           hidden_states: torch.Tensor) -> None:
 
         raise NotImplementedError
 
@@ -33,13 +33,14 @@ class KVCacheTransporterBase(ABC):
                            hidden_states: torch.Tensor):
 
         raise NotImplementedError
-    
+
     def get_hidden_states_cache_key(self, page_hash: str) -> str:
         raise NotImplementedError
-    
-    def get_kv_cache_key(self, page_hash: str, layer_idx: int) -> Tuple[str, str]:
+
+    def get_kv_cache_key(self, page_hash: str,
+                         layer_idx: int) -> Tuple[str, str]:
         raise NotImplementedError
-    
+
     @abstractmethod
     def key_exists(self, key: str) -> bool:
         raise NotImplementedError
@@ -52,7 +53,13 @@ class KVCacheTransporterBase(ABC):
     def synchronize(self):
 
         raise NotImplementedError
-    
+
     @abstractmethod
-    def publish_kv_cache_prefill_done(self, input_token_hashes: List[str], seq_lens: List[int], layer_idx: int) -> None:
+    def publish_kv_cache_prefill_done(self, input_token_hashes: List[str],
+                                      seq_lens: List[int],
+                                      layer_idx: int) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def check_kv_cache_ready(self, hash: str) -> bool:
         raise NotImplementedError

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -1,6 +1,5 @@
 """Sampling parameters for text generation."""
 import copy
-import os
 from dataclasses import dataclass
 from enum import Enum, IntEnum
 from functools import cached_property
@@ -407,7 +406,10 @@ class SamplingParams(
                 RequestOutputKind.DELTA):
             raise ValueError("best_of must equal n to use output_kind=DELTA")
 
-        if os.environ.get("PD_SEPARATE_STAGE", "").lower() == "prefill":
+        # use local imports to avoid circular imports
+        from vllm.distributed.kv_transfer.utils import (PDDisaggStage,
+                                                        get_pd_stage)
+        if get_pd_stage() == PDDisaggStage.PREFILL:
             if self.max_tokens is None or self.max_tokens != 1:
                 logger.warning("Prefill run only generates one token. "
                                "max_tokens is set to 1.")

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -433,6 +433,14 @@ class Sequence:
         # Input + output tokens
         self.tokens: Optional[List[str]] = None
 
+        # using local import to aoivd circular import
+        from vllm.distributed.kv_transfer.utils import (
+            PDDisaggStage, get_pd_stage, compute_token_page_hashes)
+
+        if get_pd_stage() != PDDisaggStage.NONE:
+            self.prompt_token_hashes = compute_token_page_hashes(
+                self.prompt_token_ids, [len(self.prompt_token_ids)])
+
     @property
     def n_blocks(self) -> int:
         return (self.get_len() + self.block_size - 1) // self.block_size
@@ -473,6 +481,10 @@ class Sequence:
     def prompt_adapter_id(self) -> int:
         return self.prompt_adapter_request.prompt_adapter_id \
                         if self.prompt_adapter_request else 0
+
+    @property
+    def last_prompt_hash(self) -> str:
+        return self.prompt_token_hashes[-1] if self.prompt_token_hashes else ""
 
     def get_output_text_to_return(self, buffer_length: int,
                                   delta: bool) -> str:

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -2,7 +2,6 @@
 from typing import List
 
 import torch
-import os
 
 from vllm.attention import get_attn_backend
 from vllm.config import CacheConfig, DeviceConfig, ModelConfig, ParallelConfig
@@ -66,7 +65,10 @@ class CacheEngine:
             self.num_gpu_blocks, self.device_config.device_type)
         self.cpu_cache = self._allocate_kv_cache(self.num_cpu_blocks, "cpu")
 
-        if os.environ.get("PD_SEPARATE_STAGE", "") != "":
+        # use local imports to avoid circular imports
+        from vllm.distributed.kv_transfer.utils import (PDDisaggStage,
+                                                        get_pd_stage)
+        if get_pd_stage() != PDDisaggStage.NONE:
             self.set_kv_cache_transporter()
 
     def set_kv_cache_transporter(self):


### PR DESCRIPTION
This PR includes some updates to help improve e2e latency:

1. Skip the sampling in prefill side as the first token is returned by the decode side.
2. In decode side, download the KV cache before a request is scheduled, thus avoiding the waiting in model forward pass.
3. only write the hidden_states in TP where rank == 0, as the hidden states are the same across all the ranks.
4. compute the token hashes BEFORE the input_ids are turned into tensors in GPU. Tests show that computing hashes based on GPU tensors are detrimental to prefill latencies. Now the hashes are computed and attached to AttentionMetadata.
5. handle the case of request preemption in the decode side.

This PR also update the benchmark tool to have a better control of the prompts when using booksum datasets. It makes sure that every sequence is unique if the users wants it. User can also control the repitition rate of the prompts being tested now.