### PR TITLE
Align Mooncake device config with upstream

### DIFF
--- a/docs/features/mooncake_connector_usage.md
+++ b/docs/features/mooncake_connector_usage.md
@@ -60,7 +60,7 @@ Now you can send requests to the proxy server through port 8000.
 
 - **num_workers**: Size of thread pool for one prefiller worker to transfer KV caches by mooncake. (default 10)
 - **mooncake_protocol**: Mooncake connector protocol. (default "rdma")
-- **mooncake_device**: RDMA device list for the Mooncake transfer engine, for example `"mlx5_1,mlx5_2"`. If unset, `MOONCAKE_DEVICE` is used when present.
+- **device_name**: RDMA device list for the Mooncake transfer engine, for example `"mlx5_1,mlx5_2"`. If unset, Mooncake uses its default device selection.
 
 ## Example Scripts/Code
 

--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -859,35 +859,23 @@ def patch_worker_dependencies():
 
 
 @pytest.mark.parametrize(
-    ("extra_config", "env_device", "expected_device"),
+    ("extra_config", "expected_device"),
     [
         (
-            {"mooncake_device": "mlx5_1,mlx5_2"},
-            "mlx5_3",
-            "mlx5_1,mlx5_2",
-        ),
-        (
             {"device_name": "mlx5_2"},
-            "mlx5_3",
             "mlx5_2",
         ),
-        ({}, "mlx5_1,mlx5_2,mlx5_3,mlx5_4", "mlx5_1,mlx5_2,mlx5_3,mlx5_4"),
-        ({"mooncake_device": ""}, "mlx5_3", ""),
+        ({}, ""),
     ],
     ids=[
-        "extra_config_mooncake_device",
-        "extra_config_device_name_alias",
-        "mooncake_device_env",
-        "explicit_empty_device",
+        "extra_config_device_name",
+        "default_empty_device",
     ],
 )
 def test_worker_initializes_mooncake_with_configured_device(
-    monkeypatch,
     extra_config: dict[str, str],
-    env_device: str,
     expected_device: str,
 ):
-    monkeypatch.setenv("MOONCAKE_DEVICE", env_device)
     vllm_config = create_vllm_config(
         kv_connector="MooncakeConnector",
         kv_role="kv_consumer",

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import asyncio
 import logging
-import os
 import threading
 import time
 from collections import defaultdict
@@ -1217,26 +1216,22 @@ class MooncakeConnectorWorker:
         assert (kv_transfer_config := vllm_config.kv_transfer_config)
         self.is_kv_producer: bool = kv_transfer_config.kv_role == "kv_producer"
         self.is_kv_consumer: bool = kv_transfer_config.kv_role == "kv_consumer"
-        extra_config = kv_transfer_config.kv_connector_extra_config
-        self.num_sender_workers = extra_config.get("num_workers", 10)
+        self.num_sender_workers = kv_transfer_config.kv_connector_extra_config.get(
+            "num_workers", 10
+        )
         # Create more tasks than workers to keep the thread pool saturated.
         # Tasks can await async events, so a surplus (2x is a robust heuristic)
         # prevents workers from idling.
         self.num_sender_tasks = self.num_sender_workers * 2
-        protocol = extra_config.get("mooncake_protocol", "rdma")
-        device_name = extra_config.get("mooncake_device")
-        if device_name is None:
-            device_name = extra_config.get("device_name")
-        if device_name is None:
-            device_name = os.environ.get("MOONCAKE_DEVICE", "")
+        protocol = kv_transfer_config.kv_connector_extra_config.get(
+            "mooncake_protocol", "rdma"
+        )
+        device_name = kv_transfer_config.kv_connector_extra_config.get(
+            "device_name", ""
+        )
         logger.info(
             "The Mooncake Transfer Engine is using %s as its protocol.", protocol
         )
-        if device_name:
-            logger.info(
-                "The Mooncake Transfer Engine is using %s as its device.",
-                device_name,
-            )
         ret_value = self.engine.initialize(
             self.hostname, "P2PHANDSHAKE", protocol, device_name
         )


### PR DESCRIPTION
## Summary

- Align IaaS MooncakeConnector device selection with upstream vLLM behavior.
- Use `kv_connector_extra_config["device_name"]` as the RDMA device list key.
- Remove the IaaS-only `mooncake_device` alias and `MOONCAKE_DEVICE` fallback from the connector path.
- Keep unit coverage for the `TransferEngine.initialize(..., device_name)` argument and update docs to the community-compatible key.

## Upstream Reference

Community vLLM already passes `device_name` into `TransferEngine.initialize` through `vllm-project/vllm#46807`. This PR adapts IaaS to that behavior instead of keeping the earlier IaaS-only `mooncake_device` convention.

## Validation

- `git diff --check`

I did not run local pytest because this workspace requires vLLM validation to run inside Kubernetes Pods rather than local host Python.

## AI Assistance

This change was prepared with AI assistance and reviewed in the local workspace before submission.
