### PR TITLE
ci: schedule daily ByteIAAS vLLM dev builds

### DIFF
--- a/.github/workflows/byteiaas-release-dev.yml
+++ b/.github/workflows/byteiaas-release-dev.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - iaas_main
+  schedule:
+    # Daily at 02:00 Asia/Shanghai.
+    - cron: "0 18 * * *"
   workflow_dispatch:
     inputs:
       checkout_ref:


### PR DESCRIPTION
## Summary\n- add a daily schedule to the ByteIAAS vLLM development build workflow\n- keep existing push and manual workflow_dispatch triggers\n- schedule runs at 02:00 Asia/Shanghai (18:00 UTC)\n\n## Validation\n- /data00/home/hanhan.hank/workspace/vllm_pp/vllm/.venv/bin/python YAML parse for .github/workflows/byteiaas-release-dev.yml\n- /data00/home/hanhan.hank/workspace/vllm_pp/vllm/.venv/bin/pre-commit run actionlint --files .github/workflows/byteiaas-release-dev.yml\n\nAI assistance was used for this change.\n