### PR TITLE
[Feature] Support DeepSeek V4 index cache for Hopper

### DIFF
--- a/docs/features/index_cache.md
+++ b/docs/features/index_cache.md
@@ -1,10 +1,10 @@
 # IndexCache
 
-IndexCache reduces redundant top-k computation in DeepSeek-V3.2 (DSA) models by caching and reusing top-k indices across layers.
+IndexCache reduces redundant top-k computation in DeepSeek-V3.2 (DSA) and compatible DeepSeek-V4 CUDA SM90/Hopper models by caching and reusing top-k indices across layers.
 
 ## Background
 
-DeepSeek-V3.2 uses a DeepSeek Sparse Attention (DSA) mechanism where top-k token selection is computed per layer. For deep models with many layers, this computation can be expensive. IndexCache allows skipping redundant top-k computations by reusing indices from previous layers.
+DeepSeek-V3.2 and compatible DeepSeek-V4 CUDA SM90/Hopper models use a DeepSeek Sparse Attention (DSA) mechanism where top-k token selection is computed per layer. For deep models with many layers, this computation can be expensive. IndexCache allows skipping redundant top-k computations by reusing indices from previous layers.
 
 See: [IndexCache Paper](https://arxiv.org/abs/2603.12201)
 
@@ -50,5 +50,5 @@ vllm serve deepseek-ai/DeepSeek-V3.2 \
 
 ## Requirements
 
-- DeepSeek-V3.2 or compatible DSA model
+- DeepSeek-V3.2, DeepSeek-V4 on CUDA SM90/Hopper, or compatible DSA model
 - `use_index_cache: true` via `--hf-overrides`

--- a/tests/models/test_deepseek_v4_index_cache.py
+++ b/tests/models/test_deepseek_v4_index_cache.py
@@ -1,0 +1,315 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for DeepSeek V4 IndexCache layer selection."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+import vllm.models.deepseek_v4.attention as dsv4_attn_mod
+import vllm.models.deepseek_v4.nvidia.model as dsv4_nvidia_model
+from vllm.models.deepseek_v4.attention import (
+    DeepseekV4Attention,
+    compute_dsv4_index_cache_skip_flags,
+)
+
+COMPRESS_RATIOS = [128, 128, 4, 128, 4, 128, 4, 4, 128, 4]
+NUM_HIDDEN_LAYERS = len(COMPRESS_RATIOS)
+
+
+def _skipped_layer_ids(flags: tuple[bool, ...]) -> list[int]:
+    return [idx for idx, skip in enumerate(flags) if skip]
+
+
+def test_index_cache_disabled_skips_no_layers():
+    flags = compute_dsv4_index_cache_skip_flags(
+        COMPRESS_RATIOS,
+        NUM_HIDDEN_LAYERS,
+        use_index_cache=False,
+        index_topk_freq=4,
+    )
+    assert _skipped_layer_ids(flags) == []
+
+
+def test_index_cache_freq_one_skips_no_layers():
+    flags = compute_dsv4_index_cache_skip_flags(
+        COMPRESS_RATIOS,
+        NUM_HIDDEN_LAYERS,
+        use_index_cache=True,
+        index_topk_freq=1,
+    )
+    assert _skipped_layer_ids(flags) == []
+
+
+def test_index_cache_freq_four_uses_default_offset_two():
+    flags = compute_dsv4_index_cache_skip_flags(
+        COMPRESS_RATIOS,
+        NUM_HIDDEN_LAYERS,
+        use_index_cache=True,
+        index_topk_freq=4,
+    )
+    assert _skipped_layer_ids(flags) == [6, 7, 9]
+
+
+def test_index_cache_offset_one_matches_fsss_pattern():
+    flags = compute_dsv4_index_cache_skip_flags(
+        COMPRESS_RATIOS,
+        NUM_HIDDEN_LAYERS,
+        use_index_cache=True,
+        index_topk_freq=4,
+        index_skip_topk_offset=1,
+    )
+    assert _skipped_layer_ids(flags) == [4, 6, 7]
+
+
+def test_index_cache_custom_pattern_maps_to_c4_layers_only():
+    flags = compute_dsv4_index_cache_skip_flags(
+        COMPRESS_RATIOS,
+        NUM_HIDDEN_LAYERS,
+        use_index_cache=True,
+        index_topk_pattern="FSFSS",
+    )
+    assert _skipped_layer_ids(flags) == [4, 7, 9]
+
+
+def test_non_c4_layers_are_never_skipped():
+    flags = compute_dsv4_index_cache_skip_flags(
+        COMPRESS_RATIOS,
+        NUM_HIDDEN_LAYERS,
+        use_index_cache=True,
+        index_topk_pattern="FSSSS",
+    )
+    assert all(
+        not flags[idx] for idx, ratio in enumerate(COMPRESS_RATIOS) if ratio != 4
+    )
+
+
+def test_extra_compress_ratios_do_not_affect_backbone_mapping():
+    flags = compute_dsv4_index_cache_skip_flags(
+        COMPRESS_RATIOS + [4, 4, 4],
+        NUM_HIDDEN_LAYERS,
+        use_index_cache=True,
+        index_topk_pattern="FSFSS",
+    )
+    assert len(flags) == NUM_HIDDEN_LAYERS
+    assert _skipped_layer_ids(flags) == [4, 7, 9]
+
+
+def test_each_pp_stage_first_local_c4_layer_is_forced_full():
+    flags = compute_dsv4_index_cache_skip_flags(
+        COMPRESS_RATIOS,
+        NUM_HIDDEN_LAYERS,
+        use_index_cache=True,
+        index_topk_pattern="FSSSS",
+        local_start_layer=3,
+        local_end_layer=8,
+    )
+    assert _skipped_layer_ids(flags) == [6, 7, 9]
+    assert not flags[4]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"index_topk_freq": 0}, "index_topk_freq must be positive"),
+        ({"index_skip_topk_offset": 0}, "index_skip_topk_offset must be at least 1"),
+        ({"index_topk_pattern": "FXFSS"}, "only supports 'F'.*'S'"),
+        ({"index_topk_pattern": "FSS"}, "length must match"),
+        ({"index_topk_pattern": "SFFFF"}, "must start with 'F'"),
+    ],
+)
+def test_invalid_index_cache_config_raises(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        compute_dsv4_index_cache_skip_flags(
+            COMPRESS_RATIOS,
+            NUM_HIDDEN_LAYERS,
+            use_index_cache=True,
+            **kwargs,
+        )
+
+
+def test_short_compress_ratios_raises():
+    with pytest.raises(ValueError, match="at least num_hidden_layers"):
+        compute_dsv4_index_cache_skip_flags(
+            [4, 128],
+            3,
+            use_index_cache=True,
+        )
+
+
+def test_invalid_local_range_raises():
+    with pytest.raises(ValueError, match="local layer range"):
+        compute_dsv4_index_cache_skip_flags(
+            COMPRESS_RATIOS,
+            NUM_HIDDEN_LAYERS,
+            use_index_cache=True,
+            local_start_layer=8,
+            local_end_layer=7,
+        )
+
+
+class _TestDeepseekV4Attention(DeepseekV4Attention):
+    @classmethod
+    def get_padded_num_q_heads(cls, num_heads: int) -> int:
+        return num_heads
+
+    def forward_mqa(
+        self,
+        q: torch.Tensor,
+        kv: torch.Tensor,
+        positions: torch.Tensor,
+        output: torch.Tensor,
+    ) -> None:
+        pass
+
+    def _o_proj(self, o: torch.Tensor, positions: torch.Tensor) -> torch.Tensor:
+        return o
+
+
+def _make_attention(skip_topk: bool) -> _TestDeepseekV4Attention:
+    attn = object.__new__(_TestDeepseekV4Attention)
+    attn.indexer = Mock(name="indexer")
+    attn.skip_topk = skip_topk
+    attn.compressor = Mock(name="compressor")
+    attn.aux_stream_list = None
+    attn.ln_events = [None, None, None, None]
+    attn.n_local_heads = 1
+    attn.head_dim = 2
+    attn.wq_b = Mock(return_value=torch.zeros(1, 2))
+    attn._fused_qnorm_rope_kv_insert = Mock(side_effect=lambda q, *_args: q)
+    attn.forward_mqa = Mock()
+    attn.indexer_rotary_emb = object()
+    attn.rotary_emb = object()
+    return attn
+
+
+@pytest.fixture()
+def _patch_attention_helpers(monkeypatch):
+    monkeypatch.setattr(
+        dsv4_attn_mod,
+        "get_forward_context",
+        lambda: type("Context", (), {"attn_metadata": {}})(),
+    )
+    monkeypatch.setattr(
+        dsv4_attn_mod,
+        "execute_in_parallel",
+        lambda main_fn, fns, *_args, **_kwargs: (
+            main_fn(),
+            [fn() if fn is not None else None for fn in fns],
+        ),
+    )
+    monkeypatch.setattr(
+        dsv4_attn_mod,
+        "maybe_execute_in_parallel",
+        lambda first_fn, second_fn, *_args, **_kwargs: (first_fn(), second_fn()),
+    )
+
+
+def test_skip_topk_bypasses_indexer_but_keeps_main_compressor(_patch_attention_helpers):
+    attn = _make_attention(skip_topk=True)
+
+    attn.attention_impl(
+        torch.zeros(1, 4),
+        torch.zeros(1, 4),
+        torch.zeros(1, 2),
+        torch.zeros(1, 2),
+        None,
+        None,
+        torch.zeros(1, dtype=torch.long),
+        torch.zeros(1, 1, 2),
+    )
+
+    attn.indexer.assert_not_called()
+    attn.compressor.assert_called_once()
+    attn.forward_mqa.assert_called_once()
+
+
+def test_full_topk_path_calls_indexer_and_compressor(_patch_attention_helpers):
+    attn = _make_attention(skip_topk=False)
+
+    attn.attention_impl(
+        torch.zeros(1, 4),
+        torch.zeros(1, 4),
+        torch.zeros(1, 2),
+        torch.zeros(1, 2),
+        torch.zeros(1, 2),
+        torch.zeros(1, 1),
+        torch.zeros(1, dtype=torch.long),
+        torch.zeros(1, 1, 2),
+    )
+
+    attn.indexer.assert_called_once()
+    attn.compressor.assert_called_once()
+    attn.forward_mqa.assert_called_once()
+
+
+def test_index_cache_platform_guard_ignores_disabled_unknown_device(monkeypatch):
+    monkeypatch.setattr(
+        dsv4_nvidia_model.current_platform,
+        "get_device_capability",
+        lambda: None,
+    )
+
+    dsv4_nvidia_model._validate_dsv4_index_cache_platform(False)
+
+
+def test_index_cache_platform_guard_allows_hopper(monkeypatch):
+    monkeypatch.setattr(
+        dsv4_nvidia_model.current_platform,
+        "get_device_capability",
+        lambda: SimpleNamespace(major=9),
+    )
+
+    dsv4_nvidia_model._validate_dsv4_index_cache_platform(True)
+
+
+def test_index_cache_platform_guard_rejects_non_hopper(monkeypatch):
+    monkeypatch.setattr(
+        dsv4_nvidia_model.current_platform,
+        "get_device_capability",
+        lambda: SimpleNamespace(major=12),
+    )
+
+    with pytest.raises(NotImplementedError, match="only on Hopper"):
+        dsv4_nvidia_model._validate_dsv4_index_cache_platform(True)
+
+
+def test_index_cache_config_default_is_disabled():
+    config = SimpleNamespace()
+
+    flags = compute_dsv4_index_cache_skip_flags(
+        COMPRESS_RATIOS,
+        NUM_HIDDEN_LAYERS,
+        use_index_cache=getattr(config, "use_index_cache", False),
+        index_topk_freq=getattr(config, "index_topk_freq", 1),
+    )
+
+    assert _skipped_layer_ids(flags) == []
+
+
+def test_index_cache_config_hf_overrides_enable_freq_four():
+    config = SimpleNamespace(use_index_cache=True, index_topk_freq=4)
+
+    flags = compute_dsv4_index_cache_skip_flags(
+        COMPRESS_RATIOS,
+        NUM_HIDDEN_LAYERS,
+        use_index_cache=getattr(config, "use_index_cache", False),
+        index_topk_freq=getattr(config, "index_topk_freq", 1),
+    )
+
+    assert _skipped_layer_ids(flags) == [6, 7, 9]
+
+
+def test_index_cache_config_false_disables_even_with_freq_four():
+    config = SimpleNamespace(use_index_cache=False, index_topk_freq=4)
+
+    flags = compute_dsv4_index_cache_skip_flags(
+        COMPRESS_RATIOS,
+        NUM_HIDDEN_LAYERS,
+        use_index_cache=getattr(config, "use_index_cache", False),
+        index_topk_freq=getattr(config, "index_topk_freq", 1),
+    )
+
+    assert _skipped_layer_ids(flags) == []

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -5,7 +5,7 @@ DeepseekV4 MLA Attention Layer
 """
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import torch
@@ -115,6 +115,93 @@ def resolve_layer_compress_ratio(config, layer_id: int) -> tuple[int, bool]:
     return 1, False
 
 
+def compute_dsv4_index_cache_skip_flags(
+    compress_ratios: Sequence[int],
+    num_hidden_layers: int,
+    *,
+    use_index_cache: bool,
+    index_topk_freq: int = 1,
+    index_topk_pattern: str | Sequence[str] | None = None,
+    index_skip_topk_offset: int = 2,
+    local_start_layer: int = 0,
+    local_end_layer: int | None = None,
+) -> tuple[bool, ...]:
+    """Compute DeepSeek V4 C4-layer IndexCache skip decisions.
+
+    The returned tuple is indexed by global decoder layer id. Only backbone C4
+    layers (``compress_ratio == 4``) may be marked as skipped. Pipeline stages
+    have rank-local top-k buffers, so the first local C4 layer is always forced
+    to compute top-k.
+    """
+    if num_hidden_layers < 0:
+        raise ValueError(
+            f"num_hidden_layers must be non-negative, got {num_hidden_layers}"
+        )
+
+    ratios = list(compress_ratios[:num_hidden_layers])
+    if len(ratios) != num_hidden_layers:
+        raise ValueError(
+            "compress_ratios must contain at least num_hidden_layers entries, "
+            f"got {len(compress_ratios)} for {num_hidden_layers} layers"
+        )
+
+    if local_end_layer is None:
+        local_end_layer = num_hidden_layers
+    if not (0 <= local_start_layer <= local_end_layer <= num_hidden_layers):
+        raise ValueError(
+            "local layer range must satisfy "
+            "0 <= local_start_layer <= local_end_layer <= num_hidden_layers, "
+            f"got [{local_start_layer}, {local_end_layer}) for "
+            f"{num_hidden_layers} layers"
+        )
+
+    skip_flags = [False] * num_hidden_layers
+    c4_layer_ids = [layer_id for layer_id, ratio in enumerate(ratios) if ratio == 4]
+    if not use_index_cache or not c4_layer_ids:
+        return tuple(skip_flags)
+
+    if index_topk_pattern is not None:
+        pattern = list(index_topk_pattern)
+        invalid_values = set(pattern) - {"F", "S"}
+        if invalid_values:
+            raise ValueError(
+                "index_topk_pattern only supports 'F' for full indexer "
+                f"layers and 'S' for shared layers, got "
+                f"{sorted(invalid_values)}"
+            )
+        if len(pattern) != len(c4_layer_ids):
+            raise ValueError(
+                "index_topk_pattern length must match the number of C4 layers "
+                f"({len(c4_layer_ids)}), got {len(pattern)}"
+            )
+        if pattern[0] != "F":
+            raise ValueError("index_topk_pattern must start with 'F'")
+        for c4_rank, layer_id in enumerate(c4_layer_ids):
+            skip_flags[layer_id] = pattern[c4_rank] == "S"
+    else:
+        if index_topk_freq <= 0:
+            raise ValueError(f"index_topk_freq must be positive, got {index_topk_freq}")
+        if index_skip_topk_offset < 1:
+            raise ValueError(
+                "index_skip_topk_offset must be at least 1, got "
+                f"{index_skip_topk_offset}"
+            )
+        for c4_rank, layer_id in enumerate(c4_layer_ids):
+            skip_flags[layer_id] = (
+                max(c4_rank - index_skip_topk_offset + 1, 0) % index_topk_freq != 0
+            )
+
+    local_c4_layer_ids = [
+        layer_id
+        for layer_id in c4_layer_ids
+        if local_start_layer <= layer_id < local_end_layer
+    ]
+    if local_c4_layer_ids:
+        skip_flags[local_c4_layer_ids[0]] = False
+
+    return tuple(skip_flags)
+
+
 class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
     """DeepseekV4 MLA attention layer.
 
@@ -177,6 +264,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         prefix: str,
         topk_indices_buffer: torch.Tensor | None = None,
         aux_stream_list: list[torch.cuda.Stream] | None = None,
+        skip_topk: bool = False,
     ) -> None:
         super().__init__()
         config = vllm_config.model_config.hf_config
@@ -201,6 +289,12 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         self.compress_ratio, use_unscaled_rope = resolve_layer_compress_ratio(
             config, layer_id
         )
+        self.skip_topk = skip_topk
+        if self.skip_topk:
+            if self.compress_ratio != 4:
+                raise ValueError("skip_topk is only valid for C4/indexer layers")
+            if topk_indices_buffer is None:
+                raise ValueError("skip_topk requires topk_indices_buffer")
         self.eps = config.rms_norm_eps
         self.scale = self.head_dim**-0.5
 
@@ -414,7 +508,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
 
             aux_fns[0] = compressor_kv_score
 
-        if self.indexer is not None:
+        if self.indexer is not None and not self.skip_topk:
             indexer = self.indexer
 
             def indexer_weights_proj() -> torch.Tensor:
@@ -456,8 +550,8 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         qr: torch.Tensor,
         kv: torch.Tensor,
         kv_score: torch.Tensor,
-        indexer_kv_score: torch.Tensor,
-        indexer_weights: torch.Tensor,
+        indexer_kv_score: torch.Tensor | None,
+        indexer_weights: torch.Tensor | None,
         positions: torch.Tensor,
         out: torch.Tensor,  # [num_tokens, padded_heads, head_dim], written in place
     ) -> None:
@@ -468,9 +562,11 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         # on the default stream so q stays on its consumer stream (forward_mqa
         # downstream reads q on default). Indexer/compressor go on aux for
         # overlap with default's GEMM + cache write.
-        if self.indexer is not None:
+        if self.indexer is not None and not self.skip_topk:
             aux_streams = self.aux_stream_list
             indexer = self.indexer
+            assert indexer_kv_score is not None
+            assert indexer_weights is not None
             # Local ref so the closure keeps a non-None type for mypy.
             assert self.compressor is not None
             compressor = self.compressor

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -16,6 +16,7 @@ from vllm.distributed import (
     get_tensor_model_parallel_world_size,
 )
 from vllm.distributed.eplb.eplb_state import EplbLayerState
+from vllm.distributed.utils import get_pp_indices
 from vllm.forward_context import get_forward_context, is_forward_context_available
 from vllm.model_executor.kernels.mhc.tilelang import (
     hc_head_fused_kernel_tilelang,
@@ -63,7 +64,10 @@ from vllm.model_executor.models.utils import (
     maybe_prefix,
 )
 from vllm.model_executor.utils import set_weight_attrs
-from vllm.models.deepseek_v4.attention import DeepseekV4Attention
+from vllm.models.deepseek_v4.attention import (
+    DeepseekV4Attention,
+    compute_dsv4_index_cache_skip_flags,
+)
 from vllm.models.deepseek_v4.nvidia.flashinfer_sparse import (
     DeepseekV4FlashInferMLAAttention,
     DeepseekV4FlashInferSM120Attention,
@@ -1192,6 +1196,17 @@ def _select_dsv4_attn_cls(vllm_config: VllmConfig) -> type[DeepseekV4Attention]:
     return DeepseekV4FlashMLAAttention
 
 
+def _validate_dsv4_index_cache_platform(use_index_cache: bool) -> None:
+    if not use_index_cache:
+        return
+    device_capability = current_platform.get_device_capability()
+    if device_capability is None or device_capability.major != 9:
+        raise NotImplementedError(
+            "DeepSeek V4 IndexCache is currently supported only on Hopper "
+            "(SM90). Disable use_index_cache or run on H100/H200."
+        )
+
+
 class DeepseekV4DecoderLayer(nn.Module):
     def __init__(
         self,
@@ -1199,6 +1214,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         prefix,
         topk_indices_buffer: torch.Tensor | None = None,
         aux_stream_list: list[torch.cuda.Stream] | None = None,
+        skip_topk: bool = False,
     ):
         super().__init__()
 
@@ -1211,6 +1227,7 @@ class DeepseekV4DecoderLayer(nn.Module):
             prefix=f"{prefix}.attn",
             topk_indices_buffer=topk_indices_buffer,
             aux_stream_list=aux_stream_list,
+            skip_topk=skip_topk,
         )
         self.ffn = DeepseekV4MoE(vllm_config, prefix=f"{prefix}.ffn")
 
@@ -1376,6 +1393,23 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
             config.index_topk,
             dtype=torch.int32,
         )
+        use_index_cache = getattr(config, "use_index_cache", False)
+        _validate_dsv4_index_cache_platform(use_index_cache)
+        start_layer, end_layer = get_pp_indices(
+            config.num_hidden_layers,
+            get_pp_group().rank_in_group,
+            get_pp_group().world_size,
+        )
+        index_cache_skip_flags = compute_dsv4_index_cache_skip_flags(
+            config.compress_ratios,
+            config.num_hidden_layers,
+            use_index_cache=use_index_cache,
+            index_topk_freq=getattr(config, "index_topk_freq", 1),
+            index_topk_pattern=getattr(config, "index_topk_pattern", None),
+            index_skip_topk_offset=getattr(config, "index_skip_topk_offset", 2),
+            local_start_layer=start_layer,
+            local_end_layer=end_layer,
+        )
 
         if get_pp_group().is_first_rank:
             self.embed_tokens = VocabParallelEmbedding(
@@ -1394,6 +1428,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                 prefix=prefix,
                 topk_indices_buffer=self.topk_indices_buffer,
                 aux_stream_list=aux_stream_list,
+                skip_topk=index_cache_skip_flags[extract_layer_index(prefix)],
             ),
             prefix=f"{prefix}.layers",
         )


### PR DESCRIPTION
## Purpose
Support DeepSeek V4 index cache for Hopper.
```
--hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}'
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

