### PR TITLE
ci: extend byteiaas build job timeout

### DIFF
--- a/.github/workflows/_byteiaas-build-and-publish-image.yml
+++ b/.github/workflows/_byteiaas-build-and-publish-image.yml
@@ -32,6 +32,7 @@ jobs:
   build-and-publish-image:
     if: github.repository == 'bytedance-iaas/vllm'
     runs-on: x64-vllm-docker-build-node
+    timeout-minutes: 1440
     env:
       HTTP_PROXY: http://100.68.162.211:3128
       HTTPS_PROXY: http://100.68.162.211:3128

--- a/.github/workflows/_byteiaas-build-wheel.yml
+++ b/.github/workflows/_byteiaas-build-wheel.yml
@@ -23,6 +23,7 @@ jobs:
   build-wheel:
     if: github.repository == 'bytedance-iaas/vllm'
     runs-on: x64-vllm-wheel-build-node
+    timeout-minutes: 1440
     env:
       HTTP_PROXY: http://100.68.162.211:3128
       HTTPS_PROXY: http://100.68.162.211:3128


### PR DESCRIPTION
## Summary
- Extend ByteIAAS reusable wheel and image build jobs to 24h timeout.
- This fixes the first dev build being cancelled at GitHub Actions' default 6h job timeout while vLLM CUDA/FlashAttention extensions were still compiling.

## Validation
- `.venv/bin/pre-commit run actionlint --files .github/actionlint.yaml .github/workflows/_byteiaas-build-wheel.yml .github/workflows/_byteiaas-build-and-publish-image.yml .github/workflows/byteiaas-release-dev.yml .github/workflows/byteiaas-release.yml`
- `git diff --check`

## Duplicate Work
- Fork-scoped ByteIAAS CI operational fix for `bytedance-iaas/vllm`; no upstream PR search is needed for this internal workflow timeout.

## AI Assistance
- Prepared with OpenAI Codex.
