### PR TITLE
ci: bypass proxy for astral uv download

### DIFF
--- a/.github/workflows/_byteiaas-build-wheel.yml
+++ b/.github/workflows/_byteiaas-build-wheel.yml
@@ -28,7 +28,7 @@ jobs:
       HTTP_PROXY: http://100.68.162.211:3128
       HTTPS_PROXY: http://100.68.162.211:3128
       ALL_PROXY: http://100.68.162.211:3128
-      NO_PROXY: localhost,127.0.0.1,::1,mirrors.ivolces.com,.ivolces.com,.volceapi.com,.byted.org,eic-sdk-release.tos-cn-beijing.ivolces.com,scqq9isgq31i0fb8nt4eg.apigateway-cn-beijing.volceapi.com,bytedpypi.byted.org,mirrors.byted.org,iaas-gpu-cn-beijing.cr.volces.com
+      NO_PROXY: localhost,127.0.0.1,::1,mirrors.ivolces.com,.ivolces.com,.volceapi.com,.byted.org,eic-sdk-release.tos-cn-beijing.ivolces.com,scqq9isgq31i0fb8nt4eg.apigateway-cn-beijing.volceapi.com,bytedpypi.byted.org,mirrors.byted.org,iaas-gpu-cn-beijing.cr.volces.com,.astral.sh,astral.sh,releases.astral.sh
     steps:
       - name: Cleanup workspace
         run: sudo rm -rf "$GITHUB_WORKSPACE"/* || true


### PR DESCRIPTION
## Summary
- add Astral domains to the ByteIAAS wheel workflow `NO_PROXY` list
- keep image publishing workflow unchanged

## Why
- run 28094678517 reached the uv installer tarball download inside the wheel Docker build
- the same URL downloaded at only a few KB/s through the proxy, while direct access was much faster in a host probe
- the Dockerfile downloads both `astral.sh` and `releases.astral.sh` during uv bootstrap

## Tests
- `.venv/bin/pre-commit run actionlint --files .github/workflows/_byteiaas-build-wheel.yml`
- `git diff --check`

AI-assisted-by: Codex