### PR TITLE
ci: trigger ByteIAAS dev builds on iaas_main pushes

### DIFF
--- a/.github/workflows/byteiaas-release-dev.yml
+++ b/.github/workflows/byteiaas-release-dev.yml
@@ -1,6 +1,9 @@
 name: ByteIAAS vLLM Development Build
 
 on:
+  push:
+    branches:
+      - iaas_main
   workflow_dispatch:
     inputs:
       checkout_ref:
@@ -21,7 +24,7 @@ jobs:
     if: github.repository == 'bytedance-iaas/vllm'
     uses: ./.github/workflows/_byteiaas-build-wheel.yml
     with:
-      checkout_ref: ${{ inputs.checkout_ref || github.ref }}
+      checkout_ref: ${{ github.event_name == 'workflow_dispatch' && inputs.checkout_ref || github.ref }}
       cuda_version: "13.0.2"
       artifact_name: vllm-cu130-wheel-dev
 
@@ -29,8 +32,8 @@ jobs:
     if: github.repository == 'bytedance-iaas/vllm'
     uses: ./.github/workflows/_byteiaas-build-and-publish-image.yml
     with:
-      checkout_ref: ${{ inputs.checkout_ref || github.ref }}
+      checkout_ref: ${{ github.event_name == 'workflow_dispatch' && inputs.checkout_ref || github.ref }}
       cuda_version: "13.0.2"
       tag_mode: dev
-      vllm_version: ${{ inputs.vllm_version }}
+      vllm_version: ${{ github.event_name == 'workflow_dispatch' && inputs.vllm_version || '' }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- trigger the ByteIAAS development build workflow on pushes to `iaas_main`
- keep `workflow_dispatch` support, but guard dispatch-only inputs for push events

## Why
GitHub only exposes `workflow_dispatch` for workflows that exist on the repository default branch. This repository's default branch is `main`, while the ByteIAAS build workflow intentionally lives on `iaas_main`, so push-triggered dev builds are needed for the requested `iaas_main` build path.

## Tests
- `.venv/bin/pre-commit run actionlint --files .github/actionlint.yaml .github/workflows/byteiaas-release-dev.yml .github/workflows/_byteiaas-build-wheel.yml .github/workflows/_byteiaas-build-and-publish-image.yml`
- `git diff --check`

## Duplicate work check
No duplicate ByteIAAS vLLM build workflow existed before this task; this is a small follow-up to make the merged workflow executable on `iaas_main` despite the repository default branch remaining `main`.

## AI assistance disclosure
This PR was prepared with AI assistance and reviewed by the author before submission.
