### PR TITLE
ci: avoid buildx load for byteiaas wheel build

### DIFF
--- a/.github/workflows/_byteiaas-build-wheel.yml
+++ b/.github/workflows/_byteiaas-build-wheel.yml
@@ -40,24 +40,14 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Set up Docker Buildx with local Docker Hub mirror
-        uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: |
-            network=host
-          buildkitd-config-inline: |
-            [registry."docker.io"]
-              mirrors = ["127.0.0.1:5000"]
-
       - name: Build wheel stage image
         run: |
           set -euo pipefail
-          docker buildx build \
+          DOCKER_BUILDKIT=1 docker build \
             --target build \
-            --platform linux/amd64 \
-            --load \
             -f docker/Dockerfile \
             --build-arg CUDA_VERSION=${{ inputs.cuda_version }} \
+            --build-arg BUILD_BASE_IMAGE="127.0.0.1:5000/nvidia/cuda:${{ inputs.cuda_version }}-devel-ubuntu22.04" \
             --build-arg HTTP_PROXY="${HTTP_PROXY}" \
             --build-arg HTTPS_PROXY="${HTTPS_PROXY}" \
             --build-arg ALL_PROXY="${ALL_PROXY}" \


### PR DESCRIPTION
## Summary
- switch the ByteIAAS wheel workflow from ephemeral buildx `--load` to local Docker BuildKit `docker build`
- keep the local Docker Hub pull-through mirror by overriding `BUILD_BASE_IMAGE` to `127.0.0.1:5000/nvidia/cuda:${CUDA_VERSION}-devel-ubuntu22.04`
- leave the image publishing workflow unchanged

## Why
- dev run 28069113786 proved the image job successfully built, skipped the wheel size guard, pushed digest `sha256:d3200bda05d3a93b302803a3ecb7df29178209a5068fb25f0c0c6ef708e55423`, and published `iaas-gpu-cn-beijing.cr.volces.com/serving/vllm:v0.10.0.iaas.dev.202606240936-cu130`
- the wheel job then stalled inside `docker buildx build --target build --load` with no active executor and nearly unchanged I/O counters, so this removes that buildx load path for wheel artifacts only

## Tests
- `.venv/bin/pre-commit run actionlint --files .github/workflows/_byteiaas-build-wheel.yml`
- `git diff --check`

AI-assisted-by: Codex