### PR TITLE
ci: pass host network to byteiaas wheel build

### DIFF
--- a/.github/workflows/_byteiaas-build-wheel.yml
+++ b/.github/workflows/_byteiaas-build-wheel.yml
@@ -45,6 +45,7 @@ jobs:
           set -euo pipefail
           DOCKER_BUILDKIT=1 docker build \
             --target build \
+            --network=host \
             -f docker/Dockerfile \
             --build-arg CUDA_VERSION=${{ inputs.cuda_version }} \
             --build-arg BUILD_BASE_IMAGE="127.0.0.1:5000/nvidia/cuda:${{ inputs.cuda_version }}-devel-ubuntu22.04" \
@@ -52,6 +53,10 @@ jobs:
             --build-arg HTTPS_PROXY="${HTTPS_PROXY}" \
             --build-arg ALL_PROXY="${ALL_PROXY}" \
             --build-arg NO_PROXY="${NO_PROXY}" \
+            --build-arg http_proxy="${HTTP_PROXY}" \
+            --build-arg https_proxy="${HTTPS_PROXY}" \
+            --build-arg all_proxy="${ALL_PROXY}" \
+            --build-arg no_proxy="${NO_PROXY}" \
             --build-arg RUN_WHEEL_CHECK=false \
             -t "local/byteiaas-vllm-wheel:${GITHUB_RUN_ID}" \
             .


### PR DESCRIPTION
## Summary
- add `--network=host` to the ByteIAAS wheel Docker build
- pass lowercase proxy build args alongside the existing uppercase values

## Why
- after PR #136 switched wheel artifacts to local Docker BuildKit, run 28093950332 reached the uv bootstrap layer but `curl https://astral.sh/uv/install.sh` returned HTTP 504 and `uv` was not installed
- the image workflow uses a host-network BuildKit builder, so this makes the wheel build network/proxy shape match that working path

## Tests
- `.venv/bin/pre-commit run actionlint --files .github/workflows/_byteiaas-build-wheel.yml`
- `git diff --check`

AI-assisted-by: Codex