### PR TITLE
ci: add byteiaas openai devel image flavor

### DIFF
--- a/.github/workflows/_byteiaas-build-and-publish-image.yml
+++ b/.github/workflows/_byteiaas-build-and-publish-image.yml
@@ -31,13 +31,21 @@ on:
 jobs:
   build-and-publish-image:
     if: github.repository == 'bytedance-iaas/vllm'
+    name: build-and-publish-image (${{ matrix.image_flavor }})
     runs-on: x64-vllm-docker-build-node
     timeout-minutes: 1440
+    strategy:
+      fail-fast: false
+      matrix:
+        image_flavor:
+          - openai
+          - openai-devel
     env:
       HTTP_PROXY: http://100.68.162.211:3128
       HTTPS_PROXY: http://100.68.162.211:3128
       ALL_PROXY: http://100.68.162.211:3128
       NO_PROXY: localhost,127.0.0.1,::1,mirrors.ivolces.com,.ivolces.com,.volceapi.com,.byted.org,eic-sdk-release.tos-cn-beijing.ivolces.com,scqq9isgq31i0fb8nt4eg.apigateway-cn-beijing.volceapi.com,bytedpypi.byted.org,mirrors.byted.org,iaas-gpu-cn-beijing.cr.volces.com,.astral.sh,astral.sh,releases.astral.sh
+      IMAGE_FLAVOR: ${{ matrix.image_flavor }}
       VOLCENGINE_CR_REGISTRY: ${{ vars.VOLCENGINE_CR_REGISTRY }}
       VOLCENGINE_CR_NAMESPACE: ${{ vars.VOLCENGINE_CR_NAMESPACE }}
       VOLCENGINE_CR_REPOSITORY: ${{ vars.VOLCENGINE_CR_REPOSITORY || 'vllm' }}
@@ -75,7 +83,11 @@ jobs:
           BYTEIAAS_VLLM_VERSION: ${{ inputs.vllm_version }}
         run: |
           set -euo pipefail
-          tag_args=(--mode "${{ inputs.tag_mode }}" --cuda-suffix cu130)
+          tag_args=(
+            --mode "${{ inputs.tag_mode }}"
+            --image-flavor "${IMAGE_FLAVOR}"
+            --cuda-suffix cu130
+          )
           if [ -n "${{ inputs.tag_value }}" ]; then
             tag_args+=(--tag-value "${{ inputs.tag_value }}")
           fi
@@ -104,21 +116,66 @@ jobs:
         id: build
         run: |
           set -euo pipefail
-          docker buildx build \
-            --target vllm-openai \
-            --platform linux/amd64 \
-            --output "type=image,name=${IMAGE_REPO},push-by-digest=true,name-canonical=true,push=true" \
-            -f docker/Dockerfile \
-            --build-arg CUDA_VERSION=${{ inputs.cuda_version }} \
-            --build-arg HTTP_PROXY="${HTTP_PROXY}" \
-            --build-arg HTTPS_PROXY="${HTTPS_PROXY}" \
-            --build-arg ALL_PROXY="${ALL_PROXY}" \
-            --build-arg NO_PROXY="${NO_PROXY}" \
-            --build-arg RUN_WHEEL_CHECK=false \
-            --metadata-file /tmp/byteiaas-vllm-image-metadata.json \
-            .
-          DIGEST="$(python3 -c "import json; print(json.load(open('/tmp/byteiaas-vllm-image-metadata.json'))['containerimage.digest'])")"
-          echo "Pushed digest: ${DIGEST}"
+          ubuntu_version="22.04"
+          final_base_image="nvidia/cuda:${{ inputs.cuda_version }}-base-ubuntu${ubuntu_version}"
+          metadata_file="/tmp/byteiaas-vllm-image-${IMAGE_FLAVOR}.json"
+
+          build_vllm_openai() {
+            local output_name="$1"
+            local metadata_path="$2"
+            local final_base="$3"
+            docker buildx build \
+              --target vllm-openai \
+              --platform linux/amd64 \
+              --output "type=image,name=${output_name},push-by-digest=true,name-canonical=true,push=true" \
+              -f docker/Dockerfile \
+              --build-arg CUDA_VERSION=${{ inputs.cuda_version }} \
+              --build-arg FINAL_BASE_IMAGE="${final_base}" \
+              --build-arg INSTALL_KV_CONNECTORS=true \
+              --build-arg HTTP_PROXY="${HTTP_PROXY}" \
+              --build-arg HTTPS_PROXY="${HTTPS_PROXY}" \
+              --build-arg ALL_PROXY="${ALL_PROXY}" \
+              --build-arg NO_PROXY="${NO_PROXY}" \
+              --build-arg http_proxy="${HTTP_PROXY}" \
+              --build-arg https_proxy="${HTTPS_PROXY}" \
+              --build-arg all_proxy="${ALL_PROXY}" \
+              --build-arg no_proxy="${NO_PROXY}" \
+              --build-arg RUN_WHEEL_CHECK=false \
+              --metadata-file "${metadata_path}" \
+              .
+          }
+
+          if [ "${IMAGE_FLAVOR}" = "openai" ]; then
+            build_vllm_openai "${IMAGE_REPO}" "${metadata_file}" "${final_base_image}"
+          elif [ "${IMAGE_FLAVOR}" = "openai-devel" ]; then
+            devel_base_image="nvidia/cuda:${{ inputs.cuda_version }}-devel-ubuntu${ubuntu_version}"
+            base_metadata_file="/tmp/byteiaas-vllm-image-${IMAGE_FLAVOR}-base.json"
+            build_vllm_openai "${IMAGE_REPO}" "${base_metadata_file}" "${devel_base_image}"
+            base_digest="$(python3 -c "import json; print(json.load(open('${base_metadata_file}'))['containerimage.digest'])")"
+            echo "Pushed openai-devel base digest: ${base_digest}"
+
+            docker buildx build \
+              --platform linux/amd64 \
+              --output "type=image,name=${IMAGE_REPO},push-by-digest=true,name-canonical=true,push=true" \
+              -f docker/byteiaas-openai-devel.Dockerfile \
+              --build-arg "VLLM_OPENAI_DEVEL_BASE_IMAGE=${IMAGE_REPO}@${base_digest}" \
+              --build-arg HTTP_PROXY="${HTTP_PROXY}" \
+              --build-arg HTTPS_PROXY="${HTTPS_PROXY}" \
+              --build-arg ALL_PROXY="${ALL_PROXY}" \
+              --build-arg NO_PROXY="${NO_PROXY}" \
+              --build-arg http_proxy="${HTTP_PROXY}" \
+              --build-arg https_proxy="${HTTPS_PROXY}" \
+              --build-arg all_proxy="${ALL_PROXY}" \
+              --build-arg no_proxy="${NO_PROXY}" \
+              --metadata-file "${metadata_file}" \
+              .
+          else
+            echo "::error::Unsupported image flavor: ${IMAGE_FLAVOR}"
+            exit 1
+          fi
+
+          DIGEST="$(python3 -c "import json; print(json.load(open('${metadata_file}'))['containerimage.digest'])")"
+          echo "Pushed ${IMAGE_FLAVOR} digest: ${DIGEST}"
           echo "digest=${DIGEST}" >> "${GITHUB_OUTPUT}"
 
       - name: Create Volcengine image tag
@@ -127,4 +184,4 @@ jobs:
           docker buildx imagetools create \
             -t "${IMAGE_REPO}:${{ steps.image-tag.outputs.image-tag }}" \
             "${IMAGE_REPO}@${{ steps.build.outputs.digest }}"
-          echo "Published ${IMAGE_REPO}:${{ steps.image-tag.outputs.image-tag }}"
+          echo "Published image ${IMAGE_FLAVOR}: ${IMAGE_REPO}:${{ steps.image-tag.outputs.image-tag }}"

--- a/.github/workflows/_byteiaas-build-and-publish-image.yml
+++ b/.github/workflows/_byteiaas-build-and-publish-image.yml
@@ -37,7 +37,7 @@ jobs:
       HTTP_PROXY: http://100.68.162.211:3128
       HTTPS_PROXY: http://100.68.162.211:3128
       ALL_PROXY: http://100.68.162.211:3128
-      NO_PROXY: localhost,127.0.0.1,::1,mirrors.ivolces.com,.ivolces.com,.volceapi.com,.byted.org,eic-sdk-release.tos-cn-beijing.ivolces.com,scqq9isgq31i0fb8nt4eg.apigateway-cn-beijing.volceapi.com,bytedpypi.byted.org,mirrors.byted.org,iaas-gpu-cn-beijing.cr.volces.com
+      NO_PROXY: localhost,127.0.0.1,::1,mirrors.ivolces.com,.ivolces.com,.volceapi.com,.byted.org,eic-sdk-release.tos-cn-beijing.ivolces.com,scqq9isgq31i0fb8nt4eg.apigateway-cn-beijing.volceapi.com,bytedpypi.byted.org,mirrors.byted.org,iaas-gpu-cn-beijing.cr.volces.com,.astral.sh,astral.sh,releases.astral.sh
       VOLCENGINE_CR_REGISTRY: ${{ vars.VOLCENGINE_CR_REGISTRY }}
       VOLCENGINE_CR_NAMESPACE: ${{ vars.VOLCENGINE_CR_NAMESPACE }}
       VOLCENGINE_CR_REPOSITORY: ${{ vars.VOLCENGINE_CR_REPOSITORY || 'vllm' }}

--- a/docker/byteiaas-openai-devel.Dockerfile
+++ b/docker/byteiaas-openai-devel.Dockerfile
@@ -1,0 +1,35 @@
+ARG VLLM_OPENAI_DEVEL_BASE_IMAGE
+FROM ${VLLM_OPENAI_DEVEL_BASE_IMAGE}
+
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG ALL_PROXY
+ARG NO_PROXY
+ARG http_proxy
+ARG https_proxy
+ARG all_proxy
+ARG no_proxy
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        cmake \
+        curl \
+        gdb \
+        git \
+        git-lfs \
+        less \
+        lsof \
+        ninja-build \
+        pkg-config \
+        rsync \
+        strace \
+        tmux \
+        vim \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace

--- a/scripts/ci/get_byteiaas_image_tag.py
+++ b/scripts/ci/get_byteiaas_image_tag.py
@@ -90,6 +90,7 @@ def current_timestamp(timestamp_arg: str) -> str:
 def build_tag(
     *,
     mode: str,
+    image_flavor: str,
     vllm_version: str,
     timestamp: str,
     tag_value: str,
@@ -106,6 +107,13 @@ def build_tag(
     else:
         raise SystemExit(f"unsupported mode: {mode}")
 
+    if image_flavor == "openai":
+        pass
+    elif image_flavor == "openai-devel":
+        tag = f"{tag}-openai-devel"
+    else:
+        raise SystemExit(f"unsupported image flavor: {image_flavor}")
+
     if cuda_suffix:
         tag = f"{tag}-{cuda_suffix}"
     return tag
@@ -116,6 +124,12 @@ def main() -> None:
         description="Generate ByteIAAS Volcengine CR image tags for vLLM."
     )
     parser.add_argument("--mode", choices=["dev", "release"], required=True)
+    parser.add_argument(
+        "--image-flavor",
+        choices=["openai", "openai-devel"],
+        default="openai",
+        help="Image flavor. The default preserves the existing openai tag format.",
+    )
     parser.add_argument(
         "--tag-value",
         default="",
@@ -141,6 +155,7 @@ def main() -> None:
 
     tag = build_tag(
         mode=args.mode,
+        image_flavor=args.image_flavor,
         vllm_version=get_vllm_version(args.vllm_version),
         timestamp=current_timestamp(args.timestamp),
         tag_value=args.tag_value,

--- a/tests/ci/test_get_byteiaas_image_tag.py
+++ b/tests/ci/test_get_byteiaas_image_tag.py
@@ -22,6 +22,7 @@ def test_build_dev_tag_with_cuda_suffix() -> None:
     assert (
         helper.build_tag(
             mode="dev",
+            image_flavor="openai",
             vllm_version="0.12.0",
             timestamp="202606231234",
             tag_value="",
@@ -35,6 +36,7 @@ def test_build_release_tag_with_internal_tag_and_cuda_suffix() -> None:
     assert (
         helper.build_tag(
             mode="release",
+            image_flavor="openai",
             vllm_version="0.12.0",
             timestamp="202606231234",
             tag_value="0.0.11",
@@ -44,10 +46,51 @@ def test_build_release_tag_with_internal_tag_and_cuda_suffix() -> None:
     )
 
 
+def test_build_dev_openai_devel_tag_with_cuda_suffix() -> None:
+    assert (
+        helper.build_tag(
+            mode="dev",
+            image_flavor="openai-devel",
+            vllm_version="0.12.0",
+            timestamp="202606231234",
+            tag_value="",
+            cuda_suffix="cu130",
+        )
+        == "v0.12.0.iaas.dev.202606231234-openai-devel-cu130"
+    )
+
+
+def test_build_release_openai_devel_tag_with_cuda_suffix() -> None:
+    assert (
+        helper.build_tag(
+            mode="release",
+            image_flavor="openai-devel",
+            vllm_version="0.12.0",
+            timestamp="202606231234",
+            tag_value="0.0.11",
+            cuda_suffix="cu130",
+        )
+        == "v0.12.0.byted.0.0.11.202606231234-openai-devel-cu130"
+    )
+
+
+def test_build_tag_rejects_unknown_image_flavor() -> None:
+    with pytest.raises(SystemExit, match="unsupported image flavor"):
+        helper.build_tag(
+            mode="dev",
+            image_flavor="runtime",
+            vllm_version="0.12.0",
+            timestamp="202606231234",
+            tag_value="",
+            cuda_suffix="cu130",
+        )
+
+
 def test_release_requires_tag_value() -> None:
     with pytest.raises(SystemExit, match="--tag-value is required"):
         helper.build_tag(
             mode="release",
+            image_flavor="openai",
             vllm_version="0.12.0",
             timestamp="202606231234",
             tag_value="",
@@ -59,6 +102,7 @@ def test_release_rejects_unsafe_tag_value() -> None:
     with pytest.raises(SystemExit, match="Docker tag-safe suffix"):
         helper.build_tag(
             mode="release",
+            image_flavor="openai",
             vllm_version="0.12.0",
             timestamp="202606231234",
             tag_value="../bad",


### PR DESCRIPTION
## Summary
- keep the Astral release domains in ByteIAAS image build `NO_PROXY`
- publish both ByteIAAS `openai` and `openai-devel` image flavors from the reusable image workflow
- add `docker/byteiaas-openai-devel.Dockerfile` in the vLLM repo for the final debugging/tooling layer
- extend the ByteIAAS tag helper with `--image-flavor openai|openai-devel` while preserving existing `openai` tag format

## Context
The first-version dev build succeeded for the wheel and `openai` image, but the formal image path hit the same Astral/uv proxy failure already fixed for the wheel path. After that, the image requirement changed: ByteIAAS should publish the community-aligned `vllm-openai` image plus an additive `openai-devel` image that uses the CUDA devel final base and adds debugging/build tools.

The `openai-devel` wrapper now lives in this vLLM GitHub repository because it is directly used by the vLLM GitHub Actions workflow.

## Tests
- `.venv/bin/python -m pytest --confcutdir=tests/ci tests/ci/test_get_byteiaas_image_tag.py -v`
- `.venv/bin/pre-commit run actionlint --files .github/workflows/_byteiaas-build-and-publish-image.yml .github/workflows/byteiaas-release-dev.yml .github/workflows/byteiaas-release.yml`
- `.venv/bin/pre-commit run ruff-check --files scripts/ci/get_byteiaas_image_tag.py tests/ci/test_get_byteiaas_image_tag.py`
- `.venv/bin/pre-commit run ruff-format --files scripts/ci/get_byteiaas_image_tag.py tests/ci/test_get_byteiaas_image_tag.py`
- `.venv/bin/python - <<'PY' ... yaml.safe_load(...) ... PY`
- `git diff --check`

## Duplicate Work
- Checked the current ByteIAAS workflow state and prior PRs in this fork; this is fork-scoped CI work for `bytedance-iaas/vllm`, building on the already-merged ByteIAAS workflow series and superseding the old Astral-only scope of this PR.

## AI Assistance
- Prepared with AI assistance in Codex.
