### PR TITLE
Dsv4 h20 flashinfer stack iaasmain 20260804

### DIFF
--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -36,6 +36,13 @@ def test_nixl_side_channel_host_is_not_compile_factor(
     assert "VLLM_NIXL_SIDE_CHANNEL_HOST" not in envs.compile_factors()
 
 
+def test_mooncake_pd_trace_env() -> None:
+    with patch.dict(os.environ, {}, clear=True):
+        assert environment_variables["VLLM_MOONCAKE_PD_TRACE"]() is False
+    with patch.dict(os.environ, {"VLLM_MOONCAKE_PD_TRACE": "1"}, clear=True):
+        assert environment_variables["VLLM_MOONCAKE_PD_TRACE"]() is True
+
+
 def test_getattr_with_cache(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("VLLM_HOST_IP", "1.1.1.1")
     monkeypatch.setenv("VLLM_PORT", "1234")

--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -1498,6 +1498,96 @@ def test_register_kv_caches_keeps_non_mtp_speculative_layers_outside_base_model(
     assert worker.registered_layer_indices == [0, num_hidden_layers]
 
 
+def test_pd_trace_lifecycle_clears_on_success_and_failure(monkeypatch):
+    """Request-scoped trace timestamps must not survive terminal outcomes."""
+    monkeypatch.setattr(envs, "VLLM_MOONCAKE_PD_TRACE", True)
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker._online_c128_state_transfer_enabled = False
+    worker._invalid_block_ids_lock = threading.Lock()
+    worker._invalid_block_ids = set()
+    worker.finished_recving_reqs = set()
+    worker.dp_rank = worker.pp_rank = worker.tp_rank = 0
+    worker._pd_trace_pull_started = {
+        "d-req-ok": time.perf_counter(),
+        "d-req-failed": time.perf_counter(),
+    }
+
+    ok_meta = PullReqMeta(
+        d_req_id="d-req-ok",
+        transfer_id="xfer-ok",
+        local_block_ids=[[100]],
+        remote_engine_id="p-engine",
+        remote_bootstrap_addr="http://bootstrap",
+        pull_tasks_count=1,
+    )
+    worker.process_pulling_result(
+        MooncakeXferResponse(
+            status=MooncakeXferResponseStatus.FINISH,
+            ok_reqs=[ok_meta.d_req_id],
+        ),
+        {ok_meta.d_req_id: ok_meta},
+    )
+
+    failed_meta = PullReqMeta(
+        d_req_id="d-req-failed",
+        transfer_id="xfer-failed",
+        local_block_ids=[[101]],
+        remote_engine_id="p-engine",
+        remote_bootstrap_addr="http://bootstrap",
+    )
+    worker._mark_pull_failed(failed_meta)
+
+    assert worker._pd_trace_pull_started == {}
+    assert worker.finished_recving_reqs == {"d-req-ok", "d-req-failed"}
+    assert worker.get_block_ids_with_load_errors() == {101}
+
+
+def test_large_request_gate_uses_largest_kv_group_block_count():
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker._large_request_semaphore = object()
+    worker.large_request_threshold_tokens = 32768
+    worker.block_size = 256
+
+    long_meta = SimpleNamespace(
+        req_blocks={"request": ("transfer", [[0] * 256])}
+    )
+    short_meta = SimpleNamespace(
+        req_blocks={"request": ("transfer", [[0] * 14])}
+    )
+
+    assert worker._is_large_request_meta(long_meta)
+    assert not worker._is_large_request_meta(short_meta)
+
+
+@pytest.mark.asyncio
+async def test_node_large_request_slots_are_mutually_exclusive(tmp_path):
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker._node_large_request_slot_paths = (
+        MooncakeConnectorWorker._get_node_large_request_slot_paths(
+            str(tmp_path), "engine-a", 1
+        )
+    )
+    assert worker._node_large_request_slot_paths != (
+        MooncakeConnectorWorker._get_node_large_request_slot_paths(
+            str(tmp_path), "engine-b", 1
+        )
+    )
+
+    first_slot = await worker._acquire_node_large_request_slot()
+    assert first_slot is not None
+
+    waiting_for_slot = asyncio.create_task(
+        worker._acquire_node_large_request_slot()
+    )
+    await asyncio.sleep(0.01)
+    assert not waiting_for_slot.done()
+
+    worker._release_node_large_request_slot(first_slot)
+    second_slot = await asyncio.wait_for(waiting_for_slot, timeout=1)
+    assert second_slot is not None
+    worker._release_node_large_request_slot(second_slot)
+
+
 def test_c128_pull_failure_reports_invalid_blocks_after_all_tasks_quiesce():
     worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
     worker._online_c128_state_transfer_enabled = True

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import asyncio
+import fcntl
+import hashlib
 import logging
+import os
 import threading
 import time
 from collections import defaultdict
@@ -1406,6 +1409,79 @@ class MooncakeConnectorWorker:
         self.num_sender_workers = kv_transfer_config.kv_connector_extra_config.get(
             "num_workers", 10
         )
+        self.max_concurrent_large_requests = int(
+            kv_transfer_config.kv_connector_extra_config.get(
+                "max_concurrent_large_requests", 0
+            )
+        )
+        self.large_request_threshold_tokens = int(
+            kv_transfer_config.kv_connector_extra_config.get(
+                "large_request_threshold_tokens", 0
+            )
+        )
+        self.node_large_request_slots = int(
+            kv_transfer_config.kv_connector_extra_config.get(
+                "node_large_request_slots", 0
+            )
+        )
+        extra_config = kv_transfer_config.kv_connector_extra_config
+        self.node_large_request_slot_dir = extra_config.get(
+            "node_large_request_slot_dir", "/dev/shm"
+        )
+        self.node_large_request_slot_namespace = (
+            extra_config.get(
+                "node_large_request_slot_namespace", engine_id
+            )
+        )
+        if self.max_concurrent_large_requests < 0:
+            raise ValueError(
+                "max_concurrent_large_requests must be non-negative, got "
+                f"{self.max_concurrent_large_requests}"
+            )
+        if self.large_request_threshold_tokens < 0:
+            raise ValueError(
+                "large_request_threshold_tokens must be non-negative"
+            )
+        if self.node_large_request_slots < 0:
+            raise ValueError(
+                "node_large_request_slots must be non-negative, got "
+                f"{self.node_large_request_slots}"
+            )
+        if not isinstance(self.node_large_request_slot_namespace, str) or not (
+            self.node_large_request_slot_namespace
+        ):
+            raise ValueError(
+                "node_large_request_slot_namespace must be a non-empty string"
+            )
+        self._large_request_semaphore: asyncio.Semaphore | None = (
+            asyncio.Semaphore(self.max_concurrent_large_requests)
+            if self.max_concurrent_large_requests > 0
+            and self.large_request_threshold_tokens > 0
+            else None
+        )
+        if self._large_request_semaphore is not None:
+            logger.info(
+                "Mooncake limiting requests >= %d tokens to %d concurrent send(s)",
+                self.large_request_threshold_tokens,
+                self.max_concurrent_large_requests,
+            )
+        if self.node_large_request_slots and self._large_request_semaphore is None:
+            raise ValueError(
+                "node_large_request_slots requires positive "
+                "max_concurrent_large_requests and "
+                "large_request_threshold_tokens"
+            )
+        self._node_large_request_slot_paths = self._get_node_large_request_slot_paths(
+            self.node_large_request_slot_dir,
+            self.node_large_request_slot_namespace,
+            self.node_large_request_slots,
+        )
+        if self._node_large_request_slot_paths:
+            logger.info(
+                "Mooncake limiting long requests to %d shared node slot(s) under %s",
+                self.node_large_request_slots,
+                self.node_large_request_slot_dir,
+            )
         # Create more tasks than workers to keep the thread pool saturated.
         # Tasks can await async events, so a surplus (2x is a robust heuristic)
         # prevents workers from idling.
@@ -1538,6 +1614,8 @@ class MooncakeConnectorWorker:
         self.finished_recving_reqs: set[ReqId] = set()
         self._invalid_block_ids_lock = threading.Lock()
         self._invalid_block_ids: set[int] = set()
+        # D-side request start times for opt-in P/D transfer tracing.
+        self._pd_trace_pull_started: dict[ReqId, float] = {}
 
         self.xfer_stats = MooncakeKVConnectorStats()
 
@@ -1705,7 +1783,18 @@ class MooncakeConnectorWorker:
                 identity, metadata_bytes = await self.sender_worker_queue.get()
                 try:
                     metadata = self._xfer_meta_decoder.decode(metadata_bytes)
-                    await self.send_kv_to_decode(identity, sock, metadata)
+                    if self._is_large_request_meta(metadata):
+                        assert self._large_request_semaphore is not None
+                        async with self._large_request_semaphore:
+                            slot_fd = await self._acquire_node_large_request_slot()
+                            try:
+                                await self.send_kv_to_decode(
+                                    identity, sock, metadata
+                                )
+                            finally:
+                                self._release_node_large_request_slot(slot_fd)
+                    else:
+                        await self.send_kv_to_decode(identity, sock, metadata)
                 except Exception as e:
                     logger.error("Error processing Mooncake xfer request: %s", e)
                     error_response = MooncakeXferResponse(
@@ -1721,9 +1810,65 @@ class MooncakeConnectorWorker:
             except Exception as e:
                 logger.error("Error in _sender_worker: %s", e)
 
+    def _is_large_request_meta(self, meta: MooncakeXferMetadata) -> bool:
+        """Return whether a pull covers a long-context request.
+
+        The per-group block count, rather than their sum, reflects prompt
+        length: KV cache groups represent parallel cache layouts.
+        """
+        if self._large_request_semaphore is None:
+            return False
+        max_blocks = max(
+            (
+                len(block_ids)
+                for _, request_groups in meta.req_blocks.values()
+                for block_ids in request_groups
+            ),
+            default=0,
+        )
+        return max_blocks * self.block_size >= self.large_request_threshold_tokens
+
+    @staticmethod
+    def _get_node_large_request_slot_paths(
+        slot_dir: str, namespace: str, num_slots: int
+    ) -> list[str]:
+        namespace_hash = hashlib.sha256(namespace.encode()).hexdigest()[:16]
+        return [
+            os.path.join(
+                slot_dir,
+                f"vllm-mooncake-large-request-{namespace_hash}-slot-{slot}",
+            )
+            for slot in range(num_slots)
+        ]
+
+    async def _acquire_node_large_request_slot(self) -> int | None:
+        """Acquire one advisory node-wide slot without blocking the event loop."""
+        if not self._node_large_request_slot_paths:
+            return None
+        while True:
+            for slot_path in self._node_large_request_slot_paths:
+                fd = os.open(slot_path, os.O_CREAT | os.O_RDWR, 0o600)
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    return fd
+                except BlockingIOError:
+                    os.close(fd)
+            await asyncio.sleep(0.001)
+
+    @staticmethod
+    def _release_node_large_request_slot(slot_fd: int | None) -> None:
+        if slot_fd is None:
+            return
+        try:
+            fcntl.flock(slot_fd, fcntl.LOCK_UN)
+        finally:
+            os.close(slot_fd)
+
     async def send_kv_to_decode(
         self, identity: bytes, sock: zmq.asyncio.Socket, meta: MooncakeXferMetadata
     ):
+        trace_enabled = envs.VLLM_MOONCAKE_PD_TRACE
+        query_started = time.perf_counter() if trace_enabled else 0.0
         pending_reqs: dict[ReqId, SendBlockMeta] = {}
         remote_tp_ranks = self.transfer_topo.handshake_target_ranks(meta.remote_tp_size)
         if meta.remote_tp_rank not in remote_tp_ranks:
@@ -1870,6 +2015,7 @@ class MooncakeConnectorWorker:
             err_msg: str | None = None
             ok_ready_reqs: list[tuple[ReqId, SendBlockMeta]] = []
             try:
+                build_started = time.perf_counter() if trace_enabled else 0.0
                 (
                     src_ptrs,
                     dst_ptrs,
@@ -1883,6 +2029,9 @@ class MooncakeConnectorWorker:
                     local_regions,
                     remote_regions,
                 )
+                build_duration = (
+                    time.perf_counter() - build_started if trace_enabled else 0.0
+                )
                 err_req_set = set(err_reqs)
                 ok_ready_reqs = [
                     (d_req_id, send_meta)
@@ -1892,6 +2041,7 @@ class MooncakeConnectorWorker:
 
                 if src_ptrs:
                     remote_session = f"{meta.remote_hostname}:{meta.remote_port}"
+                    send_started = time.perf_counter() if trace_enabled else 0.0
                     ret_value = await self.sender_loop.run_in_executor(
                         self._sender_executor,
                         self._send_blocks,
@@ -1901,6 +2051,21 @@ class MooncakeConnectorWorker:
                         lengths,
                         state_transfer_events,
                     )
+                    if trace_enabled:
+                        logger.info(
+                            "MOONCAKE_PD_TRACE P_BATCH reqs=%s pp=%d tp=%d "
+                            "remote_tp=%d ready_wait_ms=%.3f build_ms=%.3f "
+                            "send_ms=%.3f descriptors=%d bytes=%d",
+                            [req_id for req_id, _ in ready_reqs],
+                            self.pp_rank,
+                            self.tp_rank,
+                            meta.remote_tp_rank,
+                            (build_started - query_started) * 1e3,
+                            build_duration * 1e3,
+                            (time.perf_counter() - send_started) * 1e3,
+                            len(src_ptrs),
+                            sum(lengths),
+                        )
 
                     if ret_value != 0:
                         transfer_err_msg = (
@@ -3084,6 +3249,7 @@ class MooncakeConnectorWorker:
 
     def _mark_pull_failed(self, pull_meta: "PullReqMeta") -> None:
         """Report a failed async pull to the scheduler after RDMA quiesce."""
+        getattr(self, "_pd_trace_pull_started", {}).pop(pull_meta.d_req_id, None)
         invalid_blocks = {
             block_id for group in pull_meta.local_block_ids for block_id in group
         }
@@ -3110,6 +3276,8 @@ class MooncakeConnectorWorker:
         worker_addr: str,
         pull_metas: dict[ReqId, PullReqMeta],
     ):
+        trace_enabled = envs.VLLM_MOONCAKE_PD_TRACE
+        worker_started = time.perf_counter() if trace_enabled else 0.0
         req_ids = list(pull_metas.keys())
         outstanding_req_ids: set[ReqId] = set(req_ids)
         metadata = MooncakeXferMetadata(
@@ -3196,6 +3364,17 @@ class MooncakeConnectorWorker:
                     outstanding_req_ids.difference_update(accounted_req_ids)
                     if response.status == MooncakeXferResponseStatus.FINISH:
                         break
+            if trace_enabled:
+                logger.info(
+                    "MOONCAKE_PD_TRACE D_WORKER reqs=%s dp=%d pp=%d tp=%d "
+                    "worker=%s duration_ms=%.3f",
+                    req_ids,
+                    self.dp_rank,
+                    self.pp_rank,
+                    self.tp_rank,
+                    worker_addr,
+                    (time.perf_counter() - worker_started) * 1e3,
+                )
         except zmq.ContextTerminated:
             logger.debug("ZMQ context terminated, exiting Mooncake receiver thread.")
         except Exception as e:
@@ -3224,7 +3403,21 @@ class MooncakeConnectorWorker:
                 if pull_meta.pull_failed:
                     self._mark_pull_failed(pull_meta)
                 else:
+                    ready_started = time.perf_counter()
                     self.finished_recving_reqs.add(pull_meta.d_req_id)
+                    if envs.VLLM_MOONCAKE_PD_TRACE:
+                        pull_started = getattr(
+                            self, "_pd_trace_pull_started", {}
+                        ).pop(pull_meta.d_req_id, ready_started)
+                        logger.info(
+                            "MOONCAKE_PD_TRACE D_READY req=%s dp=%d pp=%d tp=%d "
+                            "wait_ms=%.3f",
+                            pull_meta.d_req_id,
+                            self.dp_rank,
+                            self.pp_rank,
+                            self.tp_rank,
+                            (ready_started - pull_started) * 1e3,
+                        )
         # Success keeps the slot for admission unless another worker fails.
         if ok_reqs:
             self._c128_account_pull_tasks(pull_metas, failed=False, req_ids=ok_reqs)
@@ -3349,6 +3542,20 @@ class MooncakeConnectorWorker:
                 and pull_meta.c128_import_slot is not None
             ):
                 self._c128_active_pulls[pull_meta.d_req_id] = pull_meta
+        if envs.VLLM_MOONCAKE_PD_TRACE:
+            trace_started = time.perf_counter()
+            for pull_meta in pull_metas.values():
+                self._pd_trace_pull_started[pull_meta.d_req_id] = trace_started
+            logger.info(
+                "MOONCAKE_PD_TRACE D_START reqs=%s engine=%s workers=%d "
+                "dp=%d pp=%d tp=%d",
+                list(pull_metas),
+                remote_engine_id,
+                count,
+                self.dp_rank,
+                self.pp_rank,
+                self.tp_rank,
+            )
         for worker_addr in worker_addrs:
             asyncio.create_task(
                 self.receive_kv_from_single_worker(worker_addr, pull_metas)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -209,6 +209,7 @@ if TYPE_CHECKING:
     VLLM_MOONCAKE_DISK_STAGING_USABLE_RATIO: float = 0.9
     VLLM_MOONCAKE_ENABLE_CHUNKED_TRANSFER: bool = False
     VLLM_MOONCAKE_TRANSFER_CHUNK_SIZE_MB: int = 512
+    VLLM_MOONCAKE_PD_TRACE: bool = False
     MOONCAKE_PREFERRED_SEGMENT: str | None = None
     MOONCAKE_REQUESTER_LOCAL_HOSTNAME: str | None = None
     VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE: int = 163840
@@ -1593,6 +1594,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Per-call payload limit used when VLLM_MOONCAKE_ENABLE_CHUNKED_TRANSFER=1.
     "VLLM_MOONCAKE_TRANSFER_CHUNK_SIZE_MB": lambda: int(
         os.getenv("VLLM_MOONCAKE_TRANSFER_CHUNK_SIZE_MB", "512")
+    ),
+    # Emit request-scoped Mooncake P/D timing and byte diagnostics. Disabled
+    # by default because INFO logs can perturb latency measurements.
+    "VLLM_MOONCAKE_PD_TRACE": lambda: (
+        os.getenv("VLLM_MOONCAKE_PD_TRACE", "False").lower() in ("true", "1")
     ),
     # Pin this rank to a specific owner segment ("host:port").
     "MOONCAKE_PREFERRED_SEGMENT": lambda: os.getenv("MOONCAKE_PREFERRED_SEGMENT"),

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -93,7 +93,27 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
         # - pass per-block weight scales to the kernel
         # - skip input activation quantization (kernel applies scaling)
         self.use_deepseek_fp8_block_scale = quant_config.is_block_quantized
+        self.max_capture_size = moe_config.max_capture_size
+        # vLLM PR #48303: gpt-oss supplies its clamped-SwiGLU parameters
+        # (alpha=1.702, beta=1.0, clamp=7.0) via its quant config
+        # (GptOssMxfp4MoEMethod); None means standard SwiGLU (DeepSeek-V4 /
+        # GLM / MiMo). Honor the quant-config values instead of hardcoding
+        # gpt-oss's, otherwise DeepSeek-V4 gets silently-clamped activations.
+        self.gemm1_alpha: torch.Tensor | None = None
+        self.gemm1_beta: torch.Tensor | None = None
         self.gemm1_clamp_limit: torch.Tensor | None = None
+        if quant_config.gemm1_alpha is not None:
+            self.gemm1_alpha = torch.tensor(
+                [quant_config.gemm1_alpha] * self.num_experts,
+                dtype=torch.float32,
+                device=self.device,
+            )
+        if quant_config.gemm1_beta is not None:
+            self.gemm1_beta = torch.tensor(
+                [quant_config.gemm1_beta] * self.num_experts,
+                dtype=torch.float32,
+                device=self.device,
+            )
         if quant_config.gemm1_clamp_limit is not None:
             self.gemm1_clamp_limit = torch.tensor(
                 [quant_config.gemm1_clamp_limit] * self.num_experts,
@@ -101,27 +121,15 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
                 device=self.device,
             )
 
-        if quant_config.weight_quant_dtype == "mxfp4":
-            # This value is used specifically for gpt-oss,
-            # Need to revisit this for other models
-            self.gemm1_alpha = torch.tensor(
-                [1.702] * self.num_experts, dtype=torch.float32, device=self.device
+        if (
+            quant_config.weight_quant_dtype == "mxfp4"
+            and quant_config.quant_dtype == "mxfp8"
+        ):
+            self.fake_input_scale = torch.ones(
+                self.num_experts,
+                device=self.device,
+                dtype=torch.float32,
             )
-            self.gemm1_beta = torch.tensor(
-                [1.0] * self.num_experts, dtype=torch.float32, device=self.device
-            )
-            if self.gemm1_clamp_limit is None:
-                self.gemm1_clamp_limit = torch.tensor(
-                    [7.0] * self.num_experts,
-                    dtype=torch.float32,
-                    device=self.device,
-                )
-            if quant_config.quant_dtype == "mxfp8":
-                self.fake_input_scale = torch.ones(
-                    self.num_experts,
-                    device=self.device,
-                    dtype=torch.float32,
-                )
 
     @property
     def expects_unquantized_inputs(self) -> bool:
@@ -322,11 +330,10 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
             fc1_expert_weights = w1.view(torch.long)
             fc2_expert_weights = w2.view(torch.long)
         elif self.weight_quant_dtype == "mxfp4":
+            # vLLM PR #48303: SwiGLU params may be None (standard SwiGLU) for
+            # DeepSeek-V4 / GLM / MiMo; do not assert them present.
             assert self.w1_scale is not None and self.w2_scale is not None
             assert w1.is_contiguous() and w2.is_contiguous()
-            assert self.gemm1_alpha is not None
-            assert self.gemm1_beta is not None
-            assert self.gemm1_clamp_limit is not None
             assert topk_ids.is_contiguous()
 
             fc1_expert_biases = self.w1_bias

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -1555,6 +1555,89 @@ def convert_weight_to_mxfp4_moe_kernel_format(
             w13_bias,
             w2_bias,
         )
+    elif mxfp4_backend in (
+        Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
+        Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
+    ):
+        # vLLM PR #48303: complete FlashInfer CUTLASS MXFP4 MoE wiring for
+        # DeepSeek/GLM/MiMo-family models. Native GLM/DeepSeek/MiMo MXFP4
+        # loading produces contiguous [w1/gate, w3/up] rows. FlashInfer Cutlass
+        # consumes the opposite SwiGLU order, so swap the two halves without
+        # GPT-OSS de-interleave, then interleave into the kernel layout:
+        # block_scale_interleave for the MXFP8-activation backend, or the sm90
+        # mixed-gemm interleaves for the BF16-activation backend (H20/SM90).
+        intermediate_size = w13_weight.shape[1] // 2
+        w13_w = w13_weight.data
+        w1_w = w13_w[:, :intermediate_size, :]
+        w3_w = w13_w[:, intermediate_size:, :]
+        w13_weight_swapped = torch.cat([w3_w, w1_w], dim=1)
+
+        if w13_bias is not None:
+            w13_bias = w13_bias.data.to(torch.float32)
+            b1 = w13_bias[:, :intermediate_size]
+            b3 = w13_bias[:, intermediate_size:]
+            w13_bias_swapped = torch.cat([b3, b1], dim=-1).to(torch.bfloat16)
+        else:
+            w13_bias_swapped = None
+        if w2_bias is not None:
+            w2_bias = w2_bias.data.to(torch.float32).to(torch.bfloat16)
+        else:
+            w2_bias = None
+
+        w13_s = w13_weight_scale.data
+        s1 = w13_s[:, :intermediate_size, :]
+        s3 = w13_s[:, intermediate_size:, :]
+        w13_scale_swapped = torch.cat([s3, s1], dim=1)
+
+        if mxfp4_backend == Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8:
+            from flashinfer import block_scale_interleave
+
+            orig_shape = w13_scale_swapped.shape
+            w13_scale_interleaved = block_scale_interleave(
+                w13_scale_swapped.view(torch.uint8)
+            ).reshape(orig_shape)
+
+            w2_s = w2_weight_scale.data
+            orig_shape = w2_s.shape
+            w2_scale_interleaved = block_scale_interleave(
+                w2_s.view(torch.uint8)
+            ).reshape(orig_shape)
+
+            return (
+                w13_weight_swapped,
+                w2_weight.data,
+                w13_scale_interleaved,
+                w2_scale_interleaved,
+                w13_bias_swapped,
+                w2_bias,
+            )
+
+        from flashinfer.fused_moe import (
+            interleave_moe_scales_for_sm90_mixed_gemm,
+            interleave_moe_weights_for_sm90_mixed_gemm,
+        )
+
+        w13_weight_interleaved = interleave_moe_weights_for_sm90_mixed_gemm(
+            w13_weight_swapped.contiguous(), "fp4"
+        )
+        w2_weight_interleaved = interleave_moe_weights_for_sm90_mixed_gemm(
+            w2_weight.data.contiguous(), "fp4"
+        )
+        w31_scales_interleaved = interleave_moe_scales_for_sm90_mixed_gemm(
+            w13_scale_swapped.to(torch.uint8)
+        )
+        w2_scale_interleaved = interleave_moe_scales_for_sm90_mixed_gemm(
+            w2_weight_scale.data.to(torch.uint8)
+        )
+
+        return (
+            w13_weight_interleaved,
+            w2_weight_interleaved,
+            w31_scales_interleaved,
+            w2_scale_interleaved,
+            w13_bias_swapped,
+            w2_bias,
+        )
     else:
         raise ValueError(
             f"Unsupported mxfp4_backend for Mxfp4MoEMethod: {mxfp4_backend}. "

--- a/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
@@ -87,6 +87,12 @@ def _swizzle_mxfp4(quant_tensor, scale, num_warps=8):
                 "split_k": 1,
             }
             opt_flags.update_opt_flags_constraints(constraints)
+            # Patches #47303: pad K (num scale groups) to 0 mod 4
+            # TODO: Remove once we upgrade to Triton 3.8.0+ kernels
+            if scale.numel() > 0:
+                K = scale.shape[-1]
+                pad_k = -K % 4
+                scale = torch.nn.functional.pad(scale, (0, pad_k))
         elif current_platform.is_device_capability_family(100):
             constraints = {
                 "is_persistent": True,

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -82,6 +82,7 @@ from vllm.v1.kv_cache_interface import (
 from vllm.v1.utils import CpuGpuBuffer
 
 FLASHINFER_WORKSPACE_BUFFER_SIZE_BATCH_INVARIANT = 2048 * 1024 * 1024
+FLASHINFER_PREFILL_WORKSPACE_BYTES_PER_ELEM = 16
 
 FP8_DTYPE = current_platform.fp8_dtype()
 FP4_DTYPE = torch.uint8
@@ -630,6 +631,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             self.disable_split_kv = False
 
         self.compilation_config = vllm_config.compilation_config
+        self.max_num_batched_tokens = (
+            vllm_config.scheduler_config.max_num_batched_tokens
+        )
         max_num_pages_per_req = cdiv(
             self.model_config.max_model_len, self.kv_cache_spec.block_size
         )
@@ -896,6 +900,21 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             buffer_size = envs.VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE
             if envs.VLLM_BATCH_INVARIANT:
                 buffer_size = FLASHINFER_WORKSPACE_BUFFER_SIZE_BATCH_INVARIANT
+            else:
+                # FlashInfer prefill temp buffers (batch_prefill_tmp_v, ...)
+                # scale with the prefill chunk and query-head footprint, NOT
+                # context length. The fixed ~394 MiB default is too small for
+                # wide-head models at the default 8192-token chunk on some
+                # archs (e.g. sm_120), where FlashInfer hard-errors instead of
+                # growing. Size to the batch's head footprint; never shrink
+                # below the configured default.
+                est = (
+                    self.max_num_batched_tokens
+                    * self.num_qo_heads
+                    * self.head_dim
+                    * FLASHINFER_PREFILL_WORKSPACE_BYTES_PER_ELEM
+                )
+                buffer_size = max(buffer_size, est)
             self._workspace_buffer = torch.zeros(
                 buffer_size, dtype=torch.uint8, device=self.device
             )


### PR DESCRIPTION
## Summary
This PR adds the DeepSeek-V4-Pro H20 tuning stack on top of `iaas_main`.

  Main changes:
  - Backport FlashInfer CUTLASS MXFP4 MoE wiring for DeepSeek-family models.
  - Include the Hopper MXFP4 OOB scale-read fix to avoid NaN / invalid scale access.
  - Size FlashInfer prefill workspace by batch head footprint.
  - Add a Mooncake long-context send gate per prefill node to avoid overloading large KV transfers.

  ## Motivation
DeepSeek-V4-Pro on H20 needs `flashinfer_cutlass` prefill MoE for better TTFT / input throughput, while long-context PD
  serving needs bounded Mooncake KV send concurrency to keep 64K requests stable.

  This branch is used by the ServingKit DeepSeek-V4-Pro PD chart.

  ## Deployment Shape Validated

  - Prefill: 2 nodes, TP4 / PP4, `flashinfer_cutlass`, `kv_producer`
  - Decode: 2 nodes, DP2 / TP8, MTP-1 speculative decoding, `kv_consumer`
  - Router: native `vllm-router` with Mooncake PD
  - Model: `/data01/DeepSeek-V4-Pro`
  - Served model name: `deepseek-v4-pro`

  ## Validation

  Image built from this branch:

  ```text
  iaas-gpu-cn-beijing.cr.volces.com/serving/vllm:v0.25.0.iaas.dev.202608111144-openai-devel-cu130

  Smoke tests:

  - /health and /v1/models passed.
  - Chat Chinese / code / Unicode / tool-call tests passed.
  - No mojibake or invalid UTF-8 replacement characters observed.

  Performance validation:

  - 3500/1500, QPS 0.1, 2 warmups + 8 requests:
      - TTFT mean/p99: 1680.83 / 1878.06 ms
      - TPOT p99: 14.06 ms
      - 8/8 requests succeeded

  - 65536/1500, C=1, 2 warmups + 5 requests, after decode prefix cache warmup:
      - TTFT mean/p99: 8049.57 / 8190.76 ms
      - TPOT p99: 11.88 ms
      - 5/5 requests succeeded

  Accuracy smoke:

  - Standard MMLU fixed200 completions protocol:
      - Accuracy: 85.5%
      - 200/200 requests succeeded
      - 0 unparsed
      - 0 mojibake

  Notes

  The first 64K validation round immediately after a full restart can be slower while decode prefix cache is cold and more
  prompt tokens are served by external KV transfer instead of local cache hits. Re-running after cache warmup returns the
  long-context result to the expected range.