### PR TITLE
Enable Mooncake device selection in connector

### DIFF
--- a/docs/features/mooncake_connector_usage.md
+++ b/docs/features/mooncake_connector_usage.md
@@ -60,6 +60,7 @@ Now you can send requests to the proxy server through port 8000.
 
 - **num_workers**: Size of thread pool for one prefiller worker to transfer KV caches by mooncake. (default 10)
 - **mooncake_protocol**: Mooncake connector protocol. (default "rdma")
+- **mooncake_device**: RDMA device list for the Mooncake transfer engine, for example `"mlx5_1,mlx5_2"`. If unset, `MOONCAKE_DEVICE` is used when present.
 
 ## Example Scripts/Code
 

--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -54,9 +54,12 @@ class FakeMooncakeWrapper:
     """Mock Mooncake TransferEngine for unit testing environments."""
 
     def __init__(self, *args, **kwargs):
-        pass
+        self.initialize_calls = []
 
     def initialize(self, local_hostname, metadata_server, protocol, device_name) -> int:
+        self.initialize_calls.append(
+            (local_hostname, metadata_server, protocol, device_name)
+        )
         return 0
 
     def get_rpc_port(self) -> int:
@@ -853,6 +856,56 @@ def patch_worker_dependencies():
             "mock_async_client": mock_async_client,
             "mock_http_client": mock_http_client_instance,
         }
+
+
+@pytest.mark.parametrize(
+    ("extra_config", "env_device", "expected_device"),
+    [
+        (
+            {"mooncake_device": "mlx5_1,mlx5_2"},
+            "mlx5_3",
+            "mlx5_1,mlx5_2",
+        ),
+        (
+            {"device_name": "mlx5_2"},
+            "mlx5_3",
+            "mlx5_2",
+        ),
+        ({}, "mlx5_1,mlx5_2,mlx5_3,mlx5_4", "mlx5_1,mlx5_2,mlx5_3,mlx5_4"),
+        ({"mooncake_device": ""}, "mlx5_3", ""),
+    ],
+    ids=[
+        "extra_config_mooncake_device",
+        "extra_config_device_name_alias",
+        "mooncake_device_env",
+        "explicit_empty_device",
+    ],
+)
+def test_worker_initializes_mooncake_with_configured_device(
+    monkeypatch,
+    extra_config: dict[str, str],
+    env_device: str,
+    expected_device: str,
+):
+    monkeypatch.setenv("MOONCAKE_DEVICE", env_device)
+    vllm_config = create_vllm_config(
+        kv_connector="MooncakeConnector",
+        kv_role="kv_consumer",
+        kv_connector_extra_config=extra_config,
+    )
+
+    with set_current_vllm_config(vllm_config), patch_worker_dependencies():
+        connector = MooncakeConnector(
+            vllm_config,
+            KVConnectorRole.WORKER,
+            _make_test_kv_cache_config(),
+        )
+
+    worker = connector.connector_worker
+    assert worker is not None
+    assert worker.engine.initialize_calls == [
+        ("127.0.0.1", "P2PHANDSHAKE", "rdma", expected_device)
+    ]
 
 
 @pytest.mark.asyncio

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import asyncio
 import logging
+import os
 import threading
 import time
 from collections import defaultdict
@@ -1216,20 +1217,29 @@ class MooncakeConnectorWorker:
         assert (kv_transfer_config := vllm_config.kv_transfer_config)
         self.is_kv_producer: bool = kv_transfer_config.kv_role == "kv_producer"
         self.is_kv_consumer: bool = kv_transfer_config.kv_role == "kv_consumer"
-        self.num_sender_workers = kv_transfer_config.kv_connector_extra_config.get(
-            "num_workers", 10
-        )
+        extra_config = kv_transfer_config.kv_connector_extra_config
+        self.num_sender_workers = extra_config.get("num_workers", 10)
         # Create more tasks than workers to keep the thread pool saturated.
         # Tasks can await async events, so a surplus (2x is a robust heuristic)
         # prevents workers from idling.
         self.num_sender_tasks = self.num_sender_workers * 2
-        protocol = kv_transfer_config.kv_connector_extra_config.get(  # type: ignore[union-attr]
-            "mooncake_protocol", "rdma"
-        )
+        protocol = extra_config.get("mooncake_protocol", "rdma")
+        device_name = extra_config.get("mooncake_device")
+        if device_name is None:
+            device_name = extra_config.get("device_name")
+        if device_name is None:
+            device_name = os.environ.get("MOONCAKE_DEVICE", "")
         logger.info(
             "The Mooncake Transfer Engine is using %s as its protocol.", protocol
         )
-        ret_value = self.engine.initialize(self.hostname, "P2PHANDSHAKE", protocol, "")
+        if device_name:
+            logger.info(
+                "The Mooncake Transfer Engine is using %s as its device.",
+                device_name,
+            )
+        ret_value = self.engine.initialize(
+            self.hostname, "P2PHANDSHAKE", protocol, device_name
+        )
         if ret_value != 0:
             raise RuntimeError("Mooncake Transfer Engine initialization failed.")
 


### PR DESCRIPTION
## Summary

- Pass an explicit Mooncake RDMA device list from `kv_connector_extra_config` into `TransferEngine.initialize`.
- Support `mooncake_device`, compatible `device_name`, and `MOONCAKE_DEVICE` fallback.
- Add unit coverage for initialize argument selection and document the new config.

## Root Cause

The vLLM P2P Mooncake connector previously initialized Mooncake with an empty `device_name`, so Mooncake auto-discovered all HCAs. On the target deployment this included `mlx5_6`, even though the intended RDMA devices are `mlx5_1..mlx5_4`.

## Duplicate Check

I checked open PRs with Mooncake connector/device keywords. Upstream PR `vllm-project/vllm#44919` is related but handles auto-discovery of compatible RDMA devices. This PR is narrower and targets `iaas_main` by adding explicit device selection plumbing for the current deployment path.

## Validation

- `git diff --check`

I did not run local pytest because this workspace requires vLLM validation to run inside Kubernetes Pods rather than local host Python.

## AI Assistance

This change was prepared with AI assistance and reviewed in the local workspace before submission.
