### PR TITLE
Fix/deepep batched marlin activation compaction

### DIFF
--- a/.buildkite/test_areas/engine.yaml
+++ b/.buildkite/test_areas/engine.yaml
@@ -38,7 +38,7 @@ steps:
     - pytest -v -s v1/engine --ignore v1/engine/test_preprocess_error_handling.py
   mirror:
     amd:
-      device: mi300_1
+      device: mi325_1
       timeout_in_minutes: 40
       depends_on:
       - image-build-amd

--- a/.buildkite/test_areas/entrypoints.yaml
+++ b/.buildkite/test_areas/entrypoints.yaml
@@ -28,7 +28,7 @@ steps:
   - pytest -v -s entrypoints/offline_mode # Needs to avoid interference with other tests
   mirror:
     amd:
-      device: mi300_1
+      device: mi325_1
       soft_fail: true
       depends_on:
       - image-build-amd
@@ -46,7 +46,7 @@ steps:
   - pytest -v -s entrypoints/openai/chat_completion --ignore=entrypoints/openai/chat_completion/test_chat_with_tool_reasoning.py --ignore=entrypoints/openai/chat_completion/test_oot_registration.py
   mirror:
     amd:
-      device: mi300_1
+      device: mi325_1
       soft_fail: true
       timeout_in_minutes: 80
       depends_on:
@@ -65,7 +65,7 @@ steps:
   - pytest -v -s entrypoints/test_chat_utils.py
   mirror:
     amd:
-      device: mi300_1
+      device: mi325_1
       soft_fail: true
       timeout_in_minutes: 60
       depends_on:
@@ -85,7 +85,7 @@ steps:
   - pytest -v -s entrypoints/openai --ignore=entrypoints/openai/chat_completion --ignore=entrypoints/openai/completion --ignore=entrypoints/openai/correctness/ --ignore=entrypoints/openai/tool_parsers/ --ignore=entrypoints/openai/responses --ignore=entrypoints/openai/test_multi_api_servers.py
   mirror:
     amd:
-      device: mi300_1
+      device: mi325_1
       soft_fail: true
       timeout_in_minutes: 60
       depends_on:
@@ -108,7 +108,7 @@ steps:
   - pytest -v -s tool_use
   mirror:
     amd:
-      device: mi300_1
+      device: mi325_1
       soft_fail: true
       depends_on:
       - image-build-amd

--- a/.buildkite/test_areas/kernels.yaml
+++ b/.buildkite/test_areas/kernels.yaml
@@ -86,7 +86,7 @@ steps:
   parallelism: 2
   mirror:
     amd:
-      device: mi300_1
+      device: mi325_1
       source_file_dependencies:
       - csrc/quantization/
       - vllm/model_executor/layers/quantization

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -52,7 +52,7 @@ steps:
     - pytest -v -s v1/test_outputs.py
   mirror:
     amd:
-      device: mi300_1
+      device: mi325_1
       depends_on:
       - image-build-amd
 

--- a/.buildkite/test_areas/models_language.yaml
+++ b/.buildkite/test_areas/models_language.yaml
@@ -50,7 +50,7 @@ steps:
   mirror:
     torch_nightly: {}
     amd:
-      device: mi300_1
+      device: mi325_1
       depends_on:
       - image-build-amd
       commands:
@@ -96,7 +96,7 @@ steps:
     - pytest -v -s models/language/pooling -m 'not core_model'
   mirror:
     amd:
-      device: mi300_1
+      device: mi325_1
       timeout_in_minutes: 100
       depends_on:
       - image-build-amd

--- a/.buildkite/test_areas/models_multimodal.yaml
+++ b/.buildkite/test_areas/models_multimodal.yaml
@@ -15,7 +15,7 @@ steps:
     - pytest -v -s models/multimodal/generation/test_ultravox.py -m core_model
   mirror:
     amd:
-      device: mi300_1
+      device: mi325_1
       depends_on:
       - image-build-amd
 
@@ -33,7 +33,7 @@ steps:
     - pytest -v -s models/multimodal/generation/test_vit_cudagraph.py -m core_model
   mirror:
     amd:
-      device: mi300_1
+      device: mi325_1
       depends_on:
       - image-build-amd
 
@@ -50,7 +50,7 @@ steps:
     - pytest -v -s models/multimodal/generation/test_qwen2_vl.py -m core_model
   mirror:
     amd:
-      device: mi300_1
+      device: mi325_1
       depends_on:
       - image-build-amd
 
@@ -118,7 +118,7 @@ steps:
     - pytest -v -s models/multimodal/test_mapping.py
   mirror:
     amd:
-      device: mi300_1
+      device: mi325_1
       depends_on:
       - image-build-amd
 

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -103,6 +103,19 @@ pull_request_rules:
       add:
         - frontend
 
+- name: label-rust
+  description: Automatically apply rust label
+  conditions:
+    - label != stale
+    - or:
+      - files~=(?i)rust
+      - title~=(?i)rust
+      - title~=(?i)vllm-rs
+  actions:
+    label:
+      add:
+        - rust
+
 - name: label-llama
   description: Automatically apply llama label
   conditions:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,16 +365,30 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
   # are not supported by Machete yet.
 
   # marlin arches for fp16 output
-  cuda_archs_loose_intersection(MARLIN_ARCHS "8.0+PTX" "${CUDA_ARCHS}")
+  # Family-conditional 12.0f (one cubin for SM12x family) requires CUDA >= 13.0;
+  # fall back to architecture-specific 12.0a;12.1a on CUDA < 13.0 (e.g. 12.8).
+  if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 13.0)
+    cuda_archs_loose_intersection(MARLIN_ARCHS "8.0+PTX;12.0f" "${CUDA_ARCHS}")
+  else()
+    cuda_archs_loose_intersection(MARLIN_ARCHS "8.0+PTX;12.0a;12.1a" "${CUDA_ARCHS}")
+  endif()
   # marlin has limited support for turing
   cuda_archs_loose_intersection(MARLIN_SM75_ARCHS "7.5" "${CUDA_ARCHS}")
   # marlin arches for bf16 output (we need 9.0 for bf16 atomicAdd PTX)
-  cuda_archs_loose_intersection(MARLIN_BF16_ARCHS "8.0+PTX;9.0+PTX" "${CUDA_ARCHS}")
+  if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 13.0)
+    cuda_archs_loose_intersection(MARLIN_BF16_ARCHS "8.0+PTX;9.0+PTX;12.0f" "${CUDA_ARCHS}")
+  else()
+    cuda_archs_loose_intersection(MARLIN_BF16_ARCHS "8.0+PTX;9.0+PTX;12.0a;12.1a" "${CUDA_ARCHS}")
+  endif()
   # marlin arches for fp8 input
   # - sm80 doesn't support fp8 computation
   # - sm90 and sm100 don't support QMMA.16832.F32.E4M3.E4M3 SAAS instruction
   # so we only enable fp8 computation for SM89 (e.g. RTX 40x0)  and 12.0 (e.g. RTX 50x0)
-  cuda_archs_loose_intersection(MARLIN_FP8_ARCHS "8.9;12.0;12.1" "${CUDA_ARCHS}")
+  if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 13.0)
+    cuda_archs_loose_intersection(MARLIN_FP8_ARCHS "8.9;12.0f" "${CUDA_ARCHS}")
+  else()
+    cuda_archs_loose_intersection(MARLIN_FP8_ARCHS "8.9;12.0a;12.1a" "${CUDA_ARCHS}")
+  endif()
   # marlin arches for other files
   cuda_archs_loose_intersection(MARLIN_OTHER_ARCHS "7.5;8.0+PTX" "${CUDA_ARCHS}")
 
@@ -1121,7 +1135,11 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
   # moe marlin arches
   # note that we always set `use_atomic_add=False` for moe marlin now,
   # so we don't need 9.0 for bf16 atomicAdd PTX
-  cuda_archs_loose_intersection(MARLIN_MOE_ARCHS "8.0+PTX" "${CUDA_ARCHS}")
+  if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 13.0)
+    cuda_archs_loose_intersection(MARLIN_MOE_ARCHS "8.0+PTX;12.0f" "${CUDA_ARCHS}")
+  else()
+    cuda_archs_loose_intersection(MARLIN_MOE_ARCHS "8.0+PTX;12.0a;12.1a" "${CUDA_ARCHS}")
+  endif()
   # moe marlin has limited support for turing
   cuda_archs_loose_intersection(MARLIN_MOE_SM75_ARCHS "7.5" "${CUDA_ARCHS}")
   # moe marlin arches for fp8 input

--- a/csrc/quantization/marlin/marlin.cu
+++ b/csrc/quantization/marlin/marlin.cu
@@ -400,10 +400,12 @@ void marlin_mm(const void* A, const void* B, void* C, void* C_tmp, void* b_bias,
                 "Turing only support FP16 or INT8 activation.");
   }
   if (a_type == vllm::kFE4M3fn) {
+    TORCH_CHECK(major_capability * 10 + minor_capability >= 89,
+                "FP8 only support Ada Lovelace or newer GPUs.");
     TORCH_CHECK(
         major_capability * 10 + minor_capability == 89 ||
-            major_capability * 10 + minor_capability == 120,
-        "Marlin W4A8-FP8 only support SM89 or SM120 device (It is slower than "
+            major_capability == 12,
+        "Marlin W4A8-FP8 only support SM89 or SM12x device (It is slower than "
         "Marlin W4A16 on other devices).");
   }
 

--- a/docs/benchmarking/cli.md
+++ b/docs/benchmarking/cli.md
@@ -918,6 +918,41 @@ vllm bench serve \
 
 </details>
 
+### Replay Timed Traces
+
+<details class="admonition abstract" markdown="1">
+<summary>Show more</summary>
+
+Example of how to run traces which have timing information
+with them.
+
+#### Running MoonshotAI traces
+
+Start the server:
+
+```bash
+vllm serve Qwen/Qwen3.5-2B \
+--host 127.0.0.1 --port 8000
+```
+
+Run the benchmark:
+
+```bash
+# Download an example trace 
+# curl -L -o conversation_trace.jsonl \
+#https://raw.githubusercontent.com/kvcache-ai/Mooncake/main/FAST25-release/traces/conversation_trace.jsonl 
+
+vllm bench serve --model Qwen/Qwen3.5-2B \  
+--dataset-name=timed_trace --num-prompts 100 --host 127.0.0.1 \
+--port 8000 --dataset-path ./conversation_trace.jsonl \
+--ignore-eos  --self-timed --timed-trace-chunk-hash-size 512 \
+--timed-trace-sec-multiplier 0.001 
+```
+
+This will replay the first 100 lines from the trace file `conversation.jsonl`.  
+
+</details>
+
 ### 🧪 Hashing Benchmarks
 
 <details class="admonition abstract" markdown="1">

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -335,7 +335,7 @@ _TEXT_GENERATION_EXAMPLE_MODELS = {
     "HYV3ForCausalLM": _HfExamplesInfo("tencent/Hy3-preview", trust_remote_code=True),
     "HyperCLOVAXForCausalLM": _HfExamplesInfo(
         "naver-hyperclovax/HyperCLOVAX-SEED-Think-14B",
-        trust_remote_code=True,
+        min_transformers_version="5.9.0",
     ),
     "InternLMForCausalLM": _HfExamplesInfo(
         "internlm/internlm-chat-7b", trust_remote_code=True

--- a/tests/tool_parsers/test_deepseekv32_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv32_tool_parser.py
@@ -10,6 +10,7 @@ import json
 from unittest.mock import MagicMock
 
 import pytest
+from openai.types.responses.function_tool import FunctionTool
 
 from tests.tool_parsers.utils import run_tool_extraction_streaming
 from vllm.entrypoints.openai.chat_completion.protocol import (
@@ -718,6 +719,81 @@ class TestExtractToolCallsStreaming:
             "patches": [{"op": "replace", "path": "/schedule", "value": "quiet"}],
         }
 
+    def test_responses_function_tool_schema_in_streaming(self):
+        """Responses API FunctionTool schemas must drive streaming conversion."""
+        tool = FunctionTool(
+            type="function",
+            name="toggle",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "enabled": {"type": "boolean"},
+                    "count": {"type": "integer"},
+                },
+            },
+        )
+        parser = make_parser(tools=[tool])
+        full_text = (
+            f"{FC_START}\n"
+            f'{INV_START}toggle">\n'
+            f'{PARAM_START}enabled" string="false">true{PARAM_END}\n'
+            f'{PARAM_START}count" string="false">42{PARAM_END}\n'
+            f"{INV_END}\n"
+            f"{FC_END}"
+        )
+
+        deltas = self._stream(parser, full_text)
+        args = json.loads(self._reconstruct_args(deltas))
+
+        assert args == {"enabled": True, "count": 42}
+        assert isinstance(args["enabled"], bool)
+        assert isinstance(args["count"], int)
+
+    def test_streaming_matches_non_streaming_conversion_fallbacks(self):
+        """Streaming must reuse conversion fallback semantics for string=false."""
+        tool = ChatCompletionToolsParam(
+            function=FunctionDefinition(
+                name="coerce",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "union_value": {"type": ["null", "string"]},
+                        "bad_int": {"type": "integer"},
+                        "nullable_string": {"type": ["null", "string"]},
+                        "null_string": {"type": "string"},
+                        "whole_number": {"type": "number"},
+                    },
+                },
+            ),
+        )
+        parser = make_parser(tools=[tool])
+        full_text = (
+            f"{FC_START}\n"
+            f'{INV_START}coerce">\n'
+            f'{PARAM_START}union_value" string="false">hello{PARAM_END}\n'
+            f'{PARAM_START}bad_int" string="false">abc{PARAM_END}\n'
+            f'{PARAM_START}nullable_string" string="false">null{PARAM_END}\n'
+            f'{PARAM_START}null_string" string="false">null{PARAM_END}\n'
+            f'{PARAM_START}whole_number" string="false">3.0{PARAM_END}\n'
+            f"{INV_END}\n"
+            f"{FC_END}"
+        )
+
+        non_stream = parser.extract_tool_calls(full_text, None)
+        non_stream_args = json.loads(non_stream.tool_calls[0].function.arguments)
+
+        deltas = self._stream(parser, full_text)
+        stream_args = json.loads(self._reconstruct_args(deltas))
+
+        assert stream_args == non_stream_args
+        assert stream_args == {
+            "union_value": "hello",
+            "bad_int": "abc",
+            "nullable_string": None,
+            "null_string": "null",
+            "whole_number": 3,
+        }
+
     def test_multiple_tools_streaming(self, parser):
         full_text = (
             f"{FC_START}\n"
@@ -890,8 +966,8 @@ class TestExtractToolCallsStreaming:
         assert json.loads(self._reconstruct_args(deltas, tool_index=0)) == {"p": "v1"}
         assert json.loads(self._reconstruct_args(deltas, tool_index=1)) == {"q": "v2"}
 
-    def test_no_emission_while_incomplete(self, parser):
-        """No tool calls should be emitted until an invoke block completes."""
+    def test_emits_arguments_before_invoke_completes(self, parser):
+        """Argument deltas should stream before the invoke block closes."""
         # Stream only a partial invoke (no closing tag)
         partial_text = (
             f"{FC_START}\n"
@@ -899,8 +975,13 @@ class TestExtractToolCallsStreaming:
             f'{PARAM_START}k" string="true">val{PARAM_END}\n'
         )
         deltas = self._stream(parser, partial_text)
-        # Should have no tool call deltas yet
-        assert all(not d.tool_calls for d in deltas)
+        arg_chunks = [
+            tc.function.arguments
+            for delta in deltas
+            for tc in delta.tool_calls or []
+            if tc.function and tc.function.arguments is not None
+        ]
+        assert "".join(arg_chunks) == '{"k":"val"'
 
     def test_no_marker_leak_chunked(self, parser):
         """Chunked streaming must NOT leak DSML start-marker fragments

--- a/tests/tool_parsers/test_deepseekv4_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv4_tool_parser.py
@@ -14,6 +14,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionNamedToolChoiceParam,
     ChatCompletionRequest,
     ChatCompletionToolsParam,
+    FunctionDefinition,
 )
 from vllm.tool_parsers import ToolParserManager
 from vllm.tool_parsers.deepseekv4_tool_parser import DeepSeekV4ToolParser
@@ -164,9 +165,55 @@ def test_streaming_extracts_complete_invokes():
         for delta in deltas
         if delta.tool_calls
         for tool_call in delta.tool_calls
+        if tool_call.function.name
     ]
     assert names == ["search"]
     assert json.loads(reconstruct_args(deltas)) == {"query": "deepseek v4"}
+
+
+def test_streaming_emits_incremental_argument_chunks():
+    tool = ChatCompletionToolsParam(
+        function=FunctionDefinition(
+            name="plan_trip",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "days": {"type": "integer"},
+                    "flexible": {"type": "boolean"},
+                    "cities": {"type": "array", "items": {"type": "string"}},
+                    "notes": {"type": "string"},
+                },
+            },
+        ),
+    )
+    parser = make_parser(tools=[tool])
+    full_text = (
+        f"{TC_START}\n"
+        f'{INV_START}plan_trip">\n'
+        f'{PARAM_START}days" string="false">3{PARAM_END}\n'
+        f'{PARAM_START}flexible" string="false">false{PARAM_END}\n'
+        f'{PARAM_START}cities" string="false">'
+        f'["Beijing","Shanghai","Tokyo","New York"]{PARAM_END}\n'
+        f'{PARAM_START}notes" string="true">靠窗座位{PARAM_END}\n'
+        f"{INV_END}\n"
+        f"{TC_END}"
+    )
+
+    deltas = stream(parser, full_text, chunk_size=4)
+    arg_chunks = [
+        tool_call.function.arguments
+        for delta in deltas
+        for tool_call in delta.tool_calls or []
+        if tool_call.function and tool_call.function.arguments is not None
+    ]
+
+    assert len([chunk for chunk in arg_chunks if chunk]) > 2
+    assert json.loads("".join(arg_chunks)) == {
+        "days": 3,
+        "flexible": False,
+        "cities": ["Beijing", "Shanghai", "Tokyo", "New York"],
+        "notes": "靠窗座位",
+    }
 
 
 def test_get_vllm_registry_structural_tag_returns_structural_tag(

--- a/vllm/benchmarks/datasets/datasets.py
+++ b/vllm/benchmarks/datasets/datasets.py
@@ -83,6 +83,7 @@ class SampleRequest:
     multi_modal_data: MultiModalDataDict | dict | list[dict] | None = None
     lora_request: LoRARequest | None = None
     request_id: str | None = None
+    timestamp: float | None = None
 
 
 # -----------------------------------------------------------------------------
@@ -1399,6 +1400,168 @@ class ShareGPTDataset(BenchmarkDataset):
         return samples
 
 
+class TimedTrace(BenchmarkDataset):
+    """
+    Implements a base class to replay various timed traces.
+    Loads data from a JSON file and generates sample requests
+    based on the timing information in the traces.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        random.seed(self.random_seed)
+        np.random.seed(self.random_seed)
+
+        # Set parameters with defaults from timed_trace_group arguments
+        self.chunk_size = int(kwargs.get("timed_trace_chunk_hash_size", 16))
+        self.sec_multiplier = float(kwargs.get("timed_trace_sec_multiplier", 1))
+        self.label_ts = str(kwargs.get("timed_trace_label_timestamp"))
+        self.label_input_length = str(kwargs.get("timed_trace_label_input_length"))
+        self.label_output_length = str(kwargs.get("timed_trace_label_output_length"))
+        self.label_hash_ids = str(kwargs.get("timed_trace_label_hash_ids"))
+        print(
+            f"timed-trace: chunk_size: {self.chunk_size}, "
+            f"sec_multiplier: {self.sec_multiplier}, "
+            f'label_ts: "{self.label_ts}", '
+            f'label_input_length: "{self.label_input_length}", '
+            f'label_output_length: "{self.label_output_length}", '
+            f'label_hash_ids: "{self.label_hash_ids}"'
+        )
+        self._expanded_generated_prompts = {}
+        self.load_data()
+
+    def load_data(self) -> None:
+        # check if the file is there
+        if self.dataset_path is None:
+            raise ValueError("dataset_path must be provided for loading data.")
+
+        # load and we will do transformation once we have the Tokenizer available
+        # this is jsonl data format
+        with open(self.dataset_path) as f:
+            self.data = f.readlines()
+
+    def _sample_token(
+        self, num_tokens: int, tokenizer: TokenizerLike, seed: int | None = None
+    ) -> list[int]:
+        # Initialize vocab only if it doesn't exist yet
+        if not hasattr(self, "vocab"):
+            self.vocab = tokenizer.get_vocab()
+            # Remove the special tokens.
+            self.vocab = {
+                k: v
+                for k, v in self.vocab.items()
+                if v not in tokenizer.all_special_ids
+            }
+            # Create a sorted list of vocab values for deterministic sampling
+            self.vocab_values_sorted = sorted(self.vocab.values())
+
+        # Use the provided seed if given, otherwise use global random state
+        if seed is not None:
+            rng = random.Random(seed)
+            sampled_token_ids = rng.choices(self.vocab_values_sorted, k=num_tokens)
+        else:
+            sampled_token_ids = random.choices(self.vocab_values_sorted, k=num_tokens)
+
+        return sampled_token_ids
+
+    def _expand_prompt(
+        self,
+        chunked_hashes: list[int],
+        target_input_size: int,
+        tokenizer: TokenizerLike,
+    ) -> list[int]:
+        raw_tokenized_prompt = []
+        for h in chunked_hashes:
+            # Calculate how many tokens to expand for this chunk
+            expanded_size = (
+                self.chunk_size
+                if target_input_size >= self.chunk_size
+                else target_input_size
+            )
+
+            # Cache key includes size for partial chunks at the end
+            key = f"{h}:{expanded_size}"
+
+            if key not in self._expanded_generated_prompts:
+                # Convert key to a deterministic seed
+                key_seed = hash(key) & 0xFFFFFFFF  # Convert to 32-bit int
+                self._expanded_generated_prompts[key] = self._sample_token(
+                    expanded_size, tokenizer, seed=key_seed
+                )
+            # once inserted get the tokenized prompt and append to the list
+            raw_tokenized_prompt.extend(self._expanded_generated_prompts[key])
+            target_input_size -= expanded_size
+
+            if target_input_size <= 0:
+                break
+
+        return raw_tokenized_prompt
+
+    def sample(
+        self,
+        tokenizer: TokenizerLike,
+        num_requests: int,
+        request_id_prefix: str = "",
+        **kwargs,
+    ) -> list:
+        samples: list = []
+        assert tokenizer is not None, "Tokenizer must be provided, now is Null"
+
+        for ind, entry in enumerate(self.data):
+            if len(samples) >= num_requests:
+                break
+
+            # now we create the SampleRequest with timing info
+            entry = json.loads(entry.strip())
+            input_length = entry.get(self.label_input_length)
+            if input_length is None:
+                raise ValueError(
+                    f"Input length field '{self.label_input_length}' "
+                    f"not found in trace entry. "
+                    f"Available fields: {list(entry.keys())}. "
+                    f"Use --label-input-length to specify the correct "
+                    f"field name."
+                )
+            new_output_len = entry.get(self.label_output_length)
+            if new_output_len is None:
+                raise ValueError(
+                    f"Output length field '{self.label_output_length}' "
+                    f"not found in trace entry. "
+                    f"Available fields: {list(entry.keys())}. "
+                    f"Use --label-output-length to specify the correct "
+                    f"field name."
+                )
+            prompt_ids = self._expand_prompt(
+                entry.get(self.label_hash_ids, []), input_length, tokenizer
+            )
+            prompt = tokenizer.decode(prompt_ids)
+
+            # Get timestamp with proper error handling
+            ts_value = entry.get(self.label_ts)
+            if ts_value is None:
+                raise ValueError(
+                    f"Timestamp field '{self.label_ts}' not found in trace entry. "
+                    f"Available fields: {list(entry.keys())}. "
+                    f"Use --label-timestamp to specify the correct field name."
+                )
+            timestamp = float(ts_value) * self.sec_multiplier
+
+            prompt_len = len(prompt_ids)
+
+            samples.append(
+                SampleRequest(
+                    prompt=prompt,
+                    prompt_len=prompt_len,
+                    expected_output_len=new_output_len,
+                    lora_request=None,
+                    multi_modal_data=None,
+                    request_id=request_id_prefix + str(ind),
+                    timestamp=timestamp,
+                )
+            )
+        return samples
+
+
 def add_dataset_parser(parser: FlexibleArgumentParser):
     parser.add_argument(
         "--trust-remote-code",
@@ -1431,6 +1594,7 @@ def add_dataset_parser(parser: FlexibleArgumentParser):
             "prefix_repetition",
             "spec_bench",
             "speed_bench",
+            "timed_trace",
         ],
         help="Name of the dataset to benchmark on.",
     )
@@ -1519,6 +1683,53 @@ def add_dataset_parser(parser: FlexibleArgumentParser):
         default=None,
         help="Output length for each request. Overrides the output length "
         "from the ShareGPT dataset.",
+    )
+
+    timed_trace_group = parser.add_argument_group("timed-trace dataset options")
+    timed_trace_group.add_argument(
+        "--timed-trace-chunk-hash-size",
+        type=int,
+        default=16,
+        help=(
+            "Each hash tokens, if present, represent how many token "
+            "hashes. For example in the Moonshot traces it is 512, while "
+            "the Qwen/Alibaba has 16."
+        ),
+    )
+    timed_trace_group.add_argument(
+        "--timed-trace-sec-multiplier",
+        type=float,
+        default=1,
+        help=(
+            "What multiplier to use when converting timestamps to "
+            "seconds. We will multiply timestamps by this. For example"
+            "if the timestamps are in milliseconds, then pass 0.001."
+            "If they are already in seconds, then the default 1 is sufficient."
+        ),
+    )
+    timed_trace_group.add_argument(
+        "--timed-trace-label-timestamp",
+        type=str,
+        default="timestamp",
+        help="What json label to use to index the timestamp in the trace.",
+    )
+    timed_trace_group.add_argument(
+        "--timed-trace-label-input-length",
+        type=str,
+        default="input_length",
+        help=("What json label to use to index the input length field in the trace."),
+    )
+    timed_trace_group.add_argument(
+        "--timed-trace-label-output-length",
+        type=str,
+        default="output_length",
+        help=("What json label to use to index the output length field in the trace."),
+    )
+    timed_trace_group.add_argument(
+        "--timed-trace-label-hash-ids",
+        type=str,
+        default="hash_ids",
+        help=("What json label to use to index the hash ids for the input prompts."),
     )
 
     blazedit_group = parser.add_argument_group("blazedit dataset options")
@@ -2049,6 +2260,14 @@ def get_samples(args, tokenizer: TokenizerLike) -> list[SampleRequest]:
             no_oversample=args.no_oversample,
             skip_chat_template=args.skip_chat_template,
             **hf_kwargs,
+        )
+
+    elif args.dataset_name == "timed_trace":
+        dataloader = TimedTrace(**vars(args))
+        input_requests = dataloader.sample(
+            num_requests=args.num_prompts,
+            tokenizer=tokenizer,
+            request_id_prefix=args.request_id_prefix,
         )
 
     else:

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -251,6 +251,7 @@ async def get_request(
     ramp_up_strategy: Literal["linear", "exponential"] | None = None,
     ramp_up_start_rps: int | None = None,
     ramp_up_end_rps: int | None = None,
+    self_timed: bool = False,
 ) -> AsyncGenerator[tuple[SampleRequest, float], None]:
     """
     Asynchronously generates requests at a specified rate
@@ -290,49 +291,59 @@ async def get_request(
     # Precompute delays among requests to minimize request send laggings
     request_rates = []
     delay_ts = []
-    for request_index, request in enumerate(input_requests):
-        current_request_rate = _get_current_request_rate(
-            ramp_up_strategy,
-            ramp_up_start_rps,
-            ramp_up_end_rps,
-            request_index,
-            total_requests,
-            request_rate,
-        )
-        assert current_request_rate > 0.0, (
-            f"Obtained non-positive request rate {current_request_rate}."
-        )
-        request_rates.append(current_request_rate)
-        if current_request_rate == float("inf"):
-            delay_ts.append(0)
-        elif burstiness == float("inf"):
-            # when burstiness tends to infinity, the delay time becomes constant
-            # and tends to the inverse of the request rate
-            delay_ts.append(1.0 / current_request_rate)
-        else:
-            theta = 1.0 / (current_request_rate * burstiness)
 
-            # Sample the request interval from the gamma distribution.
-            # If burstiness is 1, it follows exponential distribution.
-            delay_ts.append(np.random.gamma(shape=burstiness, scale=theta))
+    # if the traces have timing info then:
+    if not self_timed:
+        for request_index, request in enumerate(input_requests):
+            current_request_rate = _get_current_request_rate(
+                ramp_up_strategy,
+                ramp_up_start_rps,
+                ramp_up_end_rps,
+                request_index,
+                total_requests,
+                request_rate,
+            )
+            assert current_request_rate > 0.0, (
+                f"Obtained non-positive request rate {current_request_rate}."
+            )
+            request_rates.append(current_request_rate)
+            if current_request_rate == float("inf"):
+                delay_ts.append(0)
+            elif burstiness == float("inf"):
+                # when burstiness tends to infinity, the delay time becomes constant
+                # and tends to the inverse of the request rate
+                delay_ts.append(1.0 / current_request_rate)
+            else:
+                theta = 1.0 / (current_request_rate * burstiness)
 
-    # Calculate the cumulative delay time from the first sent out requests.
-    for i in range(1, len(delay_ts)):
-        delay_ts[i] += delay_ts[i - 1]
-    if ramp_up_strategy is None and delay_ts[-1] != 0:
-        # When ramp_up_strategy is not set, we assume the request rate is fixed
-        # and all requests should be sent in target_total_delay_s, the following
-        # logic would re-scale delay time to ensure the final delay_ts
-        # align with target_total_delay_s.
-        #
-        # NOTE: If we simply accumulate the random delta values
-        # from the gamma distribution, their sum would have 1-2% gap
-        # from target_total_delay_s. The purpose of the following logic is to
-        # close the gap for stabilizing the throughput data
-        # from different random seeds.
-        target_total_delay_s = total_requests / request_rate
-        normalize_factor = target_total_delay_s / delay_ts[-1]
-        delay_ts = [delay * normalize_factor for delay in delay_ts]
+                # Sample the request interval from the gamma distribution.
+                # If burstiness is 1, it follows exponential distribution.
+                delay_ts.append(np.random.gamma(shape=burstiness, scale=theta))
+
+        # Calculate the cumulative delay time from the first sent out requests.
+        for i in range(1, len(delay_ts)):
+            delay_ts[i] += delay_ts[i - 1]
+        if ramp_up_strategy is None and delay_ts[-1] != 0:
+            # When ramp_up_strategy is not set, we assume the request rate is fixed
+            # and all requests should be sent in target_total_delay_s, the following
+            # logic would re-scale delay time to ensure the final delay_ts
+            # align with target_total_delay_s.
+            #
+            # NOTE: If we simply accumulate the random delta values
+            # from the gamma distribution, their sum would have 1-2% gap
+            # from target_total_delay_s. The purpose of the following logic is to
+            # close the gap for stabilizing the throughput data
+            # from different random seeds.
+            target_total_delay_s = total_requests / request_rate
+            normalize_factor = target_total_delay_s / delay_ts[-1]
+            delay_ts = [delay * normalize_factor for delay in delay_ts]
+    else:
+        for request_index, request in enumerate(input_requests):
+            # this is cumulative running ts, from which sleep is calculated later
+            delay_ts.append(request.timestamp)
+            # TODO: there is no notion of RPS here, may be we can calculate
+            # from the trace.
+            request_rates.append(0.0)
 
     start_ts = time.time()
     for request_index, request in enumerate(input_requests):
@@ -634,6 +645,7 @@ async def benchmark(
     ramp_up_end_rps: int | None = None,
     ready_check_timeout_sec: int = 600,
     ssl_context: ssl.SSLContext | bool | None = None,
+    self_timed: bool = False,
 ):
     try:
         request_func = ASYNC_REQUEST_FUNCS[endpoint_type]
@@ -773,18 +785,20 @@ async def benchmark(
             print("Profiler started")
 
     distribution = "Poisson process" if burstiness == 1.0 else "Gamma distribution"
+    if not self_timed:
+        if ramp_up_strategy is not None:
+            print(f"Traffic ramp-up strategy: {ramp_up_strategy}.")
+            print(
+                f"Will increase RPS from {ramp_up_start_rps} to "
+                f"{ramp_up_end_rps} RPS over the duration of the benchmark."
+            )
+        else:
+            print(f"Traffic request rate: {request_rate}")
 
-    if ramp_up_strategy is not None:
-        print(f"Traffic ramp-up strategy: {ramp_up_strategy}.")
-        print(
-            f"Will increase RPS from {ramp_up_start_rps} to "
-            f"{ramp_up_end_rps} RPS over the duration of the benchmark."
-        )
+        print(f"Burstiness factor: {burstiness} ({distribution})")
+        print(f"Maximum request concurrency: {max_concurrency}")
     else:
-        print(f"Traffic request rate: {request_rate}")
-
-    print(f"Burstiness factor: {burstiness} ({distribution})")
-    print(f"Maximum request concurrency: {max_concurrency}")
+        print("Self timing is set, using the timestamps from the trace file.")
 
     spec_decode_metrics_before = await fetch_spec_decode_metrics(base_url, session)
 
@@ -823,6 +837,7 @@ async def benchmark(
         ramp_up_strategy,
         ramp_up_start_rps,
         ramp_up_end_rps,
+        self_timed,
     ):
         if ramp_up_strategy is not None:
             current_int_rps = int(current_request_rate)
@@ -1437,6 +1452,16 @@ def add_cli_args(parser: argparse.ArgumentParser):
         "Warning: ignore_eos is not supported in deepspeed_mii and tgi.",
     )
     parser.add_argument(
+        "--self-timed",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Use timing information from the traces instead of the configuration. "
+        "This is useful when replaying traces faithfully based on their timestamps. "
+        "When unset, defaults to False, except for --dataset-name=timed_trace where "
+        "it defaults to True. Use --no-self-timed to force off. When off, user "
+        "defined generation rates are used and in trace timing info is ignored.",
+    )
+    parser.add_argument(
         "--percentile-metrics",
         type=str,
         default=None,
@@ -1767,6 +1792,24 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
     ):
         args.ignore_eos = True
 
+    if args.dataset_name == "timed_trace":
+        # timed_trace carries per-request timestamps;
+        # ignore EOS so generation runs to the trace's specified output length,
+        # and default to using those timestamps for scheduling unless the user
+        # opted out.
+        args.ignore_eos = True
+        if args.self_timed is None:
+            args.self_timed = True
+    else:
+        # if this is set for anything else, it is an error
+        if args.self_timed is not None:
+            raise ValueError(
+                "--self-timed/--no-self-timed is only supported with "
+                "--dataset-name=timed_trace"
+            )
+        # for any non self-timed trace, this is False
+        args.self_timed = False
+
     # Load the dataset.
     input_requests = get_samples(args, tokenizer)
     goodput_config_dict = check_goodput_args(args)
@@ -1846,6 +1889,7 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
         ramp_up_end_rps=args.ramp_up_end_rps,
         ready_check_timeout_sec=args.ready_check_timeout_sec,
         ssl_context=ssl_context,
+        self_timed=args.self_timed,
     )
 
     # Save config and results to json

--- a/vllm/config/weight_transfer.py
+++ b/vllm/config/weight_transfer.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from typing import Literal
+
 from vllm.config.utils import config
 
 
@@ -7,7 +9,7 @@ from vllm.config.utils import config
 class WeightTransferConfig:
     """Configuration for weight transfer during RL training."""
 
-    backend: str = "nccl"
+    backend: Literal["nccl", "ipc"] | str = "nccl"
     """The backend to use for weight transfer. Validated against the
     `WeightTransferEngineFactory` registry at engine creation time.
     """

--- a/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/marlin_moe.py
@@ -30,6 +30,7 @@ from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
 )
 from vllm.model_executor.layers.fused_moe.utils import (
     _resize_cache,
+    batched_swiglu_limit_func,
     swiglu_limit_func,
 )
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
@@ -51,6 +52,46 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 )
 from vllm.platforms import current_platform
 from vllm.scalar_type import ScalarType, scalar_types
+
+
+_BATCHED_SWIGLU_BUCKET_SIZES = (
+    256,
+    512,
+    1024,
+    2048,
+    4096,
+    8192,
+    16384,
+    32768,
+    65536,
+)
+
+
+def _select_batched_swiglu_bucket_size(
+    expert_num_tokens_cpu: torch.Tensor | None,
+    num_tokens_upper_bound_cpu: int | None,
+    num_experts: int,
+    block_size_m: int,
+    total_rows: int,
+) -> int | None:
+    if expert_num_tokens_cpu is not None:
+        valid_rows = 0
+        for num_tokens in expert_num_tokens_cpu.tolist():
+            num_tokens = int(num_tokens)
+            valid_rows += (
+                (num_tokens + block_size_m - 1) // block_size_m
+            ) * block_size_m
+    elif num_tokens_upper_bound_cpu is not None:
+        valid_rows = int(num_tokens_upper_bound_cpu)
+        valid_rows += num_experts * (block_size_m - 1)
+    else:
+        return None
+
+    valid_rows = min(valid_rows, total_rows)
+    for bucket_size in _BATCHED_SWIGLU_BUCKET_SIZES:
+        if valid_rows <= bucket_size:
+            return min(bucket_size, total_rows)
+    return total_rows
 
 
 def _fused_marlin_moe(
@@ -91,6 +132,8 @@ def _fused_marlin_moe(
     input_dtype: torch.dtype | None = None,
     is_k_full: bool = True,
     clamp_limit: float | None = None,
+    batched_activation: bool = False,
+    activation_bucket_size: int | None = None,
 ) -> torch.Tensor:
     assert hidden_states.ndim == 2
     M, K = hidden_states.size()
@@ -158,17 +201,34 @@ def _fused_marlin_moe(
         use_fp32_reduce=True,
         is_zp_float=False,
     )
-    if clamp_limit is not None and activation == MoEActivation.SILU:
-        swiglu_limit_func(
-            intermediate_cache2,
-            intermediate_cache1.view(-1, w13_num_shards * N),
-            clamp_limit,
-        )
-    else:
+    activation_input = intermediate_cache1.view(-1, w13_num_shards * N)
+    if activation_input.size(0) > 0 and activation == MoEActivation.SILU:
+        if batched_activation:
+            batched_swiglu_limit_func(
+                intermediate_cache2,
+                activation_input,
+                sorted_token_ids,
+                num_tokens_post_padded,
+                clamp_limit or 0.0,
+                bucket_size=activation_bucket_size,
+            )
+        elif clamp_limit is not None:
+            swiglu_limit_func(
+                intermediate_cache2,
+                activation_input,
+                clamp_limit,
+            )
+        else:
+            activation_func(
+                activation,
+                intermediate_cache2,
+                activation_input,
+            )
+    elif activation_input.size(0) > 0:
         activation_func(
             activation,
             intermediate_cache2,
-            intermediate_cache1.view(-1, w13_num_shards * N),
+            activation_input,
         )
 
     if output is None:
@@ -412,6 +472,8 @@ def batched_fused_marlin_moe(
     output: torch.Tensor | None = None,
     input_dtype: torch.dtype | None = None,
     clamp_limit: float | None = None,
+    expert_num_tokens_cpu: torch.Tensor | None = None,
+    num_tokens_upper_bound_cpu: int | None = None,
 ) -> torch.Tensor:
     """
     This function massages the inputs so the batched hidden_states can be
@@ -504,6 +566,13 @@ def batched_fused_marlin_moe(
     topk_weights = torch.ones(
         (M, topk), device=hidden_states.device, dtype=torch.float32
     )
+    activation_bucket_size = _select_batched_swiglu_bucket_size(
+        expert_num_tokens_cpu=expert_num_tokens_cpu,
+        num_tokens_upper_bound_cpu=num_tokens_upper_bound_cpu,
+        num_experts=E,
+        block_size_m=block_size_m,
+        total_rows=M,
+    )
 
     assert activation is not None
     output = _fused_marlin_moe(
@@ -541,6 +610,8 @@ def batched_fused_marlin_moe(
         input_dtype=input_dtype,
         is_k_full=is_k_full,
         clamp_limit=clamp_limit,
+        batched_activation=True,
+        activation_bucket_size=activation_bucket_size,
     )
 
     output = output.view(B, BATCH_TOKENS_MAX, K)
@@ -993,4 +1064,8 @@ class BatchedMarlinExperts(MarlinExpertsBase):
             input_dtype=self.input_dtype,
             is_k_full=self.is_k_full,
             clamp_limit=self.gemm1_clamp_limit,
+            expert_num_tokens_cpu=expert_tokens_meta.expert_num_tokens_cpu,
+            num_tokens_upper_bound_cpu=(
+                expert_tokens_meta.num_tokens_upper_bound_cpu
+            ),
         )

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -100,6 +100,7 @@ class ExpertTokensMetadata:
 
     expert_num_tokens: torch.Tensor
     expert_num_tokens_cpu: torch.Tensor | None
+    num_tokens_upper_bound_cpu: int | None = None
 
     @staticmethod
     def make_from_list(
@@ -111,6 +112,7 @@ class ExpertTokensMetadata:
         return ExpertTokensMetadata(
             expert_num_tokens=expert_num_tokens_cpu.to(device, non_blocking=True),
             expert_num_tokens_cpu=expert_num_tokens_cpu,
+            num_tokens_upper_bound_cpu=sum(expert_num_tokens_list),
         )
 
 

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_ll.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_ll.py
@@ -287,6 +287,10 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
             )
             a1 = a1 * topk_weights.to(a1.dtype)
 
+        num_tokens_upper_bound_cpu = (
+            a1.size(0) * topk_ids.size(1) * self.num_dispatchers_
+        )
+
         # Dispatch
         dispatch_topk_ids = self._map_global_to_physical_ids(topk_ids)
         (
@@ -322,6 +326,7 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
                 quant_config.a1_scale,
                 a1.dtype,
                 quant_config,
+                num_tokens_upper_bound_cpu,
             ),
         )
 
@@ -332,11 +337,14 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         a1_scale: torch.Tensor | None,
         a1_dtype: torch.dtype,
         quant_config: FusedMoEQuantConfig,
+        num_tokens_upper_bound_cpu: int | None,
     ) -> mk.PrepareResultType:
         expert_x, expert_x_scale = self._do_quant(expert_x, a1_dtype, quant_config)
 
         expert_tokens_meta = mk.ExpertTokensMetadata(
-            expert_num_tokens=expert_num_tokens, expert_num_tokens_cpu=None
+            expert_num_tokens=expert_num_tokens,
+            expert_num_tokens_cpu=None,
+            num_tokens_upper_bound_cpu=num_tokens_upper_bound_cpu,
         )
 
         return expert_x, expert_x_scale, expert_tokens_meta, None, None

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -3,7 +3,6 @@
 from math import prod
 
 import torch
-import torch.nn.functional as F
 
 from vllm import _custom_ops as ops
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
@@ -424,18 +423,158 @@ def trtllm_moe_pack_topk_ids_weights(
     return output.reshape(original_shape)
 
 
-@torch.compile(dynamic=True, backend=current_platform.simple_compile_backend)
+@triton.jit
+def _swiglu_limit_kernel(
+    output_ptr,
+    input_ptr,
+    d: tl.constexpr,
+    output_stride_m: tl.constexpr,
+    output_stride_n: tl.constexpr,
+    input_stride_m: tl.constexpr,
+    input_stride_n: tl.constexpr,
+    swiglu_limit: tl.constexpr,
+    HAS_LIMIT: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    token_idx = tl.program_id(0)
+    dim_block_idx = tl.program_id(1)
+    dim_offsets = dim_block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    dim_mask = dim_offsets < d
+
+    gate_offsets = token_idx * input_stride_m + dim_offsets * input_stride_n
+    up_offsets = gate_offsets + d * input_stride_n
+    output_offsets = token_idx * output_stride_m + dim_offsets * output_stride_n
+
+    gate = tl.load(input_ptr + gate_offsets, mask=dim_mask, other=0.0).to(tl.float32)
+    up = tl.load(input_ptr + up_offsets, mask=dim_mask, other=0.0).to(tl.float32)
+
+    if HAS_LIMIT:
+        gate = tl.minimum(gate, swiglu_limit)
+        up = tl.minimum(tl.maximum(up, -swiglu_limit), swiglu_limit)
+
+    sigmoid = 1.0 / (1.0 + tl.exp(-gate))
+    tl.store(output_ptr + output_offsets, gate * sigmoid * up, mask=dim_mask)
+
+
+@triton.jit
+def _batched_swiglu_limit_kernel(
+    output_ptr,
+    input_ptr,
+    sorted_token_ids_ptr,
+    num_tokens_post_padded_ptr,
+    total_rows: tl.constexpr,
+    d: tl.constexpr,
+    output_stride_m: tl.constexpr,
+    output_stride_n: tl.constexpr,
+    input_stride_m: tl.constexpr,
+    input_stride_n: tl.constexpr,
+    swiglu_limit: tl.constexpr,
+    HAS_LIMIT: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    sorted_idx = tl.program_id(0)
+    dim_block_idx = tl.program_id(1)
+    dim_offsets = dim_block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    dim_mask = dim_offsets < d
+
+    valid_rows = tl.load(num_tokens_post_padded_ptr)
+    token_idx = tl.load(
+        sorted_token_ids_ptr + sorted_idx,
+        mask=sorted_idx < valid_rows,
+        other=total_rows,
+    ).to(tl.int64)
+    token_mask = (sorted_idx < valid_rows) & (token_idx >= 0) & (token_idx < total_rows)
+
+    gate_offsets = token_idx * input_stride_m + dim_offsets * input_stride_n
+    up_offsets = gate_offsets + d * input_stride_n
+    output_offsets = token_idx * output_stride_m + dim_offsets * output_stride_n
+    mask = token_mask & dim_mask
+
+    gate = tl.load(input_ptr + gate_offsets, mask=mask, other=0.0).to(tl.float32)
+    up = tl.load(input_ptr + up_offsets, mask=mask, other=0.0).to(tl.float32)
+
+    if HAS_LIMIT:
+        gate = tl.minimum(gate, swiglu_limit)
+        up = tl.minimum(tl.maximum(up, -swiglu_limit), swiglu_limit)
+
+    sigmoid = 1.0 / (1.0 + tl.exp(-gate))
+    tl.store(output_ptr + output_offsets, gate * sigmoid * up, mask=mask)
+
+
+def _swiglu_block_size(d: int) -> int:
+    return min(triton.next_power_of_2(d), 1024)
+
+
 def swiglu_limit_func(
     output: torch.Tensor,
     input: torch.Tensor,  # first half is gate, second half is up
     swiglu_limit: float = 0.0,
 ) -> None:
-    d = input.shape[1] // 2
-    gate = input[:, :d]
-    up = input[:, d:]
+    assert input.ndim == 2
+    assert output.ndim == 2
+    assert input.shape[1] == output.shape[1] * 2
+    assert input.shape[0] == output.shape[0]
 
-    if swiglu_limit > 0:
-        gate = torch.clamp(gate, max=swiglu_limit)
-        up = torch.clamp(up, min=-swiglu_limit, max=swiglu_limit)
+    n_tokens = input.shape[0]
+    if n_tokens == 0:
+        return
 
-    output.copy_(F.silu(gate) * up)
+    d = output.shape[1]
+    block_size = _swiglu_block_size(d)
+    grid = (n_tokens, triton.cdiv(d, block_size))
+    _swiglu_limit_kernel[grid](
+        output,
+        input,
+        d,
+        output.stride(0),
+        output.stride(1),
+        input.stride(0),
+        input.stride(1),
+        swiglu_limit,
+        HAS_LIMIT=swiglu_limit > 0,
+        BLOCK_SIZE=block_size,
+    )
+
+
+def batched_swiglu_limit_func(
+    output: torch.Tensor,
+    input: torch.Tensor,  # first half is gate, second half is up
+    sorted_token_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    swiglu_limit: float = 0.0,
+    bucket_size: int | None = None,
+) -> None:
+    assert input.ndim == 2
+    assert output.ndim == 2
+    assert input.shape[1] == output.shape[1] * 2
+    assert input.shape[0] == output.shape[0]
+    assert sorted_token_ids.ndim == 1
+    assert num_tokens_post_padded.numel() == 1
+
+    total_rows = input.shape[0]
+    if total_rows == 0:
+        return
+
+    n_tokens = bucket_size if bucket_size is not None else total_rows
+    n_tokens = min(n_tokens, sorted_token_ids.numel())
+    if n_tokens == 0:
+        return
+
+    d = output.shape[1]
+    block_size = _swiglu_block_size(d)
+    grid = (n_tokens, triton.cdiv(d, block_size))
+    _batched_swiglu_limit_kernel[grid](
+        output,
+        input,
+        sorted_token_ids,
+        num_tokens_post_padded,
+        total_rows,
+        d,
+        output.stride(0),
+        output.stride(1),
+        input.stride(0),
+        input.stride(1),
+        swiglu_limit,
+        HAS_LIMIT=swiglu_limit > 0,
+        BLOCK_SIZE=block_size,
+    )

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -612,6 +612,7 @@ class Indexer(nn.Module):
         cache_config: CacheConfig | None,
         topk_indices_buffer: torch.Tensor | None,
         prefix: str = "",
+        is_inplace_rope: bool = False,
     ):
         super().__init__()
         self.vllm_config = vllm_config
@@ -673,15 +674,21 @@ class Indexer(nn.Module):
             self.topk_indices_buffer,
         )
 
+        self.is_inplace_rope = is_inplace_rope
+
     def forward(
         self, hidden_states: torch.Tensor, qr: torch.Tensor, positions, rotary_emb
     ) -> torch.Tensor:
         q, _ = self.wq_b(qr)
         q = q.view(-1, self.n_head, self.head_dim)
 
-        if current_platform.is_rocm():
+        if current_platform.is_rocm() and self.is_inplace_rope:
             # This path should works on all platform, will remove extra
             # branches in the future
+            # This fast path relies on rotary_emb mutating q and k inplace.
+            # On ROCm, this is only valid for kernels used as custom ops.
+            # In pytorch-native rope for inductor fusion, rotated q/k tensors
+            # are not mutated inplace but returned as new tensors.
             # Fused wk + weights_proj: one GEMM, then split
             kw, _ = self.wk_weights_proj(hidden_states)
             k = kw[:, : self.head_dim]
@@ -1002,6 +1009,7 @@ class DeepseekV2MLAAttention(nn.Module):
                 cache_config,
                 topk_indices_buffer,
                 f"{prefix}.indexer",
+                is_inplace_rope=self.indexer_rope_emb.enabled(),
             )
 
             # Enable IndexCache for DeepSeek models to reduce redundant top-k

--- a/vllm/model_executor/models/nemotron_vl.py
+++ b/vllm/model_executor/models/nemotron_vl.py
@@ -477,7 +477,7 @@ class LlamaNemotronVLForEmbedding(LlamaNemotronVLChatModel, VllmModelForPooling)
 
     # Weight mapping from checkpoint format to vLLM format
     # Different from parent class due to different vision model structure
-    weight_mapper = WeightsMapper(
+    hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_prefix={
             # Language model mapping
             "language_model.layers.": "language_model.model.layers.",
@@ -533,7 +533,7 @@ class LlamaNemotronVLForEmbedding(LlamaNemotronVLChatModel, VllmModelForPooling)
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         """Override to use different weight mapping for SigLIP."""
         loader = AutoWeightsLoader(self)
-        return loader.load_weights(weights, mapper=self.weight_mapper)
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
 
 
 class LlamaNemotronVLForSequenceClassification(
@@ -543,8 +543,8 @@ class LlamaNemotronVLForSequenceClassification(
 
     # Reranker checkpoint places base model weights under `model.*`,
     # while `score.*` remains at the top level.
-    weight_mapper = WeightsMapper(orig_to_new_prefix={"model.": ""}) | (
-        LlamaNemotronVLForEmbedding.weight_mapper
+    hf_to_vllm_mapper = WeightsMapper(orig_to_new_prefix={"model.": ""}) | (
+        LlamaNemotronVLForEmbedding.hf_to_vllm_mapper
     )
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -60,7 +60,6 @@ from vllm.models.deepseek_v4.attention import (
     DeepseekV4MultiHeadLatentAttentionWrapper,
 )
 from vllm.models.deepseek_v4.nvidia.ops.prepare_megamoe import prepare_megamoe_inputs
-from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.utils.torch_utils import direct_register_custom_op
 
@@ -262,13 +261,7 @@ class DeepseekV4MegaMoEExperts(nn.Module):
         return (sf.to(torch.int32) << 23).view(torch.float32)
 
     def _check_runtime_supported(self) -> None:
-        if not torch.cuda.is_available():
-            raise NotImplementedError("DeepSeek V4 MegaMoE requires CUDA.")
         device = self.w13_weight.device
-        if device.type != "cuda":
-            raise NotImplementedError(
-                "DeepSeek V4 MegaMoE expert weights must be loaded on CUDA."
-            )
         if torch.cuda.get_device_capability(device)[0] != 10:
             raise NotImplementedError("DeepGEMM MegaMoE requires SM100 GPUs.")
         if self.hidden_size % 128 != 0 or self.intermediate_size % 128 != 0:
@@ -955,7 +948,7 @@ class DeepseekV4DecoderLayer(nn.Module):
     ):
         return self.mhc_post(x, residual, post, comb)
 
-    def _forward_cuda(
+    def forward(
         self,
         x: torch.Tensor,
         positions: torch.Tensor,
@@ -1024,52 +1017,6 @@ class DeepseekV4DecoderLayer(nn.Module):
         x = self.ffn(x, input_ids)
         return x, residual, post_mix, res_mix
 
-    def _forward_native(
-        self,
-        x: torch.Tensor,
-        positions: torch.Tensor,
-        input_ids: torch.Tensor | None,
-        post_mix: torch.Tensor | None = None,
-        res_mix: torch.Tensor | None = None,
-        residual: torch.Tensor | None = None,
-    ) -> tuple[
-        torch.Tensor, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None
-    ]:
-        residual = x
-        x, post, comb = self.hc_pre(
-            x, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base
-        )
-        x = self.attn_norm(x)
-        x = self.attn(positions, x, None)
-        x = self.hc_post(x, residual, post, comb)
-
-        residual = x
-        x, post, comb = self.hc_pre(
-            x, self.hc_ffn_fn, self.hc_ffn_scale, self.hc_ffn_base
-        )
-        x = self.ffn_norm(x)
-        x = self.ffn(x, input_ids)
-        x = self.hc_post(x, residual, post, comb)
-        return x, None, None, None
-
-    def forward(
-        self,
-        x: torch.Tensor,
-        positions: torch.Tensor,
-        input_ids: torch.Tensor | None,
-        post_mix: torch.Tensor | None = None,
-        res_mix: torch.Tensor | None = None,
-        residual: torch.Tensor | None = None,
-    ) -> tuple[
-        torch.Tensor, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None
-    ]:
-        if current_platform.is_rocm() or current_platform.is_xpu():
-            return self._forward_native(
-                x, positions, input_ids, post_mix, res_mix, residual
-            )
-
-        return self._forward_cuda(x, positions, input_ids, post_mix, res_mix, residual)
-
 
 @support_torch_compile
 class DeepseekV4Model(nn.Module):
@@ -1098,20 +1045,13 @@ class DeepseekV4Model(nn.Module):
         # DeepseekV4MultiHeadLatentAttentionWrapper.attn_gemm_parallel_execute
         # (compressor kv_score, indexer.weights_proj, indexer.compressor
         # kv_score). fused_wqa_wkv stays on the default stream.
-        # Disable them on ROCm / XPU because of hang issues / no overlap.
-        aux_stream_list = (
-            None
-            if current_platform.is_rocm() or current_platform.is_xpu()
-            else [torch.cuda.Stream() for _ in range(3)]
-        )
+        aux_stream_list = [torch.cuda.Stream() for _ in range(3)]
 
-        self.device = current_platform.device_type
         # Reserved topk indices buffer for all Indexer layers to reuse.
         self.topk_indices_buffer = torch.empty(
             vllm_config.scheduler_config.max_num_batched_tokens,
             config.index_topk,
             dtype=torch.int32,
-            device=self.device,
         )
 
         if get_pp_group().is_first_rank:
@@ -1171,7 +1111,6 @@ class DeepseekV4Model(nn.Module):
                 vllm_config.scheduler_config.max_num_batched_tokens,
                 self.hc_dim,
                 dtype=vllm_config.model_config.dtype,
-                device=self.device,
             )
         else:
             self._mtp_hidden_buffer = None
@@ -1229,7 +1168,7 @@ class DeepseekV4Model(nn.Module):
                 res_mix,
                 residual,
             )
-        if layer is not None and current_platform.is_cuda():
+        if layer is not None:
             hidden_states = layer.hc_post(hidden_states, residual, post_mix, res_mix)
 
         if not get_pp_group().is_last_rank:

--- a/vllm/models/deepseek_v4/nvidia/mtp.py
+++ b/vllm/models/deepseek_v4/nvidia/mtp.py
@@ -37,7 +37,6 @@ from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.deepseek_mtp import SharedHead
 from vllm.model_executor.models.deepseek_v2 import get_spec_layer_idx_from_weight_name
 from vllm.model_executor.models.utils import maybe_prefix
-from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 
 from .model import (
@@ -147,10 +146,9 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
         hidden_states, residual, post_mix, res_mix = self.mtp_block(
             positions=positions, x=hidden_states, input_ids=None
         )
-        if current_platform.is_cuda():
-            hidden_states = self.mtp_block.hc_post(
-                hidden_states, residual, post_mix, res_mix
-            )
+        hidden_states = self.mtp_block.hc_post(
+            hidden_states, residual, post_mix, res_mix
+        )
         # Return the flat pre-hc_head residual so it can be re-fed as the
         # next spec step's `previous_hidden_states` when
         # num_speculative_tokens > 1. hc_head is deferred to compute_logits.
@@ -163,23 +161,16 @@ class DeepSeekV4MultiTokenPredictor(nn.Module):
         config = vllm_config.model_config.hf_config
         self.mtp_start_layer_idx = config.num_hidden_layers
         self.num_mtp_layers = config.num_nextn_predict_layers
-        self.device = current_platform.device_type
 
         topk_tokens = config.index_topk
         self.topk_indices_buffer = torch.empty(
             vllm_config.scheduler_config.max_num_batched_tokens,
             topk_tokens,
             dtype=torch.int32,
-            device=self.device,
         )
 
-        # Three aux streams shared across all MTP layers, mirroring
-        # DeepseekV4Model. ROCm runs the same work serially for now.
-        aux_stream_list = (
-            None
-            if current_platform.is_rocm()
-            else [torch.cuda.Stream() for _ in range(3)]
-        )
+        # Three aux streams shared across all MTP layers, mirroring DeepseekV4Model.
+        aux_stream_list = [torch.cuda.Stream() for _ in range(3)]
 
         # to map the exact layer index from weights
         self.layers = torch.nn.ModuleDict(

--- a/vllm/tool_parsers/deepseekv32_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv32_tool_parser.py
@@ -4,7 +4,7 @@
 import json
 import uuid
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, Literal
 
 import regex as re
 
@@ -62,6 +62,15 @@ class DeepSeekV32ToolParser(ToolParser):
         # Streaming state
         self.current_tool_index: int = 0
         self._sent_content_idx: int = 0
+        self._buffer: str = ""
+        self._in_tool_calls: bool = False
+        self._active_tool_index: int | None = None
+        self._active_tool_name: str | None = None
+        self._active_param_name: str | None = None
+        self._active_param_string_attr: str | None = None
+        self._active_param_mode: str | None = None
+        self._active_param_parts: list[str] = []
+        self._args_started: list[bool] = []
 
         # Regex patterns for complete parsing
         self.tool_call_complete_regex = re.compile(
@@ -76,6 +85,10 @@ class DeepSeekV32ToolParser(ToolParser):
         self.parameter_complete_regex = re.compile(
             r'<｜DSML｜parameter\s+name="([^"]+)"\s+string="(true|false)"\s*>(.*?)</｜DSML｜parameter>',
             re.DOTALL,
+        )
+        self.invoke_start_regex = re.compile(r'<｜DSML｜invoke\s+name="([^"]+)"\s*>')
+        self.parameter_start_regex = re.compile(
+            r'<｜DSML｜parameter\s+name="([^"]+)"\s+string="(true|false)"\s*>'
         )
 
         if not self.model_tokenizer:
@@ -117,7 +130,7 @@ class DeepSeekV32ToolParser(ToolParser):
     @staticmethod
     def _repair_param_dict(
         param_dict: dict[str, Any],
-        param_config: dict[str, dict],
+        param_config: dict[str, Any],
     ) -> dict[str, Any]:
         """Unwrap single 'arguments' / 'input' wrappers when the wrapper
         is not part of the requested tool schema and the wrapped object
@@ -153,6 +166,15 @@ class DeepSeekV32ToolParser(ToolParser):
             param_types = extract_types_from_schema(param_config.get(name, {}))
             converted[name] = coerce_to_schema_type(value, param_types)
         return self._repair_param_dict(converted, param_config)
+
+    def _get_param_config(self, function_name: str | None) -> dict[str, Any]:
+        if not function_name or not self.tools:
+            return {}
+        return find_tool_properties(self.tools, function_name)
+
+    @staticmethod
+    def _json_escape_string_content(text: str) -> str:
+        return json.dumps(text, ensure_ascii=False)[1:-1]
 
     def extract_tool_calls(
         self,
@@ -210,67 +232,295 @@ class DeepSeekV32ToolParser(ToolParser):
         """Reset all streaming state."""
         self.current_tool_index = 0
         self._sent_content_idx = 0
+        self._buffer = ""
+        self._in_tool_calls = False
+        self._active_tool_index = None
+        self._active_tool_name = None
+        self._active_param_name = None
+        self._active_param_string_attr = None
+        self._active_param_mode = None
+        self._active_param_parts.clear()
         self.prev_tool_call_arr.clear()
         self.streamed_args_for_tool.clear()
+        self._args_started.clear()
 
-    def _extract_delta_tool_calls(
+    def _add_tool_call_delta(
         self,
-        current_text: str,
-        request: ChatCompletionRequest | None,
-    ) -> list[DeltaToolCall]:
-        """Extract DeltaToolCalls from newly completed <invoke> blocks.
+        tool_call_deltas: dict[int, DeltaToolCall],
+        index: int,
+        *,
+        call_id: str | None = None,
+        call_type: Literal["function"] | None = None,
+        name: str | None = None,
+        arguments: str | None = None,
+    ) -> None:
+        if arguments:
+            self.streamed_args_for_tool[index] += arguments
 
-        Tracks progress via ``current_tool_index`` so each block is
-        extracted exactly once across successive streaming calls.
-        """
-        complete_invokes = self.invoke_complete_regex.findall(current_text)
-        delta_tool_calls: list[DeltaToolCall] = []
-
-        while len(complete_invokes) > self.current_tool_index:
-            invoke_name, invoke_body = complete_invokes[self.current_tool_index]
-            param_dict = self._parse_invoke_params(invoke_body)
-
-            converted = self._convert_params_with_schema(invoke_name, param_dict)
-            args_json = json.dumps(converted, ensure_ascii=False)
-            idx = self.current_tool_index
-            self.current_tool_index += 1
-
-            self.prev_tool_call_arr.append(
-                {"name": invoke_name, "arguments": converted}
+        if index not in tool_call_deltas:
+            tool_call_deltas[index] = DeltaToolCall(
+                index=index,
+                id=call_id,
+                type=call_type,
+                function=DeltaFunctionCall(name=name, arguments=arguments),
             )
-            self.streamed_args_for_tool.append(args_json)
+            return
 
-            delta_tool_calls.append(
-                DeltaToolCall(
-                    index=idx,
-                    id=self._generate_tool_call_id(),
-                    function=DeltaFunctionCall(
-                        name=invoke_name,
-                        arguments=args_json,
-                    ),
-                    type="function",
-                )
-            )
+        delta = tool_call_deltas[index]
+        if call_id is not None:
+            delta.id = call_id
+        if call_type is not None:
+            delta.type = call_type
+        if delta.function is None:
+            delta.function = DeltaFunctionCall()
+        if name is not None:
+            delta.function.name = name
+        if arguments is not None:
+            delta.function.arguments = (delta.function.arguments or "") + arguments
 
-        return delta_tool_calls
+    def _begin_streaming_tool_call(
+        self,
+        name: str,
+        tool_call_deltas: dict[int, DeltaToolCall],
+    ) -> None:
+        index = self.current_tool_index
+        self.current_tool_index += 1
+        self._active_tool_index = index
+        self._active_tool_name = name
+        self.prev_tool_call_arr.append({"name": name, "arguments": {}})
+        self.streamed_args_for_tool.append("")
+        self._args_started.append(False)
+        self._add_tool_call_delta(
+            tool_call_deltas,
+            index,
+            call_id=self._generate_tool_call_id(),
+            call_type="function",
+            name=name,
+            arguments="",
+        )
 
-    def _extract_content(self, current_text: str) -> str | None:
-        """Return unsent non-tool-call text, or None.
+    def _append_param_prefix(
+        self,
+        tool_call_deltas: dict[int, DeltaToolCall],
+        index: int,
+        key: str,
+        *,
+        as_string: bool,
+    ) -> None:
+        prefix = "{" if not self._args_started[index] else ","
+        self._args_started[index] = True
+        arguments = prefix + json.dumps(key, ensure_ascii=False) + ":"
+        if as_string:
+            arguments += '"'
+        self._add_tool_call_delta(tool_call_deltas, index, arguments=arguments)
 
-        Holds back any suffix that could be a partial start marker
-        so that split markers are never leaked as content.
-        """
-        if self.tool_call_start_token not in current_text:
-            overlap = partial_tag_overlap(current_text, self.tool_call_start_token)
-            sendable_idx = len(current_text) - overlap
-        else:
-            sendable_idx = current_text.index(self.tool_call_start_token)
+    def _append_json_param_value(
+        self,
+        tool_call_deltas: dict[int, DeltaToolCall],
+        index: int,
+        key: str,
+        value: Any,
+    ) -> None:
+        self._append_param_prefix(tool_call_deltas, index, key, as_string=False)
+        self._add_tool_call_delta(
+            tool_call_deltas,
+            index,
+            arguments=json.dumps(value, ensure_ascii=False),
+        )
 
-        if sendable_idx > self._sent_content_idx:
-            content = current_text[self._sent_content_idx : sendable_idx]
-            self._sent_content_idx = sendable_idx
-            return content
-        return None
+    def _param_types_for_name(self, name: str) -> list[str]:
+        param_config = self._get_param_config(self._active_tool_name)
+        if name in param_config and isinstance(param_config[name], dict):
+            return extract_types_from_schema(param_config[name])
+        return ["string"]
+
+    @staticmethod
+    def _can_stream_raw_param(param_types: list[str]) -> bool:
+        # Scalars and unions need the complete value so streaming and
+        # non-streaming share the same coercion fallback behavior.
+        return set(param_types).issubset({"object", "array"})
+
+    def _should_buffer_wrapper_param(self, name: str) -> bool:
+        if (
+            self._active_tool_index is None
+            or self._args_started[self._active_tool_index]
+        ):
+            return False
+        param_config = self._get_param_config(self._active_tool_name)
+        return bool(
+            param_config and name in ("arguments", "input") and name not in param_config
+        )
+
+    def _finish_buffered_param(
+        self,
+        tool_call_deltas: dict[int, DeltaToolCall],
+        index: int,
+    ) -> None:
+        assert self._active_param_name is not None
+        assert self._active_param_string_attr is not None
+        raw_value = "".join(self._active_param_parts)
+        converted = self._convert_params_with_schema(
+            self._active_tool_name or "",
+            {self._active_param_name: (raw_value, self._active_param_string_attr)},
+        )
+        for key, value in converted.items():
+            self._append_json_param_value(tool_call_deltas, index, key, value)
+
+    def _close_streaming_tool_call(
+        self,
+        tool_call_deltas: dict[int, DeltaToolCall],
+    ) -> None:
+        index = self._active_tool_index
+        if index is None:
+            return
+
+        suffix = "}" if self._args_started[index] else "{}"
+        self._add_tool_call_delta(tool_call_deltas, index, arguments=suffix)
+        try:
+            self.prev_tool_call_arr[index] = {
+                "name": self._active_tool_name,
+                "arguments": json.loads(self.streamed_args_for_tool[index]),
+            }
+        except (json.JSONDecodeError, IndexError):
+            logger.exception("Failed to finalize DeepSeek DSML streaming tool call")
+
+        self._active_tool_index = None
+        self._active_tool_name = None
+        self._active_param_name = None
+        self._active_param_string_attr = None
+        self._active_param_mode = None
+        self._active_param_parts.clear()
+
+    def _process_streaming_buffer(
+        self,
+        content_parts: list[str],
+        tool_call_deltas: dict[int, DeltaToolCall],
+    ) -> None:
+        parameter_end_token = "</｜DSML｜parameter>"
+        invoke_end_token = "</｜DSML｜invoke>"
+
+        while True:
+            if not self._in_tool_calls:
+                start_idx = self._buffer.find(self.tool_call_start_token)
+                if start_idx == -1:
+                    overlap = partial_tag_overlap(
+                        self._buffer, self.tool_call_start_token
+                    )
+                    sendable_idx = len(self._buffer) - overlap
+                    if sendable_idx > 0:
+                        content_parts.append(self._buffer[:sendable_idx])
+                        self._buffer = self._buffer[sendable_idx:]
+                    return
+
+                if start_idx > 0:
+                    content_parts.append(self._buffer[:start_idx])
+                    self._buffer = self._buffer[start_idx:]
+                    continue
+
+                self._buffer = self._buffer[len(self.tool_call_start_token) :]
+                self._in_tool_calls = True
+                continue
+
+            if self._active_tool_index is None:
+                stripped_len = len(self._buffer) - len(self._buffer.lstrip())
+                if stripped_len:
+                    self._buffer = self._buffer[stripped_len:]
+                    continue
+
+                if self._buffer.startswith(self.tool_call_end_token):
+                    self._buffer = self._buffer[len(self.tool_call_end_token) :]
+                    self._in_tool_calls = False
+                    continue
+
+                match = self.invoke_start_regex.match(self._buffer)
+                if match is None:
+                    return
+
+                self._buffer = self._buffer[match.end() :]
+                self._begin_streaming_tool_call(match.group(1), tool_call_deltas)
+                continue
+
+            index = self._active_tool_index
+
+            if self._active_param_mode is not None:
+                end_pos = self._buffer.find(parameter_end_token)
+                if end_pos != -1:
+                    raw_content = self._buffer[:end_pos]
+                    self._buffer = self._buffer[end_pos + len(parameter_end_token) :]
+                    if self._active_param_mode in ("wrapper", "buffered"):
+                        self._active_param_parts.append(raw_content)
+                        self._finish_buffered_param(tool_call_deltas, index)
+                    elif self._active_param_mode == "string":
+                        arguments = self._json_escape_string_content(raw_content) + '"'
+                        self._add_tool_call_delta(
+                            tool_call_deltas, index, arguments=arguments
+                        )
+                    else:
+                        self._add_tool_call_delta(
+                            tool_call_deltas, index, arguments=raw_content
+                        )
+
+                    self._active_param_name = None
+                    self._active_param_string_attr = None
+                    self._active_param_mode = None
+                    self._active_param_parts.clear()
+                    continue
+
+                overlap = partial_tag_overlap(self._buffer, parameter_end_token)
+                safe_len = len(self._buffer) - overlap
+                if safe_len > 0:
+                    raw_content = self._buffer[:safe_len]
+                    self._buffer = self._buffer[safe_len:]
+                    if self._active_param_mode in ("wrapper", "buffered"):
+                        self._active_param_parts.append(raw_content)
+                    elif self._active_param_mode == "string":
+                        self._add_tool_call_delta(
+                            tool_call_deltas,
+                            index,
+                            arguments=self._json_escape_string_content(raw_content),
+                        )
+                    else:
+                        self._add_tool_call_delta(
+                            tool_call_deltas, index, arguments=raw_content
+                        )
+                return
+
+            stripped_len = len(self._buffer) - len(self._buffer.lstrip())
+            if stripped_len:
+                self._buffer = self._buffer[stripped_len:]
+                continue
+
+            if self._buffer.startswith(invoke_end_token):
+                self._buffer = self._buffer[len(invoke_end_token) :]
+                self._close_streaming_tool_call(tool_call_deltas)
+                continue
+
+            match = self.parameter_start_regex.match(self._buffer)
+            if match is None:
+                return
+
+            self._buffer = self._buffer[match.end() :]
+            name = match.group(1)
+            string_attr = match.group(2)
+            self._active_param_name = name
+            self._active_param_string_attr = string_attr
+
+            if self._should_buffer_wrapper_param(name):
+                self._active_param_mode = "wrapper"
+                continue
+
+            if string_attr == "true":
+                self._append_param_prefix(tool_call_deltas, index, name, as_string=True)
+                self._active_param_mode = "string"
+                continue
+
+            param_types = self._param_types_for_name(name)
+            if not self._can_stream_raw_param(param_types):
+                self._active_param_mode = "buffered"
+                continue
+
+            self._append_param_prefix(tool_call_deltas, index, name, as_string=False)
+            self._active_param_mode = "raw"
 
     def extract_tool_calls_streaming(
         self,
@@ -284,20 +534,24 @@ class DeepSeekV32ToolParser(ToolParser):
     ) -> DeltaMessage | None:
         """Extract tool calls from streaming model output.
 
-        Uses a buffer-until-complete-invoke strategy: tokens are buffered
-        until a complete invoke block is available, then parsed and emitted
-        in one shot.
+        Buffers DSML markup while streaming tool-call metadata and argument
+        JSON fragments as soon as they are complete enough to be valid deltas.
         """
 
         # First chunk of a new stream — reset state from prior request.
         if not previous_text:
             self._reset_streaming_state()
 
-        content = self._extract_content(current_text)
-        delta_tool_calls = self._extract_delta_tool_calls(current_text, request)
+        self._buffer += delta_text
+        content_parts: list[str] = []
+        tool_call_deltas: dict[int, DeltaToolCall] = {}
+        self._process_streaming_buffer(content_parts, tool_call_deltas)
 
-        if delta_tool_calls or content:
-            return DeltaMessage(content=content, tool_calls=delta_tool_calls)
+        if content_parts or tool_call_deltas:
+            content = "".join(content_parts) or None
+            return DeltaMessage(
+                content=content, tool_calls=list(tool_call_deltas.values())
+            )
 
         # Empty delta with token ids means EOS or closing tag; return
         # non-None so the serving framework can finalize finish_reason.

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -101,6 +101,7 @@ _CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = LazyConfigDict(
     fireredlid="FireRedLIDConfig",
     funaudiochat="FunAudioChatConfig",
     granite4_vision="Granite4VisionConfig",
+    hyperclovax="HyperCLOVAXConfig",
     hyperclovax_vlm="HCXVisionConfig",
     hunyuan_vl="HunYuanVLConfig",
     hy_v3="HYV3Config",

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -107,6 +107,7 @@ def indexer_k_quant_and_cache_triton(
     kv_cache_value = kv_cache[:, : block_size * head_dim].view(fp8_dtype)
     kv_cache_scale = kv_cache[:, block_size * head_dim :].view(torch.float32)
     head_tile_size = head_tile_size // kv_cache.element_size()
+    layout = "NORMAL" if block_size == 1 else "SHUFFLE"
     grid = (num_tokens,)
     _indexer_k_quant_and_cache_kernel[grid](
         k,
@@ -118,7 +119,7 @@ def indexer_k_quant_and_cache_triton(
         block_size,
         num_tokens,
         head_dim,
-        "SHUFFLE",
+        layout,
         block_tile_size,
         head_tile_size,
         IS_FNUZ=current_platform.fp8_dtype() == torch.float8_e4m3fnuz,
@@ -229,6 +230,7 @@ def cp_gather_indexer_k_quant_cache_triton(
     k_cache_scale = k_cache[:, block_size * head_dim :].view(torch.float32)
     grid = (num_tokens,)
     k_fp8_scale = k_fp8_scale.view(torch.float32)
+    layout = "NORMAL" if block_size == 1 else "SHUFFLE"
     _cp_gather_indexer_quant_cache_kernel[grid](
         k_cache_value,
         k_cache_scale,
@@ -241,7 +243,7 @@ def cp_gather_indexer_k_quant_cache_triton(
         block_table_stride,
         k_cache_value.stride(0),
         k_cache_scale.stride(0),
-        "SHUFFLE",
+        layout,
         head_dim,
         block_tile_size,
         head_tile_size,
@@ -433,7 +435,7 @@ def rocm_fp8_paged_mqa_logits(
                 block_tables,
                 max_model_len,
                 ChunkK=256,
-                Preshuffle=block_size == 64,
+                Preshuffle=block_size > 1,
                 KVBlockSize=block_size,
                 WavePerEU=2,
             )

--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -58,13 +58,14 @@ class DPCoordinator:
 
     def _wait_for_zmq_addrs(self, zmq_addr_pipe) -> tuple[str, str, str]:
         try:
+            timeout = 120
             ready = multiprocessing.connection.wait(
-                [zmq_addr_pipe, self.proc.sentinel], timeout=30
+                [zmq_addr_pipe, self.proc.sentinel], timeout=timeout
             )
             if not ready:
                 raise RuntimeError(
                     "DP Coordinator process failed to report ZMQ addresses "
-                    "during startup."
+                    f"within timeout={timeout} seconds during startup."
                 )
             try:
                 return zmq_addr_pipe.recv()

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -241,7 +241,7 @@ class APIServerProcessManager:
 
     def gather_actual_addresses(
         self,
-        timeout: float = 60.0,
+        timeout: float = envs.VLLM_ENGINE_READY_TIMEOUT_S,
     ) -> tuple[list[str], list[str]]:
         """Return (inputs, outputs) reported by each child, indexed by
         ``client_index``. Raises ``RuntimeError`` on timeout or premature


### PR DESCRIPTION
## Purpose
This PR fixes excessive activation work on the DeepEP low-latency + batched Marlin MoE decode path.

On this path, `BatchedMarlinExperts` may run activation over the full expert-capacity layout instead of only the valid dispatched rows, which unnecessarily enlarges the launch shape and makes activation a major decode hotspot.

## Root Cause
`DeepEPLLPrepareAndFinalize` selects the batched Marlin backend. In that path, GEMM1 output is produced in expert-capacity layout, and the activation stage was effectively driven by capacity rather than the valid token rows.

## Changes
- Add a batched Triton SwiGLU kernel that uses `sorted_token_ids` and `num_tokens_post_padded` to operate only on valid rows.
- Use fixed activation buckets for the batched path to keep the launch shape CUDA-graph friendly.
- Update batched Marlin to call the new batched activation kernel.
- Extend `ExpertTokensMetadata` with `num_tokens_upper_bound_cpu`.
- Populate that upper bound in `DeepEPLLPrepareAndFinalize` so DeepEP LL can choose a safe bucket when `expert_num_tokens_cpu` is unavailable.
- Replace the non-batched `swiglu_limit_func` implementation with a Triton kernel as well.

## Testing
### Functional validation
- Multiple `chat/completions` and `completions` sanity checks passed after deployment.
- No precision regression was observed in the tested decode path.

### Decode profiling
Compared with the earlier batched-Marlin decode profile where activation was still a major hotspot:
- `act_and_mul_kernel`: `15.956s (28.03%)` -> `54.377ms (0.14%)`
- New `_batched_swiglu_limit_kernel`: `457.612ms (1.17%)`
- Decode `Self CUDA total`: `56.922s` -> `38.939s` (`-31.6%`)

### End-to-end benchmark
`sglang.bench_serving`, `8000/2000`, `num-prompts=16`, `max-concurrency=16`, with warmup:
- Output throughput: `321.62 tok/s` vs `263.17 tok/s` (`+22.21%`)
- Total throughput: `1608.08 tok/s` vs `1315.84 tok/s` (`+22.21%`)
- Mean TPOT: `26.75ms` vs `29.51ms` (`-9.35%`)
- P99 TPOT: `37.29ms` vs `46.08ms` (`-19.08%`)

## Notes
This change keeps CUDA-graph compatibility by using fixed-size activation buckets instead of Python-side variable-length compaction.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

