### PR TITLE
feat(dsv4): enable PCP with Mooncake PD on iaas_main

### DIFF
--- a/tests/models/deepseek_v4/test_pcp_reindex.py
+++ b/tests/models/deepseek_v4/test_pcp_reindex.py
@@ -1,0 +1,488 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+_PCP_METADATA_PATH = (
+    Path(__file__).parents[3] / "vllm" / "models" / "deepseek_v4" / "pcp_metadata.py"
+)
+_PCP_METADATA_SPEC = importlib.util.spec_from_file_location(
+    "_test_deepseek_v4_pcp_metadata", _PCP_METADATA_PATH
+)
+assert _PCP_METADATA_SPEC is not None
+_PCP_METADATA = importlib.util.module_from_spec(_PCP_METADATA_SPEC)
+assert _PCP_METADATA_SPEC.loader is not None
+_PCP_METADATA_SPEC.loader.exec_module(_PCP_METADATA)
+
+build_pcp_sparse_prefill_rows = _PCP_METADATA.build_pcp_sparse_prefill_rows
+build_pcp_swa_prefill_segments = _PCP_METADATA.build_pcp_swa_prefill_segments
+build_pcp_compressed_slot_mapping = _PCP_METADATA.build_pcp_compressed_slot_mapping
+build_pcp_full_slot_mapping = _PCP_METADATA.build_pcp_full_slot_mapping
+build_pcp_query_plan = _PCP_METADATA.build_pcp_query_plan
+build_pcp_restored_req_indices = _PCP_METADATA.build_pcp_restored_req_indices
+build_pcp_restored_valid_mask = _PCP_METADATA.build_pcp_restored_valid_mask
+compact_pcp_sparse_prefill_queries = _PCP_METADATA.compact_pcp_sparse_prefill_queries
+compact_pcp_sparse_indices = _PCP_METADATA.compact_pcp_sparse_indices
+overlay_pcp_restored_swa_kv_workspace = (
+    _PCP_METADATA.overlay_pcp_restored_swa_kv_workspace
+)
+
+
+def test_compact_pcp_sparse_indices_removes_sentinels_from_valid_prefix():
+    indices = torch.tensor(
+        [[0, -1, 2, -1], [-1, 4, 5, -1], [7, 8, -1, -1]],
+        dtype=torch.int32,
+    )
+    lengths = torch.tensor([3, 3, 2], dtype=torch.int32)
+
+    compacted, new_lengths = compact_pcp_sparse_indices(indices, lengths)
+
+    torch.testing.assert_close(
+        compacted,
+        torch.tensor(
+            [[0, 2, -1, -1], [4, 5, -1, -1], [7, 8, -1, -1]],
+            dtype=torch.int32,
+        ),
+    )
+    torch.testing.assert_close(
+        new_lengths,
+        torch.tensor([2, 2, 2], dtype=torch.int32),
+    )
+
+
+def test_build_pcp_full_slot_mapping_uses_restored_positions():
+    block_table = torch.tensor(
+        [
+            [4, 7, -1],
+            [9, 10, 11],
+        ],
+        dtype=torch.int32,
+    )
+
+    slot_mapping = build_pcp_full_slot_mapping(
+        positions=torch.tensor([0, 31, 32, 63, 64, 0], dtype=torch.int64),
+        req_indices=torch.tensor([0, 0, 0, 1, 1, 2], dtype=torch.int64),
+        block_table=block_table,
+        block_size=32,
+    )
+
+    torch.testing.assert_close(
+        slot_mapping,
+        torch.tensor([128, 159, 224, 351, 352, -1], dtype=torch.int64),
+    )
+
+
+def test_build_pcp_full_slot_mapping_masks_restored_padding_rows():
+    block_table = torch.tensor([[4]], dtype=torch.int32)
+
+    slot_mapping = build_pcp_full_slot_mapping(
+        positions=torch.tensor([0, 1, 2, 3], dtype=torch.int64),
+        req_indices=torch.tensor([0, 0, 0, 0], dtype=torch.int64),
+        block_table=block_table,
+        block_size=8,
+        valid_mask=torch.tensor([True, True, True, False]),
+    )
+
+    torch.testing.assert_close(
+        slot_mapping,
+        torch.tensor([32, 33, 34, -1], dtype=torch.int64),
+    )
+
+
+def test_build_pcp_full_slot_mapping_uses_storage_block_size_for_swa_cache():
+    # DeepSeek V4 SWA cache storage blocks can be smaller than the logical
+    # metadata block size. Restored PCP KV writes must use the storage block
+    # size so the slots match the sparse prefill read path.
+    block_table = torch.tensor([[1]], dtype=torch.int32)
+
+    slot_mapping = build_pcp_full_slot_mapping(
+        positions=torch.tensor([0, 1, 2], dtype=torch.int64),
+        req_indices=torch.tensor([0, 0, 0], dtype=torch.int64),
+        block_table=block_table,
+        block_size=64,
+    )
+
+    torch.testing.assert_close(
+        slot_mapping,
+        torch.tensor([64, 65, 66], dtype=torch.int64),
+    )
+
+
+def test_build_pcp_compressed_slot_mapping_uses_compressed_boundaries():
+    block_table = torch.tensor([[3, 4]], dtype=torch.int32)
+
+    slot_mapping = build_pcp_compressed_slot_mapping(
+        positions=torch.tensor([0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.int64),
+        req_indices=torch.zeros(8, dtype=torch.int64),
+        block_table=block_table,
+        block_size=4,
+        compress_ratio=4,
+        valid_mask=torch.tensor(
+            [True, True, True, True, True, True, True, False],
+        ),
+    )
+
+    torch.testing.assert_close(
+        slot_mapping,
+        torch.tensor([-1, -1, -1, 12, -1, -1, -1, -1], dtype=torch.int64),
+    )
+
+
+@pytest.mark.parametrize(
+    ("cp_rank", "physical_blocks", "expected"),
+    [
+        (
+            0,
+            [10, 11, 12, 13],
+            [20, 21, 22, 23, -1, -1, -1, -1, 24, 25, 26, 27, -1, -1, -1, -1],
+        ),
+        (
+            1,
+            [20, 21, 22, 23],
+            [-1, -1, -1, -1, 40, 41, 42, 43, -1, -1, -1, -1, 44, 45, 46, 47],
+        ),
+    ],
+)
+def test_build_pcp_full_slot_mapping_obeys_interleaved_owner(
+    cp_rank, physical_blocks, expected
+):
+    slot_mapping = build_pcp_full_slot_mapping(
+        positions=torch.arange(16, dtype=torch.int64),
+        req_indices=torch.zeros(16, dtype=torch.int64),
+        block_table=torch.tensor([physical_blocks], dtype=torch.int32),
+        block_size=2,
+        cp_world_size=2,
+        cp_rank=cp_rank,
+        cp_kv_cache_interleave_size=4,
+    )
+
+    torch.testing.assert_close(slot_mapping, torch.tensor(expected, dtype=torch.int64))
+
+
+def test_build_pcp_full_slot_mapping_supports_swa_pages_smaller_than_interleave():
+    # Production V4 uses a 256-token CP interleave while SWA stores 64-token
+    # pages. Rank 0 owns [0, 256) and [512, 768), compacted into local space.
+    slot_mapping = build_pcp_full_slot_mapping(
+        positions=torch.tensor([0, 63, 64, 255, 256, 319, 511, 512]),
+        req_indices=torch.zeros(8, dtype=torch.int64),
+        block_table=torch.tensor([[1, 2, 3, 4, 5]], dtype=torch.int32),
+        block_size=64,
+        cp_world_size=2,
+        cp_rank=0,
+        cp_kv_cache_interleave_size=256,
+    )
+
+    torch.testing.assert_close(
+        slot_mapping,
+        torch.tensor([64, 127, 128, 319, -1, -1, -1, 320]),
+    )
+
+
+@pytest.mark.parametrize(
+    ("cp_rank", "physical_blocks", "expected"),
+    [
+        (0, [3, 4], [192, 255, -1, -1, 256]),
+        (1, [7, 8], [-1, -1, 448, 511, -1]),
+    ],
+)
+def test_build_pcp_compressed_slot_mapping_uses_original_token_owner(
+    cp_rank, physical_blocks, expected
+):
+    slot_mapping = build_pcp_compressed_slot_mapping(
+        positions=torch.tensor([3, 255, 259, 511, 515]),
+        req_indices=torch.zeros(5, dtype=torch.int64),
+        block_table=torch.tensor([physical_blocks], dtype=torch.int32),
+        block_size=64,
+        compress_ratio=4,
+        cp_world_size=2,
+        cp_rank=cp_rank,
+        cp_kv_cache_interleave_size=256,
+    )
+
+    torch.testing.assert_close(slot_mapping, torch.tensor(expected))
+
+
+def test_build_pcp_compressed_slot_mapping_rejects_split_compression_group():
+    with pytest.raises(ValueError, match="divisible by compress_ratio"):
+        build_pcp_compressed_slot_mapping(
+            positions=torch.tensor([3]),
+            req_indices=torch.tensor([0]),
+            block_table=torch.tensor([[1]], dtype=torch.int32),
+            block_size=64,
+            compress_ratio=4,
+            cp_world_size=2,
+            cp_rank=0,
+            cp_kv_cache_interleave_size=2,
+        )
+
+
+def test_build_pcp_restored_req_indices_uses_view_restore_lengths():
+    req_indices = build_pcp_restored_req_indices(
+        positions=torch.arange(7, dtype=torch.int64),
+        views=[
+            SimpleNamespace(req_idx=0, restore_idx=torch.arange(4)),
+            SimpleNamespace(req_idx=1, restore_idx=torch.arange(2)),
+        ],
+    )
+
+    torch.testing.assert_close(
+        req_indices,
+        torch.tensor([0, 0, 0, 0, 1, 1, -1], dtype=torch.int64),
+    )
+
+
+def test_build_pcp_restored_valid_mask_drops_per_rank_padding_rows():
+    valid_mask = build_pcp_restored_valid_mask(
+        positions=torch.tensor([0, 1, 2, 3, 0, 1], dtype=torch.int64),
+        views=[
+            SimpleNamespace(global_seq_len=3, restore_idx=torch.arange(4)),
+            SimpleNamespace(global_seq_len=2, restore_idx=torch.arange(2)),
+        ],
+    )
+
+    torch.testing.assert_close(
+        valid_mask,
+        torch.tensor([True, True, True, False, True, True]),
+    )
+
+
+def test_build_pcp_restored_valid_mask_accepts_absolute_chunk_positions():
+    valid_mask = build_pcp_restored_valid_mask(
+        positions=torch.tensor([4096, 4097, 4098, 4099]),
+        views=[SimpleNamespace(global_seq_len=3, restore_idx=torch.arange(4))],
+    )
+
+    torch.testing.assert_close(
+        valid_mask,
+        torch.tensor([True, True, True, False]),
+    )
+
+
+@pytest.mark.parametrize(
+    ("pcp_rank", "expected_local_indices", "expected_local_valid"),
+    [
+        (0, [0, 2, 4], [True, True, True, False]),
+        (1, [1, 3], [True, True, False, False]),
+    ],
+)
+def test_build_pcp_query_plan_compacts_padding_and_selects_local_rows(
+    pcp_rank, expected_local_indices, expected_local_valid
+):
+    # Gathered rank order is [r0: 0,2,4,pad, r1: 1,3,pad,pad].  restore_idx
+    # puts the rows into request-local order with padding at the end.
+    restore_idx = torch.tensor([0, 4, 1, 5, 2, 3, 6, 7], dtype=torch.int64)
+    plan = build_pcp_query_plan(
+        pcp_allgather_restore_idx=restore_idx,
+        views=[SimpleNamespace(global_seq_len=5, restore_idx=torch.arange(8))],
+        pcp_world_size=2,
+        pcp_rank=pcp_rank,
+    )
+
+    torch.testing.assert_close(
+        plan.compact_restored_indices,
+        torch.arange(5, dtype=torch.int64),
+    )
+    torch.testing.assert_close(
+        plan.local_compact_indices,
+        torch.tensor(expected_local_indices, dtype=torch.int64),
+    )
+    torch.testing.assert_close(
+        plan.local_valid_mask,
+        torch.tensor(expected_local_valid),
+    )
+    assert plan.num_local_tokens == 4
+
+
+def test_overlay_pcp_restored_swa_kv_workspace_ignores_padding_rows():
+    restored_positions = torch.tensor([0, 0, 1, 2, 3, 4, 5, 6, 7, 0])
+    restored_valid_mask = torch.tensor(
+        [True, False, True, True, True, True, True, True, True, False]
+    )
+    restored_kv = torch.stack(
+        [restored_positions.to(torch.float32), restored_positions.to(torch.float32)],
+        dim=1,
+    )
+    out = torch.full((1, 8, 2), -1.0)
+
+    overlay_pcp_restored_swa_kv_workspace(
+        out=out,
+        restored_kv=restored_kv,
+        restored_positions=restored_positions,
+        restored_valid_mask=restored_valid_mask,
+        views=[SimpleNamespace(restore_idx=torch.arange(10))],
+        chunk_start=0,
+        chunk_end=1,
+        seq_lens=torch.tensor([8], dtype=torch.int32),
+        gather_lens=torch.tensor([8], dtype=torch.int32),
+        chunk_n=0,
+        chunk_m=8,
+    )
+
+    expected = torch.stack(
+        [torch.arange(8, dtype=torch.float32), torch.arange(8, dtype=torch.float32)],
+        dim=1,
+    )
+    torch.testing.assert_close(out[0], expected)
+
+
+def test_build_pcp_sparse_prefill_rows_compacts_global_query_rows():
+    rows = build_pcp_sparse_prefill_rows(
+        combined_lens=torch.tensor([1, 1, 0], dtype=torch.int32),
+        positions=torch.tensor([5, 6, 10], dtype=torch.int64),
+        local_query_start_loc=torch.tensor([0, 3], dtype=torch.int32),
+        seq_lens=torch.tensor([8], dtype=torch.int32),
+        gather_lens=torch.tensor([4], dtype=torch.int32),
+        chunk_n=0,
+        chunk_m=4,
+    )
+
+    assert rows.sparse_rows == 3
+    assert (rows.rows_min, rows.rows_max) == (1, 2)
+    torch.testing.assert_close(rows.q_rows, torch.tensor([1, 2, 0]))
+    torch.testing.assert_close(rows.valid_query_mask, torch.tensor([True, True, False]))
+
+
+def test_compact_pcp_sparse_prefill_queries_allocates_only_valid_local_rows():
+    q = torch.arange(4 * 2, dtype=torch.float32).view(4, 1, 2)
+    indices = torch.tensor(
+        [[100, 101], [-1, -1], [900_000, 900_001], [-1, -1]],
+        dtype=torch.int32,
+    )
+    lengths = torch.tensor([2, 0, 2, 0], dtype=torch.int32)
+
+    compact_q, compact_indices, compact_lengths, output_rows = (
+        compact_pcp_sparse_prefill_queries(q, indices, lengths)
+    )
+
+    torch.testing.assert_close(compact_q, q[[0, 2]])
+    torch.testing.assert_close(compact_indices, indices[[0, 2]])
+    torch.testing.assert_close(compact_lengths, torch.tensor([2, 2], dtype=torch.int32))
+    torch.testing.assert_close(output_rows, torch.tensor([0, 2]))
+
+    output = torch.zeros_like(q)
+    output.index_copy_(0, output_rows, compact_q + 1)
+    torch.testing.assert_close(output[output_rows], compact_q + 1)
+    torch.testing.assert_close(output[[1, 3]], torch.zeros((2, 1, 2)))
+
+
+def test_build_pcp_swa_prefill_segments_rebases_to_local_kv_window():
+    segments = build_pcp_swa_prefill_segments(
+        combined_indices=torch.tensor([[0, 1, -1], [1, 2, -1]], dtype=torch.int32),
+        combined_lens=torch.tensor([2, 2], dtype=torch.int32),
+        positions=torch.tensor([5, 6], dtype=torch.int64),
+        local_query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+        seq_lens=torch.tensor([8], dtype=torch.int32),
+        gather_lens=torch.tensor([4], dtype=torch.int32),
+        chunk_n=0,
+        chunk_m=4,
+        window_size=3,
+    )
+
+    assert len(segments) == 1
+    segment = segments[0]
+    assert (segment.query_start, segment.query_end) == (0, 2)
+    assert (segment.kv_start, segment.kv_end) == (0, 3)
+    assert segment.sparse_rows == 3
+    torch.testing.assert_close(segment.q_rows, torch.tensor([1, 2]))
+    torch.testing.assert_close(
+        segment.shifted_indices,
+        torch.tensor([[0, 1, -1], [1, 2, -1]], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        segment.topk_lens, torch.tensor([2, 2], dtype=torch.int32)
+    )
+    torch.testing.assert_close(segment.valid_mask, torch.tensor([True, True]))
+
+
+def test_build_pcp_swa_prefill_segments_splits_dual_chunk_position_jump():
+    segments = build_pcp_swa_prefill_segments(
+        combined_indices=torch.tensor(
+            [
+                [2, 3, -1],
+                [3, 4, -1],
+                [17, 18, -1],
+                [18, 19, -1],
+            ],
+            dtype=torch.int32,
+        ),
+        combined_lens=torch.tensor([2, 2, 2, 2], dtype=torch.int32),
+        positions=torch.tensor([5, 6, 20, 21], dtype=torch.int64),
+        local_query_start_loc=torch.tensor([0, 4], dtype=torch.int32),
+        seq_lens=torch.tensor([24], dtype=torch.int32),
+        gather_lens=torch.tensor([24], dtype=torch.int32),
+        chunk_n=0,
+        chunk_m=24,
+        window_size=4,
+        segment_size=64,
+    )
+
+    assert len(segments) == 2
+    assert (segments[0].query_start, segments[0].query_end) == (0, 2)
+    assert (segments[0].kv_start, segments[0].kv_end) == (2, 7)
+    assert (segments[1].query_start, segments[1].query_end) == (2, 4)
+    assert (segments[1].kv_start, segments[1].kv_end) == (17, 22)
+    torch.testing.assert_close(
+        segments[1].shifted_indices,
+        torch.tensor([[0, 1, -1], [1, 2, -1]], dtype=torch.int32),
+    )
+
+
+def test_build_pcp_swa_prefill_segments_handles_empty_valid_segment():
+    segments = build_pcp_swa_prefill_segments(
+        combined_indices=torch.full((2, 3), -1, dtype=torch.int32),
+        combined_lens=torch.zeros(2, dtype=torch.int32),
+        positions=torch.tensor([9, 10], dtype=torch.int64),
+        local_query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+        seq_lens=torch.tensor([8], dtype=torch.int32),
+        gather_lens=torch.tensor([4], dtype=torch.int32),
+        chunk_n=0,
+        chunk_m=4,
+        window_size=3,
+    )
+
+    assert len(segments) == 1
+    assert segments[0].sparse_rows == 1
+    assert (segments[0].kv_start, segments[0].kv_end) == (0, 0)
+    torch.testing.assert_close(segments[0].valid_mask, torch.tensor([False, False]))
+
+
+def test_build_pcp_swa_prefill_segments_rejects_out_of_window_indices():
+    with pytest.raises(ValueError, match="outside the rebased KV workspace"):
+        build_pcp_swa_prefill_segments(
+            combined_indices=torch.tensor([[10]], dtype=torch.int32),
+            combined_lens=torch.tensor([1], dtype=torch.int32),
+            positions=torch.tensor([5], dtype=torch.int64),
+            local_query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+            seq_lens=torch.tensor([8], dtype=torch.int32),
+            gather_lens=torch.tensor([4], dtype=torch.int32),
+            chunk_n=0,
+            chunk_m=4,
+            window_size=3,
+        )
+
+
+def test_pcp_swa_torch_sparse_fwd_keeps_overflowed_logits_finite():
+    assert hasattr(_PCP_METADATA, "pcp_swa_torch_sparse_fwd")
+    pcp_swa_torch_sparse_fwd = _PCP_METADATA.pcp_swa_torch_sparse_fwd
+    q = torch.full((1, 1, 2), 1e20, dtype=torch.float32)
+    kv = torch.full((2, 1, 2), 1e20, dtype=torch.float32)
+    indices = torch.tensor([[0, 1]], dtype=torch.int32)
+    topk_length = torch.tensor([2], dtype=torch.int32)
+    out = torch.empty_like(q)
+
+    pcp_swa_torch_sparse_fwd(
+        q=q,
+        kv=kv,
+        indices=indices,
+        topk_length=topk_length,
+        sm_scale=1.0,
+        attn_sink=None,
+        out=out,
+    )
+
+    assert torch.isfinite(out).all()

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -3037,3 +3037,44 @@ def test_resolve_block_hashes_rejects_mismatched_view():
     mismatched = BlockHashListWithBlockSize(raw, 2, 8)
     with pytest.raises(AssertionError):
         resolve_block_hashes(mismatched, 2, 4)
+
+
+def test_resolve_kv_cache_block_sizes_scales_only_legacy_pcp():
+    kv_cache_config = KVCacheConfig(
+        num_blocks=8,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["model.layers.0.self_attn"],
+                FullAttentionSpec(
+                    block_size=16,
+                    num_kv_heads=1,
+                    head_size=16,
+                    dtype=torch.float16,
+                ),
+            )
+        ],
+    )
+
+    def make_config(use_v2_model_runner: bool):
+        return SimpleNamespace(
+            cache_config=SimpleNamespace(
+                block_size=16,
+                enable_prefix_caching=False,
+                prefix_match_unit=None,
+                mamba_cache_mode="align",
+            ),
+            parallel_config=SimpleNamespace(
+                decode_context_parallel_size=1,
+                prefill_context_parallel_size=2,
+            ),
+            kv_transfer_config=None,
+            use_v2_model_runner=use_v2_model_runner,
+        )
+
+    assert kv_cache_utils.resolve_kv_cache_block_sizes(
+        kv_cache_config, make_config(use_v2_model_runner=False)
+    ) == (32, 32)
+    assert kv_cache_utils.resolve_kv_cache_block_sizes(
+        kv_cache_config, make_config(use_v2_model_runner=True)
+    ) == (16, 16)

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -6,13 +6,16 @@ from unittest.mock import Mock
 
 import pytest
 import torch
+from transformers import OPTConfig
 
 import vllm.envs as envs
 from vllm.config import (
     CacheConfig,
+    DeviceConfig,
     ECTransferConfig,
     KVTransferConfig,
     ModelConfig,
+    ParallelConfig,
     SchedulerConfig,
     SpeculativeConfig,
     VllmConfig,
@@ -26,14 +29,26 @@ from vllm.multimodal.inputs import (
 from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 from vllm.utils.hashing import sha256
 from vllm.v1.core.encoder_cache_manager import EncoderCacheManager
-from vllm.v1.core.kv_cache_utils import get_request_block_hasher, init_none_hash
+from vllm.v1.core.kv_cache_coordinator import (
+    HybridKVCacheCoordinator,
+    KVCacheCoordinatorNoPrefixCache,
+)
+from vllm.v1.core.kv_cache_utils import (
+    get_group_id,
+    get_request_block_hasher,
+    init_none_hash,
+)
 from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
 from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.core.single_type_kv_cache_manager import register_all_kvcache_specs
 from vllm.v1.engine import FinishReason
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
+    MambaSpec,
+    MLAAttentionSpec,
+    SlidingWindowMLASpec,
 )
 from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
@@ -1688,6 +1703,289 @@ def _step_until_kv_transfer_finished(scheduler: Scheduler, req_ids: list[str]):
     return initial_ecos
 
 
+def _make_hybrid_scheduler(
+    kv_cache_groups: list[KVCacheGroupSpec],
+    num_blocks: int = 800,
+    enable_prefix_caching: bool = True,
+    pcp_world_size: int = 1,
+    model: str = "facebook/opt-125m",
+) -> Scheduler:
+    scheduler_block_size = 256
+    hash_block_size = 4
+    model_config = ModelConfig(
+        model=model,
+        trust_remote_code=True,
+        dtype="float16",
+        seed=42,
+        skip_tokenizer_init=True,
+    )
+    scheduler_config = SchedulerConfig(
+        max_num_seqs=4,
+        max_num_batched_tokens=4096,
+        max_model_len=4096,
+        enable_chunked_prefill=True,
+        is_encoder_decoder=False,
+        watermark=0.0,
+    )
+    cache_config = CacheConfig(
+        block_size=scheduler_block_size,
+        prefix_match_unit=hash_block_size,
+        gpu_memory_utilization=0.9,
+        cache_dtype="auto",
+        enable_prefix_caching=enable_prefix_caching,
+        mamba_cache_mode="all",
+    )
+    cache_config.num_gpu_blocks = num_blocks
+    kv_transfer_config = KVTransferConfig(
+        kv_connector="MockKVConnector",
+        kv_role="kv_consumer",
+        kv_connector_extra_config={"matched_tokens": 0, "is_async": False},
+    )
+    vllm_config = VllmConfig(
+        scheduler_config=scheduler_config,
+        model_config=model_config,
+        cache_config=cache_config,
+        parallel_config=ParallelConfig(
+            prefill_context_parallel_size=pcp_world_size,
+        ),
+        device_config=DeviceConfig("cpu"),
+        kv_transfer_config=kv_transfer_config,
+    )
+    register_all_kvcache_specs(vllm_config)
+    scheduler = Scheduler(
+        vllm_config=vllm_config,
+        kv_cache_config=KVCacheConfig(
+            num_blocks=num_blocks,
+            kv_cache_tensors=[],
+            kv_cache_groups=kv_cache_groups,
+        ),
+        structured_output_manager=StructuredOutputManager(vllm_config),
+        block_size=scheduler_block_size,
+        hash_block_size=hash_block_size,
+        log_stats=True,
+    )
+    expected_coordinator = (
+        HybridKVCacheCoordinator
+        if enable_prefix_caching
+        else KVCacheCoordinatorNoPrefixCache
+    )
+    assert isinstance(scheduler.kv_cache_manager.coordinator, expected_coordinator)
+    return scheduler
+
+
+def _dsv4_like_kv_cache_groups() -> list[KVCacheGroupSpec]:
+    return [
+        KVCacheGroupSpec(
+            ["dense_mla"],
+            MLAAttentionSpec(
+                block_size=256,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.uint8,
+                compress_ratio=4,
+                model_version="deepseek_v4",
+            ),
+        ),
+        KVCacheGroupSpec(
+            ["swa_tail"],
+            SlidingWindowMLASpec(
+                block_size=64,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.uint8,
+                sliding_window=128,
+                model_version="deepseek_v4",
+            ),
+        ),
+        KVCacheGroupSpec(
+            ["c4_state"],
+            SlidingWindowMLASpec(
+                block_size=4,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.uint8,
+                sliding_window=8,
+            ),
+        ),
+        KVCacheGroupSpec(
+            ["c128_state"],
+            SlidingWindowMLASpec(
+                block_size=8,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.uint8,
+                sliding_window=128,
+            ),
+        ),
+    ]
+
+
+def _mamba_like_kv_cache_groups() -> list[KVCacheGroupSpec]:
+    return [
+        KVCacheGroupSpec(
+            ["dense_full_attention"],
+            FullAttentionSpec(
+                block_size=256,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.uint8,
+            ),
+        ),
+        KVCacheGroupSpec(
+            ["mamba_state"],
+            MambaSpec(
+                block_size=256,
+                shapes=((1, 1),),
+                dtypes=(torch.uint8,),
+                mamba_cache_mode="all",
+            ),
+        ),
+    ]
+
+
+def test_dsv4_hybrid_pcp_requires_prefix_cache_off(tmp_path, monkeypatch):
+    monkeypatch.setattr(envs, "VLLM_USE_V2_MODEL_RUNNER", False)
+    model_path = tmp_path / "opt"
+    OPTConfig().save_pretrained(model_path)
+
+    with pytest.raises(AssertionError, match="PCP not support hybrid attn now"):
+        _make_hybrid_scheduler(
+            _dsv4_like_kv_cache_groups(),
+            pcp_world_size=2,
+            model=str(model_path),
+        )
+
+    scheduler = _make_hybrid_scheduler(
+        _dsv4_like_kv_cache_groups(),
+        enable_prefix_caching=False,
+        pcp_world_size=2,
+        model=str(model_path),
+    )
+    managers = scheduler.kv_cache_manager.coordinator.single_type_managers
+    assert [manager.block_size for manager in managers] == [512, 128, 8, 16]
+
+    [request] = create_requests(
+        num_requests=1,
+        num_tokens=1024,
+        max_tokens=1,
+        same_prompt=True,
+        block_size=4,
+        req_ids=["pcp2"],
+    )
+    blocks = scheduler.kv_cache_manager.allocate_slots(
+        request,
+        num_new_tokens=request.num_tokens,
+    )
+    assert blocks is not None
+    assert [len(manager.req_to_blocks[request.request_id]) for manager in managers] == [
+        2,
+        8,
+        128,
+        64,
+    ]
+
+
+def _seed_local_prefix_cache(scheduler: Scheduler) -> None:
+    [fill_req] = create_requests(
+        num_requests=1,
+        num_tokens=1024,
+        max_tokens=1,
+        same_prompt=True,
+        block_size=4,
+        req_ids=["fill"],
+    )
+    manager = scheduler.kv_cache_manager
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(fill_req)
+    assert num_computed_tokens == 0
+    blocks = manager.allocate_slots(
+        fill_req,
+        num_new_tokens=fill_req.num_tokens,
+        num_new_computed_tokens=num_computed_tokens,
+        new_computed_blocks=computed_blocks,
+    )
+    assert blocks is not None
+    manager.free(fill_req)
+
+
+def _evict_cached_groups(scheduler: Scheduler, group_ids_to_evict: set[int]) -> None:
+    cached_block_ids = {
+        block.block_id
+        for block in scheduler.kv_cache_manager.block_pool.blocks
+        if block.block_hash is not None
+        and get_group_id(block.block_hash) in group_ids_to_evict
+    }
+    assert cached_block_ids
+    scheduler.kv_cache_manager.evict_blocks(cached_block_ids)
+
+
+@pytest.mark.parametrize(
+    "kv_cache_groups,group_ids_to_evict",
+    [
+        pytest.param(_dsv4_like_kv_cache_groups(), {1, 2, 3}, id="dsv4-like"),
+        pytest.param(_mamba_like_kv_cache_groups(), {1}, id="mamba-like"),
+    ],
+)
+def test_kv_connector_hybrid_uses_dense_local_prefix_hit(
+    kv_cache_groups: list[KVCacheGroupSpec],
+    group_ids_to_evict: set[int],
+):
+    """Hybrid KVConnector hits should report reusable dense prefix tokens."""
+    scheduler = _make_hybrid_scheduler(kv_cache_groups)
+    _seed_local_prefix_cache(scheduler)
+    _evict_cached_groups(scheduler, group_ids_to_evict)
+
+    queried_local_hits: list[int] = []
+
+    def record_connector_query(request: Request, num_computed_tokens: int):
+        queried_local_hits.append(num_computed_tokens)
+        return 0, False
+
+    assert scheduler.connector is not None
+    scheduler.connector.get_num_new_matched_tokens = record_connector_query
+
+    [replay_req] = create_requests(
+        num_requests=1,
+        num_tokens=1280,
+        max_tokens=1,
+        same_prompt=True,
+        block_size=4,
+        req_ids=["replay"],
+    )
+    replay_req.kv_transfer_params = {"do_remote_prefill": True}
+    scheduler.add_request(replay_req)
+    scheduler_output = scheduler.schedule()
+
+    assert queried_local_hits == [1024]
+    assert scheduler_output.num_scheduled_tokens[replay_req.request_id] == 256
+
+
+def test_kv_connector_hybrid_dense_hit_requires_remote_prefill():
+    scheduler = _make_hybrid_scheduler(_dsv4_like_kv_cache_groups())
+    _seed_local_prefix_cache(scheduler)
+    _evict_cached_groups(scheduler, {1, 2, 3})
+
+    queried_local_hits: list[int] = []
+
+    def record_connector_query(request: Request, num_computed_tokens: int):
+        queried_local_hits.append(num_computed_tokens)
+        return 0, False
+
+    assert scheduler.connector is not None
+    scheduler.connector.get_num_new_matched_tokens = record_connector_query
+
+    [local_req] = create_requests(
+        num_requests=1,
+        num_tokens=1280,
+        max_tokens=1,
+        same_prompt=True,
+        block_size=4,
+        req_ids=["local"],
+    )
+    scheduler.add_request(local_req)
+    scheduler_output = scheduler.schedule()
+
+    assert queried_local_hits == [0]
+    assert scheduler_output.num_scheduled_tokens[local_req.request_id] == 1280
 @pytest.mark.parametrize("is_async", [False, True])
 def test_kv_connector_basic(is_async: bool):
     """

--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import contextlib
+import threading
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -26,6 +27,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector im
     SendBlockMeta,
     TransferRegion,
     _align_transfer_regions,
+    _pair_pcp_block_ids,
     get_mooncake_bootstrap_addr,
     should_launch_bootstrap_server,
 )
@@ -68,6 +70,290 @@ def _make_test_kv_cache_config() -> KVCacheConfig:
             )
         ],
     )
+
+
+@pytest.mark.parametrize("group_block_size", [256, 64, 4, 8])
+def test_pair_pcp_blocks_reassembles_v4_groups(group_block_size: int):
+    """PCP ranks must write disjoint pages whose union is the D cache."""
+
+    total_tokens = 1024
+    remote_blocks = list(range(1000, 1000 + total_tokens // group_block_size))
+    local_count = total_tokens // 2 // group_block_size
+
+    rank_pairs = [
+        _pair_pcp_block_ids(
+            list(range(rank * 100, rank * 100 + local_count)),
+            remote_blocks,
+            total_tokens=total_tokens,
+            num_external_tokens=total_tokens,
+            external_start_token=0,
+            producer_pcp_size=2,
+            producer_pcp_rank=rank,
+            consumer_pcp_size=1,
+            consumer_pcp_rank=0,
+            group_block_size=group_block_size,
+            interleave_size=256,
+        )
+        for rank in range(2)
+    ]
+
+    assert all(error is None for _, _, error in rank_pairs)
+    rank0_remote = rank_pairs[0][1]
+    rank1_remote = rank_pairs[1][1]
+    assert set(rank0_remote).isdisjoint(rank1_remote)
+    assert sorted(rank0_remote + rank1_remote) == remote_blocks
+
+
+def test_pair_pcp_blocks_skips_padding_after_partial_final_chunk():
+    """Only the rank owning the request tail may write its final D page."""
+
+    total_tokens = 600
+    remote_blocks = [100, 101, 102]
+    rank0 = _pair_pcp_block_ids(
+        [10, 11],
+        remote_blocks,
+        total_tokens=total_tokens,
+        num_external_tokens=total_tokens,
+        external_start_token=0,
+        producer_pcp_size=2,
+        producer_pcp_rank=0,
+        consumer_pcp_size=1,
+        consumer_pcp_rank=0,
+        group_block_size=256,
+        interleave_size=256,
+    )
+    rank1 = _pair_pcp_block_ids(
+        [20],
+        remote_blocks,
+        total_tokens=total_tokens,
+        num_external_tokens=total_tokens,
+        external_start_token=0,
+        producer_pcp_size=2,
+        producer_pcp_rank=1,
+        consumer_pcp_size=1,
+        consumer_pcp_rank=0,
+        group_block_size=256,
+        interleave_size=256,
+    )
+
+    assert rank0 == ([10, 11], [100, 102], None)
+    assert rank1 == ([20], [101], None)
+
+
+def test_pair_pcp_blocks_skips_padding_on_rank_without_tokens():
+    """A short request may allocate one page on every PCP rank."""
+
+    rank0 = _pair_pcp_block_ids(
+        [10],
+        [100],
+        total_tokens=9,
+        num_external_tokens=9,
+        external_start_token=0,
+        producer_pcp_size=2,
+        producer_pcp_rank=0,
+        consumer_pcp_size=1,
+        consumer_pcp_rank=0,
+        group_block_size=256,
+        interleave_size=256,
+    )
+    rank1 = _pair_pcp_block_ids(
+        [20],
+        [100],
+        total_tokens=9,
+        num_external_tokens=9,
+        external_start_token=0,
+        producer_pcp_size=2,
+        producer_pcp_rank=1,
+        consumer_pcp_size=1,
+        consumer_pcp_rank=0,
+        group_block_size=256,
+        interleave_size=256,
+    )
+
+    assert rank0 == ([10], [100], None)
+    assert rank1 == ([], [], None)
+
+
+@pytest.mark.parametrize("group_block_size", [256, 64, 8, 4])
+def test_pair_pcp_blocks_maps_exact_external_suffix(group_block_size: int):
+    """Prefix hits must not shift producer-local suffix pages on Decode."""
+
+    total_tokens = 1024
+    external_start_token = 512
+    num_external_tokens = total_tokens - external_start_token
+    remote_blocks = list(range(100, 100 + num_external_tokens // group_block_size))
+    local_suffix_pages = num_external_tokens // 2 // group_block_size
+
+    rank_pairs = [
+        _pair_pcp_block_ids(
+            list(range(rank * 1000, rank * 1000 + local_suffix_pages)),
+            remote_blocks,
+            total_tokens=total_tokens,
+            num_external_tokens=num_external_tokens,
+            external_start_token=external_start_token,
+            producer_pcp_size=2,
+            producer_pcp_rank=rank,
+            consumer_pcp_size=1,
+            consumer_pcp_rank=0,
+            group_block_size=group_block_size,
+            interleave_size=256,
+        )
+        for rank in range(2)
+    ]
+
+    assert all(error is None for _, _, error in rank_pairs)
+    assert set(rank_pairs[0][1]).isdisjoint(rank_pairs[1][1])
+    assert sorted(rank_pairs[0][1] + rank_pairs[1][1]) == remote_blocks
+
+
+def test_pair_pcp_blocks_rejects_non_suffix_external_range():
+    _, _, error = _pair_pcp_block_ids(
+        [10],
+        [100],
+        total_tokens=1024,
+        num_external_tokens=256,
+        external_start_token=512,
+        producer_pcp_size=2,
+        producer_pcp_rank=0,
+        consumer_pcp_size=1,
+        consumer_pcp_rank=0,
+        group_block_size=256,
+        interleave_size=256,
+    )
+
+    assert error is not None
+    assert "exact suffix" in error
+
+
+def test_pair_pcp_blocks_fails_closed_for_unsupported_page_geometry():
+    _, _, error = _pair_pcp_block_ids(
+        [10],
+        [100],
+        total_tokens=256,
+        num_external_tokens=256,
+        external_start_token=0,
+        producer_pcp_size=2,
+        producer_pcp_rank=0,
+        consumer_pcp_size=1,
+        consumer_pcp_rank=0,
+        group_block_size=96,
+        interleave_size=256,
+    )
+
+    assert error is not None
+    assert "interleave" in error
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("group_block_size", [256, 64, 8, 4])
+@pytest.mark.parametrize("pcp_rank", [0, 1])
+async def test_build_transfer_params_reassembles_pcp_pages(
+    group_block_size: int,
+    pcp_rank: int,
+):
+    """The transfer plan must scatter compact PCP pages into D global order."""
+
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.shutdown = MagicMock()
+    worker.async_zmq_ctx = MagicMock()
+    worker.is_kv_consumer = False
+    worker.is_kv_producer = True
+    worker.tp_rank = 0
+    worker.tp_size = 1
+    worker.pcp_rank = pcp_rank
+    worker.pcp_size = 2
+    worker.cp_kv_cache_interleave_size = 256
+    worker._physical_blocks_per_logical_kv_block = 1
+    worker.transfer_topo = SimpleNamespace(local_replicates_kv_cache=False)
+    worker.kv_cache_config = KVCacheConfig(
+        num_blocks=0,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["model.layers.0.self_attn"],
+                FullAttentionSpec(
+                    block_size=group_block_size,
+                    num_kv_heads=1,
+                    head_size=16,
+                    dtype=torch.float16,
+                ),
+            )
+        ],
+    )
+
+    local_base = 0x1000
+    remote_base = 0xA000
+    region_block_len = 128
+    local_regions = [
+        TransferRegion(
+            layer_name="model.layers.0.self_attn",
+            layer_index=0,
+            base_addr=local_base,
+            block_len=region_block_len,
+            kv_block_len=region_block_len,
+            logical_group_indices=(0,),
+        )
+    ]
+    remote_regions = [
+        TransferRegion(
+            layer_name="model.layers.0.self_attn",
+            layer_index=0,
+            base_addr=remote_base,
+            block_len=region_block_len,
+            kv_block_len=region_block_len,
+            logical_group_indices=(0,),
+        )
+    ]
+    local_pages_per_chunk = 256 // group_block_size
+    local_block_ids = list(range(10, 10 + 512 // group_block_size))
+    remote_block_ids = list(range(100, 100 + 1024 // group_block_size))
+    transfer_id = "xfer-pcp"
+    send_meta = SendBlockMeta(
+        p_req_id="p-req-pcp",
+        transfer_id=transfer_id,
+        local_block_ids=[local_block_ids],
+        ready=asyncio.Event(),
+    )
+    xfer_meta = MooncakeXferMetadata(
+        remote_hostname="consumer-host",
+        remote_port=54321,
+        remote_tp_size=1,
+        remote_tp_rank=0,
+        remote_pcp_size=1,
+        remote_pcp_rank=0,
+        req_blocks={"d-req-pcp": (transfer_id, [remote_block_ids])},
+        kv_caches_base_addr=[remote_base],
+        block_lens=[region_block_len],
+        kv_block_lens=[region_block_len],
+        req_total_tokens={"d-req-pcp": 1024},
+        req_num_external_tokens={"d-req-pcp": 1024},
+        req_external_start_tokens={"d-req-pcp": 0},
+    )
+
+    (
+        src_ptrs,
+        dst_ptrs,
+        lengths,
+        err_reqs,
+        err_msg,
+    ) = await worker._build_transfer_params(
+        ready_reqs=[("d-req-pcp", send_meta)],
+        agent_meta=xfer_meta,
+        local_regions=local_regions,
+        remote_regions=remote_regions,
+    )
+
+    assert err_reqs == []
+    assert err_msg is None
+    assert src_ptrs == [
+        local_base + 10 * region_block_len,
+        local_base + (10 + local_pages_per_chunk) * region_block_len,
+    ]
+    assert dst_ptrs == [
+        remote_base + (100 + pcp_rank * local_pages_per_chunk) * region_block_len,
+        remote_base + (100 + (2 + pcp_rank) * local_pages_per_chunk) * region_block_len,
+    ]
+    assert lengths == [region_block_len * local_pages_per_chunk] * 2
 
 
 class FakeMooncakeWrapper:
@@ -382,6 +668,7 @@ async def test_build_transfer_params_separates_prefill_pp_layers():
     """Each producer PP stage should send only its registered layer shard."""
 
     worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.shutdown = MagicMock()
     worker.async_zmq_ctx = MagicMock()
     worker.is_kv_consumer = True
     worker.is_kv_producer = True
@@ -493,6 +780,7 @@ async def test_build_transfer_params_separates_prefill_pp_layers():
             lengths,
             err_reqs,
             err_msg,
+            state_transfer_events,
         ) = await worker._build_transfer_params(
             ready_reqs=[("d-req-pp", send_meta)],
             agent_meta=xfer_meta,
@@ -502,6 +790,7 @@ async def test_build_transfer_params_separates_prefill_pp_layers():
 
         assert err_reqs == []
         assert err_msg is None
+        assert state_transfer_events == []
         assert src_ptrs == expected_by_pp_rank[pp_rank]["src_ptrs"]
         assert dst_ptrs == expected_by_pp_rank[pp_rank]["dst_ptrs"]
         assert lengths == [2 * block_len, 2 * block_len]
@@ -574,10 +863,13 @@ async def test_send_kv_to_decode_aligns_consumer_regions_by_layer_metadata(
         ) as mock_send_blocks:
             await prefill_worker.send_kv_to_decode(identity, mock_socket, xfer_meta)
 
-        src_ptrs, dst_ptrs, lengths = mock_send_blocks.call_args[0][1:]
+        src_ptrs, dst_ptrs, lengths, state_transfer_events = mock_send_blocks.call_args[
+            0
+        ][1:]
         assert src_ptrs == [0x1000 + 10 * block_len]
         assert dst_ptrs == [0xB000 + 20 * block_len]
         assert lengths == [block_len]
+        assert state_transfer_events == []
 
         sent_identity, sent_payload = mock_socket.send_multipart.call_args[0][0]
         assert sent_identity == identity
@@ -712,6 +1004,8 @@ async def test_bootstrap_server(bootstrap_server: MooncakeBootstrapServer):
         "dp_rank": 0,
         "tp_rank": 0,
         "pp_rank": 0,
+        "pcp_rank": 0,
+        "pcp_size": 2,
         "addr": "tcp://1.1.1.1:1111",
     }
     async with httpx.AsyncClient() as client:
@@ -719,11 +1013,26 @@ async def test_bootstrap_server(bootstrap_server: MooncakeBootstrapServer):
         assert response.status_code == 200
         assert response.json() == {"status": "ok"}
 
+    payload1_pcp1 = {
+        "engine_id": "eng-1",
+        "dp_rank": 0,
+        "tp_rank": 0,
+        "pp_rank": 0,
+        "pcp_rank": 1,
+        "pcp_size": 2,
+        "addr": "tcp://1.1.1.2:1112",
+    }
+    async with httpx.AsyncClient() as client:
+        response = await client.post(f"{base_url}/register", json=payload1_pcp1)
+        assert response.status_code == 200
+
     payload2 = {
         "engine_id": "eng-1",
         "dp_rank": 0,
         "tp_rank": 0,
         "pp_rank": 1,
+        "pcp_rank": 0,
+        "pcp_size": 2,
         "addr": "tcp://2.2.2.2:2222",
     }
     async with httpx.AsyncClient() as client:
@@ -738,8 +1047,10 @@ async def test_bootstrap_server(bootstrap_server: MooncakeBootstrapServer):
         data = response.json()
         assert "0" in data
         assert data["0"]["engine_id"] == "eng-1"
-        assert data["0"]["worker_addr"]["0"]["0"] == "tcp://1.1.1.1:1111"
-        assert data["0"]["worker_addr"]["0"]["1"] == "tcp://2.2.2.2:2222"
+        assert data["0"]["pcp_size"] == 2
+        assert data["0"]["worker_addr"]["0"]["0"]["0"] == ("tcp://1.1.1.1:1111")
+        assert data["0"]["worker_addr"]["0"]["0"]["1"] == ("tcp://1.1.1.2:1112")
+        assert data["0"]["worker_addr"]["0"]["1"]["0"] == ("tcp://2.2.2.2:2222")
 
     # Test failure: re-registering the same worker
     async with httpx.AsyncClient() as client:
@@ -753,6 +1064,8 @@ async def test_bootstrap_server(bootstrap_server: MooncakeBootstrapServer):
         "dp_rank": 0,
         "tp_rank": 1,
         "pp_rank": 0,
+        "pcp_rank": 0,
+        "pcp_size": 2,
         "addr": "tcp://3.3.3.3:3333",
     }
     async with httpx.AsyncClient() as client:
@@ -832,6 +1145,33 @@ def test_should_launch_bootstrap_server_selects_single_owner(
     ):
         mock_pp_group.return_value.rank_in_group = pp_rank
         assert should_launch_bootstrap_server(vllm_config) is expected
+
+
+def test_should_launch_bootstrap_server_rejects_nonzero_pcp_rank():
+    vllm_config = _make_bootstrap_vllm_config(
+        local_engines_only=True,
+        data_parallel_rank_local=0,
+    )
+    vllm_config.parallel_config.prefill_context_parallel_size = 2
+    with (
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_connector.get_tensor_model_parallel_rank",
+            return_value=0,
+        ),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_connector.get_pp_group"
+        ) as mock_pp_group,
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+            "mooncake_connector.get_pcp_group",
+            create=True,
+        ) as mock_pcp_group,
+    ):
+        mock_pp_group.return_value.rank_in_group = 0
+        mock_pcp_group.return_value.rank_in_group = 1
+        assert should_launch_bootstrap_server(vllm_config) is False
 
 
 @pytest.mark.parametrize(
@@ -924,6 +1264,7 @@ def patch_worker_dependencies():
             "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
             "mooncake_connector.current_platform.set_device"
         ),
+        patch("torch.accelerator.current_device_index", return_value=0),
         patch(
             "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
             "mooncake_connector.get_current_attn_backends",
@@ -1011,56 +1352,201 @@ async def test_receive_kv_selects_remote_pp_workers(
 ):
     """Decode workers should not hard-code producer pp_rank 0."""
 
-    vllm_config = create_vllm_config(
-        kv_connector="MooncakeConnector", kv_role="kv_consumer"
+    decode_worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    decode_worker.shutdown = MagicMock()
+    decode_worker.pp_size = local_pp_size
+    decode_worker.pp_rank = local_pp_rank
+    decode_worker.pcp_size = 1
+    decode_worker.pcp_rank = 0
+    decode_worker.transfer_topo = SimpleNamespace(
+        handshake_target_ranks=lambda _size: [0]
     )
-
-    with set_current_vllm_config(vllm_config), patch_worker_dependencies():
-        decode_connector = MooncakeConnector(
-            vllm_config,
-            KVConnectorRole.WORKER,
-            _make_test_kv_cache_config(),
-        )
-        decode_worker = decode_connector.connector_worker
-        decode_worker.pp_size = local_pp_size
-        decode_worker.pp_rank = local_pp_rank
-        decode_worker._remote_agents = {
-            "p-engine": {
-                0: {
-                    0: "tcp://producer-pp0:1234",
-                    1: "tcp://producer-pp1:1234",
-                }
+    decode_worker._remote_agents = {
+        "p-engine": {
+            0: {
+                0: {0: "tcp://producer-pp0:1234"},
+                1: {0: "tcp://producer-pp1:1234"},
             }
         }
-        decode_worker._tp_size["p-engine"] = 1
+    }
+    decode_worker._tp_size = {"p-engine": 1}
+    decode_worker._pcp_size = {"p-engine": 1}
 
-        pull_metas = {
-            "d-req-1": PullReqMeta(
-                d_req_id="d-req-1",
-                transfer_id="xfer-req-1",
-                local_block_ids=[[100, 101]],
-                remote_engine_id="p-engine",
-                remote_bootstrap_addr="http://bootstrap:33333",
-            )
+    pull_metas = {
+        "d-req-1": PullReqMeta(
+            d_req_id="d-req-1",
+            transfer_id="xfer-req-1",
+            local_block_ids=[[100, 101]],
+            remote_engine_id="p-engine",
+            remote_bootstrap_addr="http://bootstrap:33333",
+        )
+    }
+    seen_addrs: list[str] = []
+
+    async def fake_receive(worker_addr: str, metas: dict[str, PullReqMeta]):
+        seen_addrs.append(worker_addr)
+        for meta in metas.values():
+            meta.pull_tasks_count -= 1
+
+    with patch.object(
+        decode_worker,
+        "receive_kv_from_single_worker",
+        side_effect=fake_receive,
+    ):
+        decode_worker.receive_kv("p-engine", pull_metas)
+        await asyncio.sleep(0)
+
+    assert seen_addrs == expected_addrs
+    assert pull_metas["d-req-1"].pull_tasks_count == 0
+
+
+@pytest.mark.asyncio
+async def test_receive_kv_waits_for_every_remote_pp_pcp_worker():
+    """A PCP1 decoder must pull every PP/PCP shard from a PCP2 producer."""
+
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.shutdown = MagicMock()
+    worker.pp_size = 1
+    worker.pp_rank = 0
+    worker.pcp_size = 1
+    worker.pcp_rank = 0
+    worker.transfer_topo = SimpleNamespace(handshake_target_ranks=lambda _size: [0])
+    worker._remote_agents = {
+        "p-engine": {
+            0: {
+                0: {
+                    0: "tcp://producer-pp0-pcp0:1234",
+                    1: "tcp://producer-pp0-pcp1:1234",
+                },
+                1: {
+                    0: "tcp://producer-pp1-pcp0:1234",
+                    1: "tcp://producer-pp1-pcp1:1234",
+                },
+            }
         }
-        seen_addrs: list[str] = []
+    }
+    worker._tp_size = {"p-engine": 1}
+    worker._pcp_size = {"p-engine": 2}
+    worker.finished_recving_reqs = set()
+    pull_metas = {
+        "d-req-1": PullReqMeta(
+            d_req_id="d-req-1",
+            transfer_id="xfer-req-1",
+            local_block_ids=[[100, 101]],
+            remote_engine_id="p-engine",
+            remote_bootstrap_addr="http://bootstrap:33333",
+        )
+    }
+    seen_addrs: list[str] = []
 
-        async def fake_receive(worker_addr: str, metas: dict[str, PullReqMeta]):
-            seen_addrs.append(worker_addr)
-            for meta in metas.values():
-                meta.pull_tasks_count -= 1
+    async def fake_receive(worker_addr: str, metas: dict[str, PullReqMeta]):
+        seen_addrs.append(worker_addr)
+        worker.process_pulling_result(
+            MooncakeXferResponse(
+                status=MooncakeXferResponseStatus.FINISH,
+                ok_reqs=list(metas),
+            ),
+            metas,
+        )
 
-        with patch.object(
-            decode_worker,
-            "receive_kv_from_single_worker",
-            side_effect=fake_receive,
-        ):
-            decode_worker.receive_kv("p-engine", pull_metas)
-            await asyncio.sleep(0)
+    with patch.object(
+        worker,
+        "receive_kv_from_single_worker",
+        side_effect=fake_receive,
+    ):
+        worker.receive_kv("p-engine", pull_metas)
+        await asyncio.sleep(0)
 
-        assert seen_addrs == expected_addrs
-        assert pull_metas["d-req-1"].pull_tasks_count == 0
-        decode_worker.shutdown()
+    assert seen_addrs == [
+        "tcp://producer-pp0-pcp0:1234",
+        "tcp://producer-pp0-pcp1:1234",
+        "tcp://producer-pp1-pcp0:1234",
+        "tcp://producer-pp1-pcp1:1234",
+    ]
+    assert pull_metas["d-req-1"].pull_tasks_count == 0
+    assert worker.finished_recving_reqs == {"d-req-1"}
+
+
+def test_receive_kv_rejects_incomplete_remote_pcp_workers():
+    """A decoder must fail closed when any producer PCP shard is absent."""
+
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.shutdown = MagicMock()
+    worker.async_zmq_ctx = MagicMock()
+    worker.pp_size = 1
+    worker.pp_rank = 0
+    worker.pcp_size = 1
+    worker.pcp_rank = 0
+    worker.transfer_topo = SimpleNamespace(handshake_target_ranks=lambda _size: [0])
+    worker._remote_agents = {
+        "p-engine": {
+            0: {
+                0: {0: "tcp://producer-pp0-pcp0:1234"},
+                1: {0: "tcp://producer-pp1-pcp0:1234"},
+            }
+        }
+    }
+    worker._tp_size = {"p-engine": 1}
+    worker._pcp_size = {"p-engine": 2}
+    worker._invalid_block_ids_lock = threading.Lock()
+    worker._invalid_block_ids = set()
+    worker.finished_recving_reqs = set()
+    pull_meta = PullReqMeta(
+        d_req_id="d-req-incomplete",
+        transfer_id="xfer-incomplete",
+        local_block_ids=[[100, 101]],
+        remote_engine_id="p-engine",
+        remote_bootstrap_addr="http://bootstrap:33333",
+    )
+
+    worker.receive_kv("p-engine", {pull_meta.d_req_id: pull_meta})
+
+    assert pull_meta.pull_failed is True
+    assert worker.finished_recving_reqs == {pull_meta.d_req_id}
+    assert worker.get_block_ids_with_load_errors() == {100, 101}
+
+
+def test_multi_shard_late_failure_waits_for_quiesce_and_invalidates_blocks():
+    """A late PCP shard failure must not expose partially reconstructed KV."""
+
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.shutdown = MagicMock()
+    worker.async_zmq_ctx = MagicMock()
+    worker._invalid_block_ids_lock = threading.Lock()
+    worker._invalid_block_ids = set()
+    worker.finished_recving_reqs = set()
+    pull_meta = PullReqMeta(
+        d_req_id="d-req-late-failure",
+        transfer_id="xfer-late-failure",
+        local_block_ids=[[100, 101]],
+        remote_engine_id="p-engine",
+        remote_bootstrap_addr="http://bootstrap:33333",
+        pull_tasks_count=2,
+    )
+    pull_metas = {pull_meta.d_req_id: pull_meta}
+
+    worker.process_pulling_result(
+        MooncakeXferResponse(
+            status=MooncakeXferResponseStatus.CONTINUE,
+            ok_reqs=[pull_meta.d_req_id],
+        ),
+        pull_metas,
+    )
+    assert pull_meta.pull_tasks_count == 1
+    assert worker.finished_recving_reqs == set()
+
+    worker.process_pulling_result(
+        MooncakeXferResponse(
+            status=MooncakeXferResponseStatus.ERROR,
+            err_reqs=[pull_meta.d_req_id],
+            err_msg="producer PCP shard failed",
+        ),
+        pull_metas,
+    )
+    assert pull_meta.pull_tasks_count == 0
+    assert pull_meta.pull_failed is True
+    assert worker.finished_recving_reqs == {pull_meta.d_req_id}
+    assert worker.get_block_ids_with_load_errors() == {100, 101}
 
 
 def test_resolve_need_send_accounts_for_remote_tp_fanout():
@@ -1167,6 +1653,7 @@ async def test_kv_producer(monkeypatch):
                 src,
                 dst,
                 lens,
+                [],
             )
             mock_socket.send_multipart.assert_called_once()
 
@@ -1199,6 +1686,7 @@ async def test_kv_producer(monkeypatch):
                 src,
                 dst,
                 lens,
+                [],
             )
             mock_socket.send_multipart.assert_called_once()
 
@@ -1296,7 +1784,10 @@ async def test_kv_consumuer(monkeypatch):
                 pull_tasks_count=1,
             )
         }
-        decode_worker._remote_agents = {"p-engine": {0: {0: "tcp://producer:1234"}}}
+        decode_worker._remote_agents = {
+            "p-engine": {0: {0: {0: "tcp://producer:1234"}}}
+        }
+        decode_worker._pcp_size["p-engine"] = 1
         decode_worker._tp_size["p-engine"] = 1
 
         # Mock the response from the producer.
@@ -1668,6 +2159,21 @@ def test_register_kv_caches_aggregates_shared_overlay_aliases():
             ),
         ],
     )
+    worker._layer_specs = {
+        layer_name: group.kv_cache_spec
+        for group in worker.kv_cache_config.kv_cache_groups
+        for layer_name in group.layer_names
+    }
+    worker._layer_group_indices = {
+        layer_name: group_index
+        for group_index, group in enumerate(worker.kv_cache_config.kv_cache_groups)
+        for layer_name in group.layer_names
+    }
+    worker._layer_logical_group_indices = {
+        layer_name: [group_index]
+        for group_index, group in enumerate(worker.kv_cache_config.kv_cache_groups)
+        for layer_name in group.layer_names
+    }
     worker.transfer_topo = SimpleNamespace(
         virtually_split_kv_in_blocks=False,
         get_transfer_cache_regions=lambda cache, _spec: [cache],

--- a/tests/v1/kv_connector/unit/test_mooncake_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector_hma.py
@@ -11,6 +11,8 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+import torch
+from transformers import OPTConfig
 
 from vllm.config import set_current_vllm_config
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector import (
@@ -26,6 +28,11 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector im
     _common_group_indices_for_regions,
     _select_region_block_ids,
 )
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+)
 
 from .test_mooncake_connector import FakeMooncakeWrapper, patch_worker_dependencies
 from .utils import create_request, create_vllm_config, make_kv_cache_config
@@ -40,9 +47,24 @@ def make_transfer_worker(num_groups: int) -> MooncakeConnectorWorker:
     worker.is_kv_producer = True
     worker.tp_rank = 0
     worker.tp_size = 1
+    worker.pcp_rank = 0
+    worker.pcp_size = 1
     worker._physical_blocks_per_logical_kv_block = 1
-    worker.kv_cache_config = SimpleNamespace(
-        kv_cache_groups=[SimpleNamespace(kv_cache_spec=None) for _ in range(num_groups)]
+    worker.kv_cache_config = KVCacheConfig(
+        num_blocks=0,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                [f"model.layers.{group_index}.attn"],
+                FullAttentionSpec(
+                    block_size=16,
+                    num_kv_heads=1,
+                    head_size=16,
+                    dtype=torch.float16,
+                ),
+            )
+            for group_index in range(num_groups)
+        ],
     )
     worker.transfer_topo = SimpleNamespace(local_replicates_kv_cache=False)
     return worker
@@ -81,6 +103,39 @@ def test_sw_sizes(swa_enabled, expected_blocks_per_sw):
         kv_cache_config=kv_cache_config,
     )
     assert scheduler.blocks_per_sw == expected_blocks_per_sw
+
+
+@pytest.mark.cpu_test
+def test_sw_sizes_scale_with_pcp(tmp_path):
+    """Each scheduler block covers one physical page on every PCP rank."""
+
+    block_size = 16
+    pcp_size = 2
+    sw_size = 2048
+    model_path = tmp_path / "opt"
+    OPTConfig().save_pretrained(model_path)
+    vllm_config = create_vllm_config(
+        model=str(model_path),
+        kv_connector="MooncakeConnector",
+        kv_role="kv_both",
+        block_size=block_size,
+    )
+    vllm_config.parallel_config.prefill_context_parallel_size = pcp_size
+    vllm_config.scheduler_config.disable_hybrid_kv_cache_manager = False
+    kv_cache_config = make_kv_cache_config(
+        block_size=block_size,
+        swa_enabled=True,
+        sw_size=sw_size,
+    )
+
+    scheduler = MooncakeConnectorScheduler(
+        vllm_config=vllm_config,
+        engine_id="test-engine",
+        kv_cache_config=kv_cache_config,
+    )
+
+    assert scheduler.block_size == block_size * pcp_size
+    assert scheduler.blocks_per_sw == [0, sw_size // (block_size * pcp_size) + 1]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/v1/kv_connector/unit/test_mooncake_connector_hybrid_mamba.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector_hybrid_mamba.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 
 import pytest
 import torch
+from transformers import OPTConfig
 
 from vllm.config import set_current_vllm_config
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector import (
@@ -212,9 +213,12 @@ def test_register_kv_caches_deduplicates_shared_backing_memory(monkeypatch):
         connector.connector_worker = None
 
 
-def test_hybrid_gdn_transfer_params_preserve_group_identity(monkeypatch):
+def test_hybrid_gdn_transfer_params_preserve_group_identity(monkeypatch, tmp_path):
     monkeypatch.setenv("VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT", "5")
+    model_path = tmp_path / "opt"
+    OPTConfig().save_pretrained(model_path)
     vllm_config = create_vllm_config(
+        model=str(model_path),
         kv_connector="MooncakeConnector",
         kv_role="kv_producer",
     )

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -164,6 +164,111 @@ def get_vllm_config():
     return vllm_config
 
 
+class _FakePCPGroup:
+    def __init__(self, rank: int, other: torch.Tensor | None = None):
+        self.rank_in_group = rank
+        self.world_size = 2
+        self._other = other
+
+    def all_gather(self, tensor: torch.Tensor, dim: int = 0) -> torch.Tensor:
+        assert dim == 0
+        assert self._other is not None
+        return torch.cat([tensor, self._other], dim=dim)
+
+
+def test_apply_pcp_token_sharding_updates_runner_local_view():
+    runner = object.__new__(GPUModelRunner)
+    runner.pcp_manager = gpu_model_runner_module.PCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        max_buffer_num_tokens=64,
+        max_num_reqs=8,
+        device=torch.device("cpu"),
+    )
+    runner.arange_np = np.arange(64, dtype=np.int64)
+    runner.query_pos = SimpleNamespace(np=np.empty(64, dtype=np.int64))
+    runner.input_batch = SimpleNamespace(
+        num_computed_tokens_cpu=np.array([10, 20, 30], dtype=np.int32)
+    )
+    runner.reorder_batch_threshold = 1
+    scheduler_output = SimpleNamespace(total_num_scheduled_tokens=14)
+    scheduled = np.array([1, 5, 8], dtype=np.int32)
+
+    total, req_indices, cu_num_tokens, positions = runner._apply_pcp_token_sharding(
+        scheduler_output,
+        scheduled,
+        num_reqs=3,
+    )
+
+    assert total == 9
+    assert scheduler_output.total_num_scheduled_tokens == 9
+    np.testing.assert_array_equal(scheduled, np.array([1, 4, 4], dtype=np.int32))
+    np.testing.assert_array_equal(
+        req_indices,
+        np.array([0, 1, 1, 1, 1, 2, 2, 2, 2], dtype=np.int64),
+    )
+    np.testing.assert_array_equal(cu_num_tokens, np.array([1, 5, 9]))
+    np.testing.assert_array_equal(
+        positions,
+        np.array([10, 20, 21, 26, 27, 30, 31, 36, 37]),
+    )
+
+
+def test_update_pcp_full_seq_lens_removes_per_request_padding():
+    runner = object.__new__(GPUModelRunner)
+    runner.pcp_world_size = 2
+    runner.optimistic_seq_lens_cpu = torch.tensor([11, 24, 34, 99], dtype=torch.int32)
+    runner.input_batch = SimpleNamespace(
+        num_computed_tokens_cpu_tensor=torch.tensor([10, 20, 30, 0], dtype=torch.int32)
+    )
+    runner.pcp_manager = SimpleNamespace(
+        num_pcp_pads_cpu_tensor=torch.tensor([1, 3, 0, 0], dtype=torch.int64)
+    )
+    full_seq_lens_cpu = torch.full((4,), -1, dtype=torch.int32)
+    copied: list[int] = []
+    runner.pcp_full_seq_lens = SimpleNamespace(
+        cpu=full_seq_lens_cpu,
+        copy_to_gpu=lambda count: copied.append(count),
+    )
+
+    result = runner._update_pcp_full_seq_lens(num_reqs=3, num_reqs_padded=4)
+
+    torch.testing.assert_close(result, torch.tensor([11, 25, 38], dtype=torch.int32))
+    torch.testing.assert_close(
+        full_seq_lens_cpu,
+        torch.tensor([11, 25, 38, 0], dtype=torch.int32),
+    )
+    assert copied == [4]
+
+
+def test_restore_pcp_hidden_states_for_logits(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    runner = object.__new__(GPUModelRunner)
+    local = torch.tensor([[10.0], [11.0]])
+
+    runner.pcp_world_size = 1
+    assert runner._maybe_restore_pcp_hidden_states_for_logits(local, 2) is local
+
+    restore_idx = torch.tensor([0, 2, 3, 1], dtype=torch.int64)
+    runner.pcp_world_size = 2
+    runner.pcp_manager = SimpleNamespace(
+        pcp_allgather_restore_idx=SimpleNamespace(gpu=restore_idx)
+    )
+    pcp_group = _FakePCPGroup(
+        rank=0,
+        other=torch.tensor([[20.0], [21.0]]),
+    )
+    monkeypatch.setattr(gpu_model_runner_module, "get_pcp_group", lambda: pcp_group)
+
+    restored = runner._maybe_restore_pcp_hidden_states_for_logits(local, 2)
+
+    torch.testing.assert_close(
+        restored,
+        torch.tensor([[10.0], [20.0], [21.0], [11.0]]),
+    )
+
+
 @pytest.fixture
 def model_runner():
     vllm_config = get_vllm_config()

--- a/tests/v1/worker/test_mixed_warmup_gate.py
+++ b/tests/v1/worker/test_mixed_warmup_gate.py
@@ -8,6 +8,9 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from vllm.model_executor.warmup.flashinfer_sparse_mla_warmup import (
+    deepseek_v4_sparse_mla_attention_warmup,
+)
 from vllm.v1.worker.gpu.warmup import run_mixed_prefill_decode_warmup, warmup_kernels
 
 
@@ -231,3 +234,25 @@ def test_warmup_kernels_skips_parallel_draft_full_k_for_unrelated_method(monkeyp
     assert sample_calls[0] is not None
     assert sample_calls[1] is None
     assert all(call.total_num_scheduled_tokens != 1 for call in execute_calls)
+
+
+def test_deepseek_v4_mixed_warmup_skipped_for_pcp():
+    class _Backend:
+        @staticmethod
+        def get_name():
+            return "DEEPSEEK_SPARSE_SWA"
+
+    runner = SimpleNamespace(
+        is_pooling_model=False,
+        attn_groups=[[SimpleNamespace(backend=_Backend())]],
+        vllm_config=SimpleNamespace(
+            parallel_config=SimpleNamespace(prefill_context_parallel_size=2)
+        ),
+        _dummy_run=_fail,
+    )
+    worker = SimpleNamespace(
+        model_runner=runner,
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=32768),
+    )
+
+    assert deepseek_v4_sparse_mla_attention_warmup(worker) is None

--- a/tests/v1/worker/test_pcp_interleave_metadata.py
+++ b/tests/v1/worker/test_pcp_interleave_metadata.py
@@ -1,0 +1,616 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+import vllm.models.deepseek_v4.attention as attention_module
+import vllm.models.deepseek_v4.nvidia.flashmla as flashmla_module
+from vllm.models.deepseek_v4.attention import DeepseekV4Attention
+from vllm.models.deepseek_v4.compressor import CompressorMetadataBuilder
+from vllm.models.deepseek_v4.nvidia.flashmla import DeepseekV4FlashMLAAttention
+from vllm.models.deepseek_v4.pcp_metadata import DeepseekV4PcpPrefillMetadata
+from vllm.models.deepseek_v4.sparse_mla import DeepseekV4FlashMLAMetadata
+from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.attention.backends.mla.sparse_swa import (
+    DeepseekSparseSWAMetadata,
+    DeepseekSparseSWAMetadataBuilder,
+)
+from vllm.v1.worker.cp_utils import (
+    PCPManager,
+    build_pcp_interleave_request_views,
+)
+
+
+def test_flashmla_declares_pcp_support():
+    assert DeepseekV4FlashMLAAttention.supports_pcp
+
+
+def test_common_attention_metadata_unpadded_preserves_pcp_batch_view():
+    request_views = [object(), object(), object()]
+    restore_idx = torch.tensor([0, 2, 3, 1], dtype=torch.int64)
+    metadata = CommonAttentionMetadata(
+        query_start_loc=torch.tensor([0, 2, 4, 6], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 2, 4, 6], dtype=torch.int32),
+        seq_lens=torch.tensor([12, 24, 36], dtype=torch.int32),
+        num_reqs=3,
+        num_actual_tokens=6,
+        max_query_len=2,
+        max_seq_len=36,
+        block_table_tensor=torch.arange(12).reshape(3, 4),
+        slot_mapping=torch.arange(6),
+        pcp_allgather_restore_idx=restore_idx,
+        pcp_full_seq_lens=torch.tensor([12, 24, 36], dtype=torch.int32),
+        pcp_full_seq_lens_cpu=torch.tensor([12, 24, 36], dtype=torch.int32),
+        pcp_request_views=request_views,
+        positions=torch.arange(6),
+    )
+
+    unpadded = metadata.unpadded(num_actual_tokens=4, num_actual_reqs=2)
+
+    assert unpadded.pcp_allgather_restore_idx is restore_idx
+    torch.testing.assert_close(
+        unpadded.pcp_full_seq_lens, torch.tensor([12, 24], dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        unpadded.pcp_full_seq_lens_cpu,
+        torch.tensor([12, 24], dtype=torch.int32),
+    )
+    assert unpadded.pcp_request_views == request_views[:2]
+    torch.testing.assert_close(unpadded.positions, torch.arange(4))
+
+
+def test_pcp_request_views_follow_dual_chunk_manager_layout():
+    manager = PCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        max_buffer_num_tokens=64,
+        max_num_reqs=8,
+        device=torch.device("cpu"),
+    )
+
+    pcp_tokens, _ = manager.update_tokens_for_pcp(
+        np.array([1, 5, 8], dtype=np.int32),
+        np.arange(64, dtype=np.int32),
+        num_reqs=3,
+        reorder_batch_threshold=1,
+    )
+
+    assert pcp_tokens.tolist() == [1, 4, 4]
+    views = manager.pcp_request_views
+    assert [view.req_idx for view in views] == [0, 1, 2]
+    assert [view.global_seq_len for view in views] == [1, 5, 8]
+    assert [view.local_token_count for view in views] == [1, 2, 4]
+    assert [(view.local_query_start, view.local_query_end) for view in views] == [
+        (0, 1),
+        (1, 3),
+        (3, 7),
+    ]
+    torch.testing.assert_close(views[0].global_positions, torch.tensor([0]))
+    torch.testing.assert_close(views[1].global_positions, torch.tensor([0, 1]))
+    torch.testing.assert_close(views[2].global_positions, torch.tensor([0, 1, 6, 7]))
+    torch.testing.assert_close(views[1].global_slot_mapping, torch.tensor([1, 2]))
+    torch.testing.assert_close(
+        views[2].global_slot_mapping, torch.tensor([6, 7, 12, 13])
+    )
+    assert [view.restore_idx.numel() for view in views] == [2, 8, 8]
+    assert [(view.local_kv_base, view.local_kv_len) for view in views] == [
+        (0, 1),
+        (1, 2),
+        (3, 4),
+    ]
+
+
+def test_build_pcp_request_views_preserves_explicit_global_slot_identity():
+    views = build_pcp_interleave_request_views(
+        original_token_counts=torch.tensor([4, 4]),
+        local_token_counts=torch.tensor([2, 2]),
+        local_positions=torch.tensor([0, 3, 1, 2]),
+        restore_idx=torch.tensor([0, 2, 3, 1, 4, 6, 7, 5]),
+        pcp_world_size=2,
+        global_slot_mapping=torch.tensor([10, 11, 12, 13, 20, 21, 22, 23]),
+    )
+
+    assert len(views) == 2
+    torch.testing.assert_close(views[0].global_positions, torch.tensor([0, 3]))
+    torch.testing.assert_close(views[0].global_slot_mapping, torch.tensor([10, 13]))
+    torch.testing.assert_close(views[0].restore_idx, torch.tensor([0, 2, 3, 1]))
+    torch.testing.assert_close(views[1].global_positions, torch.tensor([1, 2]))
+    torch.testing.assert_close(views[1].global_slot_mapping, torch.tensor([21, 22]))
+    torch.testing.assert_close(views[1].restore_idx, torch.tensor([4, 6, 7, 5]))
+
+
+def test_pcp_manager_uses_distinct_slot_mapping_buffers_per_kv_group():
+    manager = PCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        max_buffer_num_tokens=16,
+        max_num_reqs=4,
+        device=torch.device("cpu"),
+    )
+
+    gid0_slots = manager.get_pcp_padded_slot_mapping(0)
+    gid1_slots = manager.get_pcp_padded_slot_mapping(1)
+
+    assert gid0_slots.data_ptr() != gid1_slots.data_ptr()
+    gid0_slots[:4] = torch.tensor([0, 1, 2, 3])
+    gid1_slots[:4] = torch.tensor([10, 11, 12, 13])
+    torch.testing.assert_close(gid0_slots[:4], torch.tensor([0, 1, 2, 3]))
+    torch.testing.assert_close(gid1_slots[:4], torch.tensor([10, 11, 12, 13]))
+    assert manager.get_pcp_padded_slot_mapping(1).data_ptr() == gid1_slots.data_ptr()
+
+
+def test_pcp_manager_builds_full_query_start_for_restored_tokens():
+    manager = PCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        max_buffer_num_tokens=64,
+        max_num_reqs=8,
+        device=torch.device("cpu"),
+    )
+
+    pcp_tokens, _ = manager.update_tokens_for_pcp(
+        np.array([1, 5, 8], dtype=np.int32),
+        np.arange(64, dtype=np.int32),
+        num_reqs=3,
+        reorder_batch_threshold=1,
+    )
+
+    assert pcp_tokens.tolist() == [1, 4, 4]
+    torch.testing.assert_close(
+        manager.pcp_padded_query_start_loc.cpu[:4],
+        torch.tensor([0, 2, 10, 18], dtype=torch.int32),
+    )
+
+
+def test_pcp_194_local_tokens_restore_to_388_full_tokens():
+    manager = PCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        max_buffer_num_tokens=512,
+        max_num_reqs=1,
+        device=torch.device("cpu"),
+    )
+
+    pcp_tokens, pcp_positions = manager.update_tokens_for_pcp(
+        np.array([388], dtype=np.int32),
+        np.arange(512, dtype=np.int32),
+        num_reqs=1,
+        reorder_batch_threshold=1,
+    )
+
+    assert pcp_tokens.tolist() == [194]
+    assert pcp_positions[:194].tolist() == list(range(97)) + list(range(291, 388))
+    assert manager.pcp_allgather_restore_idx.cpu[:388].numel() == 388
+    assert manager.pcp_local_unpad_mask_cpu_tensor[:194].all()
+
+    views = manager.pcp_request_views
+    assert len(views) == 1
+    assert views[0].global_seq_len == 388
+    assert views[0].local_token_count == 194
+    assert views[0].local_query_start == 0
+    assert views[0].local_query_end == 194
+    torch.testing.assert_close(
+        views[0].global_positions,
+        torch.tensor(list(range(97)) + list(range(291, 388))),
+    )
+
+
+def test_sparse_swa_builder_creates_global_prefill_pcp_view():
+    manager = PCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        max_buffer_num_tokens=64,
+        max_num_reqs=4,
+        device=torch.device("cpu"),
+    )
+    local_counts, local_positions = manager.update_tokens_for_pcp(
+        np.array([8], dtype=np.int32),
+        np.arange(64, dtype=np.int32),
+        num_reqs=1,
+        reorder_batch_threshold=1,
+    )
+    assert local_counts.tolist() == [4]
+
+    builder = object.__new__(DeepseekSparseSWAMetadataBuilder)
+    builder.window_size = 4
+    builder.max_model_len = 128
+    builder.max_num_batched_tokens = 64
+    builder.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(prefill_context_parallel_size=2)
+    )
+    slot_mapping = torch.tensor([10, 11, 16, 17], dtype=torch.int64)
+    restore_idx = manager.pcp_allgather_restore_idx.cpu[:8]
+
+    fields = builder._build_deepseek_v4_metadata(
+        num_decodes=0,
+        num_prefills=1,
+        seq_lens=torch.tensor([8], dtype=torch.int32),
+        seq_lens_cpu=torch.tensor([8], dtype=torch.int32),
+        query_start_loc=torch.tensor([0, 4], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 4], dtype=torch.int32),
+        slot_mapping=slot_mapping,
+        positions=torch.from_numpy(local_positions[:4].copy()),
+        pcp_allgather_restore_idx=restore_idx,
+        pcp_request_views=manager.pcp_request_views,
+        pcp_enabled=True,
+    )
+
+    torch.testing.assert_close(
+        fields["prefill_seq_lens"], torch.tensor([8], dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        fields["prefill_gather_lens"], torch.tensor([8], dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        fields["prefill_query_lens_cpu"], torch.tensor([4], dtype=torch.int32)
+    )
+    pcp_metadata = fields["pcp_prefill_metadata"]
+    assert pcp_metadata.cp_size == 2
+    assert pcp_metadata.cp_rank == 0
+    torch.testing.assert_close(
+        pcp_metadata.local_query_start_loc,
+        torch.tensor([0, 4], dtype=torch.int32),
+    )
+    assert pcp_metadata.views is manager.pcp_request_views
+    assert pcp_metadata.restore_idx is restore_idx
+    assert pcp_metadata.global_slot_mapping is slot_mapping
+
+
+def _make_pcp_common_metadata(
+    manager: PCPManager,
+) -> CommonAttentionMetadata:
+    return CommonAttentionMetadata(
+        query_start_loc=torch.tensor([0, 4], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 4], dtype=torch.int32),
+        seq_lens=torch.tensor([4], dtype=torch.int32),
+        num_reqs=1,
+        num_actual_tokens=4,
+        max_query_len=4,
+        max_seq_len=8,
+        block_table_tensor=torch.tensor([[3, 4]], dtype=torch.int32),
+        slot_mapping=torch.tensor([10, 11, 16, 17], dtype=torch.int64),
+        pcp_allgather_restore_idx=manager.pcp_allgather_restore_idx.cpu[:8],
+        pcp_full_seq_lens=torch.tensor([8], dtype=torch.int32),
+        pcp_full_seq_lens_cpu=torch.tensor([8], dtype=torch.int32),
+        pcp_request_views=manager.pcp_request_views,
+    )
+
+
+def test_compressor_builder_expands_request_indices_for_restored_pcp_rows(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "vllm.models.deepseek_v4.compressor.np_to_pinned_tensor",
+        torch.from_numpy,
+    )
+    manager = PCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        max_buffer_num_tokens=64,
+        max_num_reqs=4,
+        device=torch.device("cpu"),
+    )
+    manager.update_tokens_for_pcp(
+        np.array([8], dtype=np.int32),
+        np.arange(64, dtype=np.int32),
+        num_reqs=1,
+        reorder_batch_threshold=1,
+    )
+    common = _make_pcp_common_metadata(manager)
+    builder = object.__new__(CompressorMetadataBuilder)
+    builder.pcp_world_size = 2
+    builder.block_size = 4
+    builder.token_to_req_indices = torch.full((64,), -1, dtype=torch.int32)
+
+    metadata = builder.build(0, common)
+
+    assert metadata.pcp_allgather_restore_idx is common.pcp_allgather_restore_idx
+    assert metadata.pcp_request_views is common.pcp_request_views
+    torch.testing.assert_close(
+        metadata.token_to_req_indices,
+        torch.zeros(8, dtype=torch.int32),
+    )
+
+
+class _TestDeepseekV4Attention(DeepseekV4Attention):
+    @classmethod
+    def get_padded_num_q_heads(cls, num_heads: int) -> int:
+        return num_heads
+
+    def forward_mqa(self, q, kv, positions, out) -> None:
+        raise NotImplementedError
+
+    def _o_proj(self, o, positions):
+        raise NotImplementedError
+
+
+class _AttentionPCPGroup:
+    world_size = 2
+    rank_in_group = 0
+
+    def all_gather(self, tensor: torch.Tensor, dim: int = 0) -> torch.Tensor:
+        assert dim == 0
+        if tensor.ndim == 3:
+            other = torch.full_like(tensor, 0)
+            other[0].fill_(11)
+            other[1].fill_(12)
+        elif tensor.ndim == 2:
+            other = torch.full_like(tensor, 0)
+            other[0].fill_(21)
+            other[1].fill_(22)
+        else:
+            other = torch.tensor([1, 2], dtype=tensor.dtype)
+        return torch.cat([tensor, other], dim=dim)
+
+
+def test_attention_pcp_restores_global_swa_slots_and_returns_local_queries(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    manager = PCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        max_buffer_num_tokens=16,
+        max_num_reqs=1,
+        device=torch.device("cpu"),
+    )
+    _, local_positions = manager.update_tokens_for_pcp(
+        np.array([4], dtype=np.int32),
+        np.arange(16, dtype=np.int32),
+        num_reqs=1,
+        reorder_batch_threshold=1,
+    )
+    restore_idx = manager.pcp_allgather_restore_idx.cpu[:4]
+    pcp_metadata = DeepseekV4PcpPrefillMetadata(
+        cp_size=2,
+        cp_rank=0,
+        strategy="dual_chunk",
+        views=manager.pcp_request_views,
+        local_query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+        local_seq_lens=torch.tensor([2], dtype=torch.int32),
+        local_swa_indices=None,
+        local_swa_valid_lens=None,
+        local_c4_indices=None,
+        local_c128_indices=None,
+        global_slot_mapping=torch.tensor([4, 7], dtype=torch.int64),
+        compressor_write_locs_global=None,
+        restore_idx=restore_idx,
+        debug_global_positions=torch.from_numpy(local_positions[:2].copy()),
+    )
+    swa_metadata = DeepseekSparseSWAMetadata(
+        block_table=torch.tensor([[1]], dtype=torch.int32),
+        slot_mapping=torch.tensor([4, 7], dtype=torch.int64),
+        block_size=4,
+        pcp_allgather_restore_idx=restore_idx,
+        pcp_prefill_metadata=pcp_metadata,
+    )
+
+    attention = object.__new__(_TestDeepseekV4Attention)
+    object.__setattr__(attention, "pcp_world_size", 2)
+    object.__setattr__(attention, "pcp_rank", 0)
+    object.__setattr__(attention, "cp_kv_cache_interleave_size", 1)
+    object.__setattr__(attention, "n_local_heads", 1)
+    object.__setattr__(attention, "padded_heads", 1)
+    object.__setattr__(attention, "head_dim", 512)
+    object.__setattr__(attention, "eps", 1e-6)
+    object.__setattr__(
+        attention,
+        "swa_cache_layer",
+        SimpleNamespace(
+            prefix="swa",
+            block_size=4,
+            kv_cache=torch.zeros((2, 4, 512), dtype=torch.bfloat16),
+        ),
+    )
+    object.__setattr__(
+        attention,
+        "rotary_emb",
+        SimpleNamespace(cos_sin_cache=torch.zeros((8, 64))),
+    )
+
+    captured = {}
+
+    def fake_bf16_insert(q, kv, cache, slots, positions, *args):
+        captured["q"] = q.clone()
+        captured["kv"] = kv.clone()
+        captured["slots"] = slots.clone()
+        captured["positions"] = positions.clone()
+        q.add_(100)
+
+    monkeypatch.setattr(
+        attention_module,
+        "get_pcp_group",
+        lambda: _AttentionPCPGroup(),
+    )
+    monkeypatch.setattr(
+        torch.ops._C,
+        "fused_deepseek_v4_qnorm_rope_kv_rope_full_cache_bf16_insert",
+        fake_bf16_insert,
+        raising=False,
+    )
+
+    q = torch.empty((2, 1, 512), dtype=torch.bfloat16)
+    q[0].fill_(10)
+    q[1].fill_(13)
+    kv = torch.empty((2, 512), dtype=torch.bfloat16)
+    kv[0].fill_(20)
+    kv[1].fill_(23)
+    result = attention._fused_qnorm_rope_kv_insert(
+        q,
+        kv,
+        torch.from_numpy(local_positions[:2].copy()).to(torch.int64),
+        {"swa": swa_metadata},
+    )
+
+    torch.testing.assert_close(
+        captured["q"][:, 0, 0],
+        torch.tensor([10, 11, 12, 13], dtype=torch.bfloat16),
+    )
+    torch.testing.assert_close(
+        captured["kv"][:, 0],
+        torch.tensor([20, 21, 22, 23], dtype=torch.bfloat16),
+    )
+    torch.testing.assert_close(captured["positions"], torch.arange(4))
+    torch.testing.assert_close(captured["slots"], torch.tensor([4, -1, 5, -1]))
+    torch.testing.assert_close(
+        result[:, 0, 0],
+        torch.tensor([110, 113], dtype=torch.bfloat16),
+    )
+    torch.testing.assert_close(pcp_metadata.restored_swa_positions, torch.arange(4))
+    assert pcp_metadata.restored_swa_valid_mask is not None
+    assert pcp_metadata.restored_swa_valid_mask.all()
+
+
+class _TestWorkspaceManager:
+    def get_simultaneous(self, *specs):
+        return [torch.empty(shape, dtype=dtype) for shape, dtype in specs]
+
+
+def test_flashmla_prefill_compacts_queries_and_uses_global_kv_rows(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    pcp_metadata = DeepseekV4PcpPrefillMetadata(
+        cp_size=2,
+        cp_rank=0,
+        strategy="dual_chunk",
+        views=[SimpleNamespace(restore_idx=torch.arange(4))],
+        local_query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+        local_seq_lens=torch.tensor([2], dtype=torch.int32),
+        local_swa_indices=None,
+        local_swa_valid_lens=None,
+        local_c4_indices=None,
+        local_c128_indices=None,
+        global_slot_mapping=torch.tensor([4, 7]),
+        compressor_write_locs_global=None,
+        restore_idx=torch.tensor([0, 2, 3, 1]),
+        debug_global_positions=torch.tensor([0, 3]),
+        restored_swa_kv=torch.tensor(
+            [[20.0, 20.0], [21.0, 21.0], [22.0, 22.0], [23.0, 23.0]],
+            dtype=torch.bfloat16,
+        ),
+        restored_swa_positions=torch.arange(4),
+        restored_swa_valid_mask=torch.ones(4, dtype=torch.bool),
+    )
+    swa_metadata = DeepseekSparseSWAMetadata(
+        block_table=torch.tensor([[0]], dtype=torch.int32),
+        slot_mapping=torch.tensor([0, 3]),
+        block_size=4,
+        query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 2], dtype=torch.int32),
+        num_prefills=1,
+        num_prefill_tokens=2,
+        prefill_seq_lens=torch.tensor([4], dtype=torch.int32),
+        prefill_seq_lens_cpu=torch.tensor([4], dtype=torch.int32),
+        prefill_gather_lens=torch.tensor([4], dtype=torch.int32),
+        prefill_gather_lens_cpu=torch.tensor([4], dtype=torch.int32),
+        prefill_query_lens_cpu=torch.tensor([2], dtype=torch.int32),
+        prefill_window_size=4,
+        prefill_max_model_len=4,
+        prefill_max_num_batched_tokens=4,
+        pcp_allgather_restore_idx=torch.tensor([0, 2, 3, 1]),
+        pcp_prefill_metadata=pcp_metadata,
+    )
+    attn_metadata = DeepseekV4FlashMLAMetadata(
+        num_reqs=1,
+        max_query_len=2,
+        max_seq_len=4,
+        num_actual_tokens=2,
+        query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+        slot_mapping=torch.tensor([0, 0]),
+        block_table=torch.tensor([[0]], dtype=torch.int32),
+        req_id_per_token=torch.tensor([0, 0], dtype=torch.int32),
+        block_size=4,
+        topk_tokens=1,
+    )
+
+    attention = object.__new__(DeepseekV4FlashMLAAttention)
+    object.__setattr__(attention, "compress_ratio", 4)
+    object.__setattr__(attention, "window_size", 4)
+    object.__setattr__(attention, "PREFILL_CHUNK_SIZE", 4)
+    object.__setattr__(attention, "scale", 1.0)
+    object.__setattr__(attention, "attn_sink", None)
+    object.__setattr__(
+        attention,
+        "topk_indices_buffer",
+        torch.tensor([[0], [0]], dtype=torch.int32),
+    )
+
+    captured = {}
+
+    def fake_gather(out, *args, offset, **kwargs):
+        out.fill_(-1)
+        captured.setdefault("gather_offsets", []).append(offset)
+
+    def fake_combine(
+        topk_indices,
+        query_positions,
+        query_start_loc,
+        seq_lens,
+        gather_lens,
+        *args,
+    ):
+        captured["query_positions"] = query_positions.clone()
+        captured["query_start_loc"] = query_start_loc.clone()
+        return (
+            torch.tensor([[0, -1], [3, -1]], dtype=torch.int32),
+            torch.tensor([1, 1], dtype=torch.int32),
+        )
+
+    def fake_sparse_fwd(*, q, kv, indices, topk_length, out, **kwargs):
+        captured["kernel_q"] = q.clone()
+        captured["kernel_kv"] = kv.clone()
+        captured["kernel_indices"] = indices.clone()
+        captured["kernel_lens"] = topk_length.clone()
+        out.copy_(q)
+
+    monkeypatch.setattr(
+        flashmla_module, "current_workspace_manager", lambda: _TestWorkspaceManager()
+    )
+    monkeypatch.setattr(flashmla_module, "dequantize_and_gather_k_cache", fake_gather)
+    monkeypatch.setattr(
+        flashmla_module,
+        "combine_topk_swa_indices_with_positions",
+        fake_combine,
+    )
+    monkeypatch.setattr(flashmla_module, "flash_mla_sparse_fwd", fake_sparse_fwd)
+
+    q = torch.tensor([[[10.0, 10.0]], [[13.0, 13.0]]])
+    output = torch.empty_like(q)
+    attention._forward_prefill(
+        q=q,
+        positions=torch.tensor([0, 3]),
+        compressed_k_cache=torch.zeros((1, 1, 2), dtype=torch.uint8),
+        swa_k_cache=torch.zeros((1, 4, 2), dtype=torch.uint8),
+        output=output,
+        attn_metadata=attn_metadata,
+        swa_metadata=swa_metadata,
+    )
+
+    torch.testing.assert_close(captured["query_positions"], torch.tensor([0, 3]))
+    torch.testing.assert_close(
+        captured["query_start_loc"], torch.tensor([0, 2], dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        captured["kernel_q"][:, 0, 0],
+        torch.tensor([10.0, 13.0]),
+    )
+    torch.testing.assert_close(
+        captured["kernel_indices"][:, 0, 0],
+        torch.tensor([0, 3], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        captured["kernel_lens"],
+        torch.tensor([1, 1], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        captured["kernel_kv"][:1, 0, 0],
+        torch.tensor([-1.0], dtype=torch.bfloat16),
+    )
+    torch.testing.assert_close(
+        captured["kernel_kv"][1:5, 0, 0],
+        torch.tensor([20.0, 21.0, 22.0, 23.0], dtype=torch.bfloat16),
+    )
+    torch.testing.assert_close(output[:, 0, 0], torch.tensor([10.0, 13.0]))

--- a/tests/v1/worker/test_pcp_interleave_metadata.py
+++ b/tests/v1/worker/test_pcp_interleave_metadata.py
@@ -10,12 +10,17 @@ import torch
 import vllm.models.deepseek_v4.attention as attention_module
 import vllm.models.deepseek_v4.nvidia.flashmla as flashmla_module
 from vllm.models.deepseek_v4.attention import DeepseekV4Attention
-from vllm.models.deepseek_v4.compressor import CompressorMetadataBuilder
+from vllm.models.deepseek_v4.compressor import (
+    CompressorBackend,
+    CompressorMetadataBuilder,
+)
 from vllm.models.deepseek_v4.nvidia.flashmla import DeepseekV4FlashMLAAttention
 from vllm.models.deepseek_v4.pcp_metadata import DeepseekV4PcpPrefillMetadata
 from vllm.models.deepseek_v4.sparse_mla import DeepseekV4FlashMLAMetadata
 from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.attention.backends.mla.indexer import DeepseekV32IndexerBackend
 from vllm.v1.attention.backends.mla.sparse_swa import (
+    DeepseekSparseSWABackend,
     DeepseekSparseSWAMetadata,
     DeepseekSparseSWAMetadataBuilder,
 )
@@ -27,6 +32,12 @@ from vllm.v1.worker.cp_utils import (
 
 def test_flashmla_declares_pcp_support():
     assert DeepseekV4FlashMLAAttention.supports_pcp
+
+
+def test_deepseek_v4_hybrid_backends_declare_pcp_support():
+    assert CompressorBackend.supports_pcp()
+    assert DeepseekV32IndexerBackend.supports_pcp()
+    assert DeepseekSparseSWABackend.supports_pcp()
 
 
 def test_common_attention_metadata_unpadded_preserves_pcp_batch_view():

--- a/tests/v1/worker/test_pcp_interleave_metadata.py
+++ b/tests/v1/worker/test_pcp_interleave_metadata.py
@@ -16,7 +16,10 @@ from vllm.models.deepseek_v4.compressor import (
 )
 from vllm.models.deepseek_v4.nvidia.flashmla import DeepseekV4FlashMLAAttention
 from vllm.models.deepseek_v4.pcp_metadata import DeepseekV4PcpPrefillMetadata
-from vllm.models.deepseek_v4.sparse_mla import DeepseekV4FlashMLAMetadata
+from vllm.models.deepseek_v4.sparse_mla import (
+    DeepseekV4FlashMLABackend,
+    DeepseekV4FlashMLAMetadata,
+)
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.mla.indexer import DeepseekV32IndexerBackend
 from vllm.v1.attention.backends.mla.sparse_swa import (
@@ -38,6 +41,7 @@ def test_deepseek_v4_hybrid_backends_declare_pcp_support():
     assert CompressorBackend.supports_pcp()
     assert DeepseekV32IndexerBackend.supports_pcp()
     assert DeepseekSparseSWABackend.supports_pcp()
+    assert DeepseekV4FlashMLABackend.supports_pcp()
 
 
 def test_common_attention_metadata_unpadded_preserves_pcp_batch_view():

--- a/tests/v1/worker/test_pcp_utils.py
+++ b/tests/v1/worker/test_pcp_utils.py
@@ -1,0 +1,421 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.config import ParallelConfig
+from vllm.v1.attention.backends.utils import (
+    get_cp_local_seq_lens,
+    get_dcp_local_seq_lens,
+    get_pcp_kv_indices,
+    get_pcp_local_indices_after_restore,
+    get_pcp_max_buffer_num_tokens,
+    get_pcp_num_local_tokens_from_restore_idx,
+    get_pcp_query_indices,
+    pcp_allgather_and_restore,
+    pcp_kv_allgather_and_restore,
+    restore_pcp_local_tensor_to_padded_tokens,
+)
+from vllm.v1.worker.cp_utils import (
+    DSV4_PCP_PREFILL_UNSUPPORTED_ERROR,
+    PCPManager,
+    guard_dsv4_pcp_prefill_runtime_metadata,
+)
+
+
+def test_pcp_manager_dual_chunk_swap_positions_rank0():
+    manager = PCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        max_buffer_num_tokens=64,
+        max_num_reqs=8,
+        device=torch.device("cpu"),
+    )
+    tokens = np.array([1, 5, 8], dtype=np.int32)
+    arange_np = np.arange(64, dtype=np.int32)
+
+    pcp_tokens, positions = manager.update_tokens_for_pcp(
+        tokens,
+        arange_np,
+        num_reqs=3,
+        reorder_batch_threshold=1,
+    )
+
+    np.testing.assert_array_equal(pcp_tokens, np.array([1, 4, 4], dtype=np.int32))
+    np.testing.assert_array_equal(
+        positions, np.array([0, 0, 1, 6, 7, 0, 1, 6, 7], dtype=np.int32)
+    )
+    np.testing.assert_array_equal(
+        manager.num_pcp_pads_cpu[:3], np.array([1, 3, 0], dtype=np.int64)
+    )
+    np.testing.assert_array_equal(
+        manager.pcp_unpad_mask_cpu[:18],
+        np.array(
+            [
+                True,
+                False,
+                True,
+                True,
+                True,
+                True,
+                True,
+                False,
+                False,
+                False,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+            ],
+            dtype=np.bool_,
+        ),
+    )
+    np.testing.assert_array_equal(
+        manager.pcp_local_unpad_mask_cpu[:9],
+        np.array(
+            [
+                True,
+                True,
+                True,
+                False,
+                False,
+                True,
+                True,
+                True,
+                True,
+            ],
+            dtype=np.bool_,
+        ),
+    )
+    np.testing.assert_array_equal(
+        manager.pcp_local_token_indices_cpu[:9],
+        np.array([0, 1, 2, 0, 0, 6, 7, 12, 13], dtype=np.int64),
+    )
+    np.testing.assert_array_equal(
+        manager.pcp_allgather_restore_idx.cpu[:18].numpy(),
+        np.array([0, 9, 1, 2, 10, 11, 12, 13, 3, 4, 5, 6, 14, 15, 16, 17, 7, 8]),
+    )
+
+
+def test_pcp_manager_dual_chunk_swap_positions_rank1():
+    manager = PCPManager(
+        pcp_world_size=2,
+        pcp_rank=1,
+        max_buffer_num_tokens=64,
+        max_num_reqs=8,
+        device=torch.device("cpu"),
+    )
+    tokens = np.array([1, 5, 8], dtype=np.int32)
+    arange_np = np.arange(64, dtype=np.int32)
+
+    pcp_tokens, positions = manager.update_tokens_for_pcp(
+        tokens,
+        arange_np,
+        num_reqs=3,
+        reorder_batch_threshold=1,
+    )
+
+    np.testing.assert_array_equal(pcp_tokens, np.array([1, 4, 4], dtype=np.int32))
+    np.testing.assert_array_equal(
+        positions, np.array([0, 2, 3, 4, 5, 2, 3, 4, 5], dtype=np.int32)
+    )
+    np.testing.assert_array_equal(
+        manager.pcp_local_unpad_mask_cpu[:9],
+        np.array(
+            [
+                True,
+                True,
+                True,
+                True,
+                False,
+                True,
+                True,
+                True,
+                True,
+            ],
+            dtype=np.bool_,
+        ),
+    )
+    np.testing.assert_array_equal(
+        manager.pcp_local_token_indices_cpu[:9],
+        np.array([0, 3, 4, 5, 0, 8, 9, 10, 11], dtype=np.int64),
+    )
+
+
+def test_pcp_restore_idx_length_uses_local_total_for_odd_request():
+    manager = PCPManager(
+        pcp_world_size=2,
+        pcp_rank=1,
+        max_buffer_num_tokens=64,
+        max_num_reqs=8,
+        device=torch.device("cpu"),
+    )
+    tokens = np.array([9], dtype=np.int32)
+    arange_np = np.arange(64, dtype=np.int32)
+
+    pcp_tokens, positions = manager.update_tokens_for_pcp(
+        tokens,
+        arange_np,
+        num_reqs=1,
+        reorder_batch_threshold=1,
+    )
+
+    original_total = int(tokens.sum())
+    local_total = int(pcp_tokens.sum())
+    assert original_total == 9
+    assert local_total == 6
+    assert positions.tolist() == [3, 4, 5, 6, 7, 8]
+
+    restore_len = local_total * manager.pcp_world_size
+    restore_idx = manager.pcp_allgather_restore_idx.cpu[:restore_len]
+    assert restore_len == 12
+    assert int(restore_idx.max()) < restore_len
+
+
+def test_pcp_restore_idx_derives_actual_local_tokens_with_padding():
+    manager = PCPManager(
+        pcp_world_size=2,
+        pcp_rank=1,
+        max_buffer_num_tokens=64,
+        max_num_reqs=8,
+        device=torch.device("cpu"),
+    )
+    tokens = np.array([11], dtype=np.int32)
+    arange_np = np.arange(64, dtype=np.int32)
+
+    pcp_tokens, _ = manager.update_tokens_for_pcp(
+        tokens,
+        arange_np,
+        num_reqs=1,
+        reorder_batch_threshold=1,
+    )
+
+    actual_local_tokens = int(pcp_tokens.sum())
+    padded_local_tokens = 8
+    restore_idx = manager.pcp_allgather_restore_idx.cpu[
+        : actual_local_tokens * manager.pcp_world_size
+    ]
+
+    assert actual_local_tokens == 6
+    assert padded_local_tokens > actual_local_tokens
+    assert (
+        get_pcp_num_local_tokens_from_restore_idx(
+            restore_idx,
+            manager.pcp_world_size,
+        )
+        == actual_local_tokens
+    )
+
+    local_indices = get_pcp_local_indices_after_restore(
+        num_local_tokens=actual_local_tokens,
+        pcp_rank=manager.pcp_rank,
+        pcp_allgather_restore_idx=restore_idx,
+    )
+    assert local_indices.numel() == actual_local_tokens
+    assert int(local_indices.max()) < restore_idx.numel()
+
+
+def test_pcp_local_restore_preserves_padded_token_shape():
+    manager = PCPManager(
+        pcp_world_size=2,
+        pcp_rank=1,
+        max_buffer_num_tokens=64,
+        max_num_reqs=8,
+        device=torch.device("cpu"),
+    )
+    tokens = np.array([11], dtype=np.int32)
+    arange_np = np.arange(64, dtype=np.int32)
+
+    pcp_tokens, _ = manager.update_tokens_for_pcp(
+        tokens,
+        arange_np,
+        num_reqs=1,
+        reorder_batch_threshold=1,
+    )
+
+    actual_local_tokens = int(pcp_tokens.sum())
+    padded_local_tokens = 8
+    restore_idx = manager.pcp_allgather_restore_idx.cpu[
+        : actual_local_tokens * manager.pcp_world_size
+    ]
+    local_indices = get_pcp_local_indices_after_restore(
+        num_local_tokens=actual_local_tokens,
+        pcp_rank=manager.pcp_rank,
+        pcp_allgather_restore_idx=restore_idx,
+    )
+    restored = torch.arange(restore_idx.numel() * 2).reshape(restore_idx.numel(), 2)
+
+    local_padded = restore_pcp_local_tensor_to_padded_tokens(
+        restored,
+        local_indices,
+        padded_local_tokens,
+    )
+
+    assert local_padded.shape == (padded_local_tokens, 2)
+    torch.testing.assert_close(
+        local_padded[:actual_local_tokens],
+        torch.index_select(restored, 0, local_indices),
+    )
+    torch.testing.assert_close(
+        local_padded[actual_local_tokens:],
+        torch.zeros(padded_local_tokens - actual_local_tokens, 2, dtype=torch.int64),
+    )
+
+
+def test_get_cp_local_seq_lens_preserves_dcp_helper_behavior():
+    seq_lens = torch.tensor([1, 5, 8, 9], dtype=torch.int64)
+
+    for rank in range(2):
+        torch.testing.assert_close(
+            get_cp_local_seq_lens(
+                seq_lens,
+                cp_world_size=2,
+                cp_rank=rank,
+                cp_kv_cache_interleave_size=1,
+            ),
+            get_dcp_local_seq_lens(
+                seq_lens,
+                dcp_size=2,
+                dcp_rank=rank,
+                cp_kv_cache_interleave_size=1,
+            ),
+        )
+
+
+def test_get_pcp_max_buffer_num_tokens():
+    config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=16, max_num_seqs=3),
+        parallel_config=SimpleNamespace(prefill_context_parallel_size=1),
+    )
+    assert get_pcp_max_buffer_num_tokens(config) == 16
+
+    config.parallel_config.prefill_context_parallel_size = 2
+    assert get_pcp_max_buffer_num_tokens(config) == 28
+
+
+@pytest.mark.parametrize(
+    "microbatch_config",
+    [
+        {"enable_dbo": True},
+        {"ubatch_size": 2},
+    ],
+)
+def test_pcp_rejects_microbatching(microbatch_config):
+    with pytest.raises(ValueError, match="does not support DBO or microbatching"):
+        ParallelConfig(prefill_context_parallel_size=2, **microbatch_config)
+
+
+def test_deepseek_v4_pcp_prefill_guard_raises_without_runtime_metadata():
+    with pytest.raises(NotImplementedError, match=DSV4_PCP_PREFILL_UNSUPPORTED_ERROR):
+        guard_dsv4_pcp_prefill_runtime_metadata(
+            pcp_allgather_restore_idx=torch.tensor([0, 1], dtype=torch.int64),
+            num_prefill_tokens=2,
+            runtime_metadata=None,
+        )
+
+
+def test_deepseek_v4_pcp_prefill_guard_allows_non_legacy_paths():
+    guard_dsv4_pcp_prefill_runtime_metadata(
+        pcp_allgather_restore_idx=None,
+        num_prefill_tokens=2,
+        runtime_metadata=None,
+    )
+    guard_dsv4_pcp_prefill_runtime_metadata(
+        pcp_allgather_restore_idx=torch.tensor([0, 1], dtype=torch.int64),
+        num_prefill_tokens=0,
+        runtime_metadata=None,
+    )
+    guard_dsv4_pcp_prefill_runtime_metadata(
+        pcp_allgather_restore_idx=torch.tensor([0, 1], dtype=torch.int64),
+        num_prefill_tokens=2,
+        runtime_metadata=object(),
+    )
+
+
+def test_get_pcp_query_and_kv_indices():
+    cu_num_tokens = torch.tensor([0, 4, 12], dtype=torch.int32)
+
+    query_head, query_tail = get_pcp_query_indices(cu_num_tokens)
+    torch.testing.assert_close(query_head, torch.tensor([0, 1, 4, 5, 6, 7]))
+    torch.testing.assert_close(query_tail, torch.tensor([2, 3, 8, 9, 10, 11]))
+
+    kv_head_rank0, kv_tail_rank0 = get_pcp_kv_indices(
+        cu_num_tokens, pcp_rank=0, pcp_size=2
+    )
+    torch.testing.assert_close(kv_head_rank0, torch.tensor([0, 4, 5]))
+    torch.testing.assert_close(
+        kv_tail_rank0, torch.tensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+    )
+
+    kv_head_rank1, kv_tail_rank1 = get_pcp_kv_indices(
+        cu_num_tokens, pcp_rank=1, pcp_size=2
+    )
+    torch.testing.assert_close(kv_head_rank1, torch.tensor([0, 1, 4, 5, 6, 7]))
+    torch.testing.assert_close(kv_tail_rank1, torch.tensor([0, 1, 2, 4, 5, 6, 7, 8, 9]))
+
+
+def test_pcp_kv_allgather_and_restore():
+    class FakePCPGroup:
+        def __init__(self, other: torch.Tensor) -> None:
+            self.other = other
+
+        def all_gather(self, local: torch.Tensor, dim: int = 0) -> torch.Tensor:
+            return torch.cat([local, self.other.to(local.dtype)], dim=dim)
+
+    key = torch.tensor([[10], [30], [999]], dtype=torch.float32)
+    value = torch.tensor([[100], [300], [999]], dtype=torch.float32)
+    other = torch.tensor([[20], [40]], dtype=torch.float32)
+    restore_idx = torch.tensor([0, 2, 1, 3], dtype=torch.int64)
+
+    restored_key, restored_value = pcp_kv_allgather_and_restore(
+        key,
+        value,
+        num_actual_tokens=2,
+        pcp_allgather_restore_idx=restore_idx,
+        pcp_group=FakePCPGroup(other),
+    )
+
+    torch.testing.assert_close(restored_key, torch.tensor([[10], [20], [30], [40.0]]))
+    torch.testing.assert_close(
+        restored_value, torch.tensor([[100], [20], [300], [40.0]])
+    )
+
+
+def test_pcp_allgather_restore_local_indices():
+    class FakePCPGroup:
+        def __init__(self, other: torch.Tensor) -> None:
+            self.other = other
+
+        def all_gather(self, local: torch.Tensor, dim: int = 0) -> torch.Tensor:
+            return torch.cat([local, self.other.to(local.dtype)], dim=dim)
+
+    local = torch.tensor([[10], [30]], dtype=torch.float32)
+    other = torch.tensor([[20], [40]], dtype=torch.float32)
+    restore_idx = torch.tensor([0, 2, 1, 3], dtype=torch.int64)
+
+    restored = pcp_allgather_and_restore(
+        local,
+        num_actual_tokens=2,
+        pcp_allgather_restore_idx=restore_idx,
+        pcp_group=FakePCPGroup(other),
+    )
+    torch.testing.assert_close(restored, torch.tensor([[10], [20], [30], [40.0]]))
+
+    local_indices = get_pcp_local_indices_after_restore(
+        num_local_tokens=2,
+        pcp_rank=0,
+        pcp_allgather_restore_idx=restore_idx,
+    )
+    torch.testing.assert_close(local_indices, torch.tensor([0, 2]))
+    torch.testing.assert_close(
+        torch.index_select(restored, 0, local_indices),
+        local,
+    )

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -810,6 +810,13 @@ class ParallelConfig:
         return hash_factors(factors)
 
     def __post_init__(self) -> None:
+        if self.prefill_context_parallel_size > 1 and self.use_ubatching:
+            raise ValueError(
+                "Prefill context parallelism does not support DBO or "
+                "microbatching yet. Disable --enable-dbo and set "
+                "--ubatch-size=1."
+            )
+
         # Continue with the rest of the initialization
         self.world_size = (
             self.pipeline_parallel_size

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -42,6 +42,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.stats import (
     MooncakeKVConnectorStats,
 )
 from vllm.distributed.parallel_state import (
+    get_pcp_group,
     get_pp_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
@@ -54,6 +55,7 @@ from vllm.utils.math_utils import cdiv
 from vllm.utils.network_utils import get_ip, make_zmq_path, make_zmq_socket
 from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.attention.backends.utils import NULL_BLOCK_ID, get_kv_cache_layout
+from vllm.v1.core.kv_cache_utils import resolve_kv_cache_block_sizes
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
@@ -684,6 +686,107 @@ def _select_region_block_ids(
     return local_block_ids, remote_block_ids, None
 
 
+def _pair_pcp_block_ids(
+    local_block_ids: list[int],
+    remote_block_ids: list[int],
+    *,
+    total_tokens: int,
+    num_external_tokens: int,
+    external_start_token: int,
+    producer_pcp_size: int,
+    producer_pcp_rank: int,
+    consumer_pcp_size: int,
+    consumer_pcp_rank: int,
+    group_block_size: int,
+    interleave_size: int,
+) -> tuple[list[int], list[int], str | None]:
+    """Pair compact producer PCP pages with global consumer pages."""
+    if producer_pcp_size <= 0 or consumer_pcp_size <= 0:
+        return [], [], "PCP world sizes must be positive"
+    if not 0 <= producer_pcp_rank < producer_pcp_size:
+        return [], [], "Invalid producer PCP rank"
+    if not 0 <= consumer_pcp_rank < consumer_pcp_size:
+        return [], [], "Invalid consumer PCP rank"
+    if group_block_size <= 0 or interleave_size <= 0:
+        return [], [], "PCP block and interleave sizes must be positive"
+    if total_tokens < 0 or num_external_tokens < 0 or external_start_token < 0:
+        return [], [], "PCP token ranges must be non-negative"
+    if external_start_token + num_external_tokens != total_tokens:
+        return [], [], "Mooncake PCP transfer requires an exact suffix token range"
+
+    if producer_pcp_size == consumer_pcp_size:
+        if producer_pcp_rank != consumer_pcp_rank:
+            return [], [], "Aligned PCP transfer requires matching PCP ranks"
+        if len(local_block_ids) < len(remote_block_ids):
+            return [], [], "P num blocks less than D"
+        if len(local_block_ids) > len(remote_block_ids):
+            local_block_ids = local_block_ids[-len(remote_block_ids) :]
+        return list(local_block_ids), list(remote_block_ids), None
+
+    if producer_pcp_size <= 1 or consumer_pcp_size != 1:
+        return (
+            [],
+            [],
+            (
+                "Unsupported unaligned PCP topology: "
+                f"producer={producer_pcp_size}, consumer={consumer_pcp_size}"
+            ),
+        )
+    if interleave_size % group_block_size != 0:
+        return (
+            [],
+            [],
+            (
+                "PCP interleave size must be divisible by every KV group block size: "
+                f"interleave={interleave_size}, block={group_block_size}"
+            ),
+        )
+
+    remote_total_blocks = cdiv(total_tokens, group_block_size)
+    if len(remote_block_ids) > remote_total_blocks:
+        return [], [], "D block list exceeds the request token range"
+    remote_first_block = remote_total_blocks - len(remote_block_ids)
+
+    cycle_size = producer_pcp_size * interleave_size
+    full_cycles, cycle_tail = divmod(total_tokens, cycle_size)
+    rank_tail = min(
+        max(cycle_tail - producer_pcp_rank * interleave_size, 0),
+        interleave_size,
+    )
+    local_tokens = full_cycles * interleave_size + rank_tail
+    local_total_blocks = cdiv(local_tokens, group_block_size)
+    # PCP allocates block-table entries uniformly across ranks. For short or
+    # partial final interleave chunks, a rank can therefore receive trailing
+    # padding pages even though it owns fewer (or zero) valid tokens. Keep the
+    # suffix offset for normal prefix-hit transfers and let the token-boundary
+    # check below discard only those padded tail pages.
+    local_first_block = max(local_total_blocks - len(local_block_ids), 0)
+
+    paired_local: list[int] = []
+    paired_remote: list[int] = []
+    for local_offset, local_block_id in enumerate(local_block_ids):
+        local_block_index = local_first_block + local_offset
+        local_token_start = local_block_index * group_block_size
+        if local_token_start >= local_tokens:
+            continue
+        cycle_index, cycle_offset = divmod(local_token_start, interleave_size)
+        global_token_start = (
+            cycle_index * cycle_size
+            + producer_pcp_rank * interleave_size
+            + cycle_offset
+        )
+        if global_token_start >= total_tokens:
+            continue
+        global_block_index = global_token_start // group_block_size
+        remote_offset = global_block_index - remote_first_block
+        if not 0 <= remote_offset < len(remote_block_ids):
+            continue
+        paired_local.append(local_block_id)
+        paired_remote.append(remote_block_ids[remote_offset])
+
+    return paired_local, paired_remote, None
+
+
 def _get_tensor_dense_flag(tensor: torch.Tensor) -> bool | None:
     is_dense = getattr(tensor, "is_non_overlapping_and_dense", None)
     if callable(is_dense):
@@ -703,6 +806,11 @@ class MooncakeXferMetadata(
     kv_caches_base_addr: list[int]
     block_lens: list[int]
     kv_block_lens: list[int]
+    remote_pcp_size: int = 1
+    remote_pcp_rank: int = 0
+    req_total_tokens: dict[ReqId, int] = msgspec.field(default_factory=dict)
+    req_num_external_tokens: dict[ReqId, int] = msgspec.field(default_factory=dict)
+    req_external_start_tokens: dict[ReqId, int] = msgspec.field(default_factory=dict)
     registered_layer_names: list[str] = msgspec.field(default_factory=list)
     registered_layer_indices: list[int] = msgspec.field(default_factory=list)
     registered_group_indices: list[int] = msgspec.field(default_factory=list)
@@ -744,10 +852,14 @@ class PullReqMeta:
     local_block_ids: list[list[int]]
     remote_engine_id: EngineId
     remote_bootstrap_addr: str
+    total_tokens: int = 0
+    num_external_tokens: int = 0
+    external_start_token: int = 0
     # Set expire time to avoid infinitely sending requests.
     expire_time: float = float("inf")
     # Designed for one D pairing to multiple P
     pull_tasks_count: int = 0
+    pull_failed: bool = False
 
 
 @dataclass
@@ -776,6 +888,9 @@ class MooncakeConnectorMetadata(KVConnectorMetadata):
         local_block_ids: list[list[int]],
         kv_transfer_params: dict[str, Any],
         load_remote_cache: bool = True,
+        total_tokens: int = 0,
+        num_external_tokens: int = 0,
+        external_start_token: int = 0,
     ):
         transfer_id = kv_transfer_params["transfer_id"]
         if load_remote_cache:
@@ -786,6 +901,9 @@ class MooncakeConnectorMetadata(KVConnectorMetadata):
                 remote_engine_id=remote_engine_id,
                 remote_bootstrap_addr=kv_transfer_params["remote_bootstrap_addr"],
                 transfer_id=transfer_id,
+                total_tokens=total_tokens,
+                num_external_tokens=num_external_tokens,
+                external_start_token=external_start_token,
             )
         else:
             self.reqs_to_send[request_id] = (transfer_id, local_block_ids)
@@ -928,6 +1046,11 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
             return None
         return self.connector_worker.get_kv_connector_stats()
 
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        if self.connector_worker is None:
+            return set()
+        return self.connector_worker.get_block_ids_with_load_errors()
+
     @classmethod
     def build_kv_connector_stats(
         cls, data: dict[str, Any] | None = None
@@ -945,7 +1068,7 @@ class MooncakeConnectorScheduler:
         kv_cache_config: "KVCacheConfig",
     ):
         self.vllm_config = vllm_config
-        self.block_size = vllm_config.cache_config.block_size
+        self.block_size, _ = resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)
 
         assert vllm_config.kv_transfer_config
         self.is_kv_producer: bool = (
@@ -970,15 +1093,24 @@ class MooncakeConnectorScheduler:
         # Requests that need to start recv/send.
         # New requests are added by update_state_after_alloc in
         # the scheduler. Used to make metadata passed to Worker.
-        self._reqs_need_recv: dict[ReqId, tuple[Request, list[list[int]]]] = {}
+        self._reqs_need_recv: dict[
+            ReqId, tuple[Request, list[list[int]], int, int, int]
+        ] = {}
         self._reqs_need_send: dict[ReqId, tuple[Request, list[list[int]]]] = {}
         # Reqs to remove from processed set because they're not to send after
         # remote prefill or aborted.
         self._reqs_not_processed: set[TransferId] = set()
 
         # Compute sliding window block counts per KV cache group.
+        cp_world_size = (
+            vllm_config.parallel_config.decode_context_parallel_size
+            * vllm_config.parallel_config.prefill_context_parallel_size
+        )
         sw_sizes_tokens: list[tuple[int, int]] = [
-            (g.kv_cache_spec.sliding_window, g.kv_cache_spec.block_size)
+            (
+                g.kv_cache_spec.sliding_window,
+                g.kv_cache_spec.block_size * cp_world_size,
+            )
             if isinstance(g.kv_cache_spec, SlidingWindowSpec)
             else (0, self.block_size)
             for g in kv_cache_config.kv_cache_groups
@@ -1109,8 +1241,18 @@ class MooncakeConnectorScheduler:
                     else ()
                 )
                 local_block_ids = self.get_sw_clipped_blocks(unhashed_block_ids)
+                total_tokens = self._get_remote_prefill_token_count(
+                    request.num_prompt_tokens
+                )
+                external_start_token = max(total_tokens - num_external_tokens, 0)
                 # Get unhashed blocks to pull from remote.
-                self._reqs_need_recv[request.request_id] = (request, local_block_ids)
+                self._reqs_need_recv[request.request_id] = (
+                    request,
+                    local_block_ids,
+                    total_tokens,
+                    num_external_tokens,
+                    external_start_token,
+                )
             else:
                 logger.warning(
                     "Got invalid KVTransferParams: %s. This "
@@ -1136,12 +1278,21 @@ class MooncakeConnectorScheduler:
 
         # Loop through scheduled reqs and convert to PullReqMeta.
         if not self.is_kv_producer:
-            for req_id, (req, block_ids) in self._reqs_need_recv.items():
+            for req_id, (
+                req,
+                block_ids,
+                total_tokens,
+                num_external_tokens,
+                external_start_token,
+            ) in self._reqs_need_recv.items():
                 assert req.kv_transfer_params is not None
                 meta.add_new_req(
                     request_id=req_id,
                     local_block_ids=block_ids,
                     kv_transfer_params=req.kv_transfer_params,
+                    total_tokens=total_tokens,
+                    num_external_tokens=num_external_tokens,
+                    external_start_token=external_start_token,
                 )
             self._reqs_need_recv.clear()
 
@@ -1189,7 +1340,7 @@ class MooncakeConnectorScheduler:
             # we must add empty block_ids to _reqs_need_recv so that our
             # worker side will notify and free blocks in the prefill instance.
             assert not self.is_kv_producer
-            self._reqs_need_recv[request.request_id] = (request, [])
+            self._reqs_need_recv[request.request_id] = (request, [], 0, 0, 0)
             params["do_remote_prefill"] = False
             return False, None
 
@@ -1342,7 +1493,7 @@ class MooncakeConnectorWorker:
             self.rpc_port,
         )
 
-        self._remote_agents: dict[EngineId, dict[int, dict[int, str]]] = {}
+        self._remote_agents: dict[EngineId, dict[int, dict[int, dict[int, str]]]] = {}
         self._pending_bootstrap_queries: dict[str, asyncio.Event] = {}
         self.side_channel_port: int = 0  # we will bind it in register_kv_caches()
         self.engine_id: EngineId = engine_id
@@ -1365,6 +1516,11 @@ class MooncakeConnectorWorker:
         self.dp_rank = dp_local_rank if parallel_config.local_engines_only else dp_rank
         self.pp_size = vllm_config.parallel_config.pipeline_parallel_size
         self.pp_rank = get_pp_group().rank_in_group
+        self.pcp_size = vllm_config.parallel_config.prefill_context_parallel_size
+        self.pcp_rank = get_pcp_group().rank_in_group if self.pcp_size > 1 else 0
+        self.cp_kv_cache_interleave_size = (
+            vllm_config.parallel_config.cp_kv_cache_interleave_size
+        )
 
         self.kv_caches_base_addr: list[int] = []
         self.device_kv_caches: dict[str, torch.Tensor] = {}
@@ -1409,6 +1565,8 @@ class MooncakeConnectorWorker:
 
         self.finished_sending_reqs: set[ReqId] = set()
         self.finished_recving_reqs: set[ReqId] = set()
+        self._invalid_block_ids_lock = threading.Lock()
+        self._invalid_block_ids: set[int] = set()
         # D-side request start times for opt-in P/D transfer tracing.
         self._pd_trace_pull_started: dict[ReqId, float] = {}
 
@@ -1431,6 +1589,7 @@ class MooncakeConnectorWorker:
         logger.debug("Detected kv cache layout %s", self.kv_cache_layout)
 
         self._tp_size: dict[EngineId, int] = {self.engine_id: self.tp_size}
+        self._pcp_size: dict[EngineId, int] = {self.engine_id: self.pcp_size}
         self._layer_specs: dict[str, KVCacheSpec] = {}
         for group in kv_cache_config.kv_cache_groups:
             group_spec = group.kv_cache_spec
@@ -1512,6 +1671,8 @@ class MooncakeConnectorWorker:
             dp_rank=self.dp_rank,
             tp_rank=self.tp_rank,
             pp_rank=self.pp_rank,
+            pcp_rank=self.pcp_rank,
+            pcp_size=self.pcp_size,
             addr=worker_addr,
         )
         while True:
@@ -1982,29 +2143,41 @@ class MooncakeConnectorWorker:
                         if block_id != NULL_BLOCK_ID
                     ]
 
-                n_local = len(local_group)
-                n_remote = len(remote_group)
-                if n_local < n_remote:
+                local_group, remote_group, pair_error = _pair_pcp_block_ids(
+                    local_group,
+                    remote_group,
+                    total_tokens=agent_meta.req_total_tokens.get(d_req_id, 0),
+                    num_external_tokens=(
+                        agent_meta.req_num_external_tokens.get(d_req_id, 0)
+                    ),
+                    external_start_token=(
+                        agent_meta.req_external_start_tokens.get(d_req_id, 0)
+                    ),
+                    producer_pcp_size=getattr(self, "pcp_size", 1),
+                    producer_pcp_rank=getattr(self, "pcp_rank", 0),
+                    consumer_pcp_size=agent_meta.remote_pcp_size,
+                    consumer_pcp_rank=agent_meta.remote_pcp_rank,
+                    group_block_size=group_specs[group_index].kv_cache_spec.block_size,
+                    interleave_size=getattr(self, "cp_kv_cache_interleave_size", 1),
+                )
+                if pair_error is not None:
                     logger.error(
-                        "req %s: local blocks(%d) < remote blocks(%d) "
-                        "in a KV cache group (is_mamba_group=%s)",
+                        "req %s: failed to pair PCP blocks for KV group %d: %s",
                         d_req_id,
-                        n_local,
-                        n_remote,
-                        is_mamba_group,
+                        group_index,
+                        pair_error,
                     )
                     has_block_error = True
+                    if err_msg is None:
+                        err_msg = pair_error
                     break
-                elif n_local > n_remote:
-                    # Partial prefix cache hit: just read uncomputed blocks.
-                    local_group = local_group[-n_remote:] if n_remote > 0 else []
                 local_block_ids_by_group.append(local_group)
                 remote_block_ids_by_group.append(remote_group)
 
             if has_block_error:
                 err_reqs.append(d_req_id)
                 if err_msg is None:
-                    err_msg = "P num blocks less than D"
+                    err_msg = "Failed to pair Mooncake PCP blocks"
                 continue
 
             if not any(local_block_ids_by_group):
@@ -2394,6 +2567,38 @@ class MooncakeConnectorWorker:
             return None
         return self.xfer_stats.clone_and_reset()
 
+    def _mark_pull_failed(self, pull_meta: PullReqMeta) -> None:
+        """Report a failed pull after all remote worker tasks have quiesced."""
+        getattr(self, "_pd_trace_pull_started", {}).pop(pull_meta.d_req_id, None)
+        invalid_blocks = {
+            block_id for group in pull_meta.local_block_ids for block_id in group
+        }
+        if invalid_blocks:
+            with self._invalid_block_ids_lock:
+                self._invalid_block_ids.update(invalid_blocks)
+        self.finished_recving_reqs.add(pull_meta.d_req_id)
+
+    def _account_failed_pull_tasks(
+        self,
+        pull_metas: dict[ReqId, PullReqMeta],
+        req_ids: list[ReqId],
+    ) -> None:
+        for req_id in req_ids:
+            pull_meta = pull_metas.get(req_id)
+            if pull_meta is None:
+                continue
+            pull_meta.pull_failed = True
+            if pull_meta.pull_tasks_count > 0:
+                pull_meta.pull_tasks_count -= 1
+            if pull_meta.pull_tasks_count == 0:
+                self._mark_pull_failed(pull_meta)
+
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        with self._invalid_block_ids_lock:
+            invalid_block_ids = set(self._invalid_block_ids)
+            self._invalid_block_ids.clear()
+        return invalid_block_ids
+
     async def receive_kv_from_single_worker(
         self,
         worker_addr: str,
@@ -2401,7 +2606,8 @@ class MooncakeConnectorWorker:
     ):
         trace_enabled = envs.VLLM_MOONCAKE_PD_TRACE
         worker_started = time.perf_counter() if trace_enabled else 0.0
-        req_ids = set(pull_metas)
+        req_ids = list(pull_metas)
+        outstanding_req_ids = set(req_ids)
         metadata = MooncakeXferMetadata(
             remote_hostname=self.hostname,
             remote_port=self.rpc_port,
@@ -2414,6 +2620,20 @@ class MooncakeConnectorWorker:
             kv_caches_base_addr=self.kv_caches_base_addr,
             block_lens=self.block_len_per_layer,
             kv_block_lens=self.kv_block_len_per_layer,
+            remote_pcp_size=self.pcp_size,
+            remote_pcp_rank=self.pcp_rank,
+            req_total_tokens={
+                req_id: pull_meta.total_tokens
+                for req_id, pull_meta in pull_metas.items()
+            },
+            req_num_external_tokens={
+                req_id: pull_meta.num_external_tokens
+                for req_id, pull_meta in pull_metas.items()
+            },
+            req_external_start_tokens={
+                req_id: pull_meta.external_start_token
+                for req_id, pull_meta in pull_metas.items()
+            },
             registered_layer_names=self.registered_layer_names,
             registered_layer_indices=self.registered_layer_indices,
             registered_group_indices=self.registered_group_indices,
@@ -2451,10 +2671,14 @@ class MooncakeConnectorWorker:
                             response.err_msg,
                         )
                         self.xfer_stats.record_failed_recv()
-                        for req_id in req_ids:
-                            self._pd_trace_pull_started.pop(req_id, None)
+                        self._account_failed_pull_tasks(
+                            pull_metas, list(outstanding_req_ids)
+                        )
                         return
-                    self.process_pulling_result(response, pull_metas)
+                    accounted_req_ids = self.process_pulling_result(
+                        response, pull_metas
+                    )
+                    outstanding_req_ids.difference_update(accounted_req_ids)
                     if response.status == MooncakeXferResponseStatus.FINISH:
                         break
             if trace_enabled:
@@ -2473,49 +2697,56 @@ class MooncakeConnectorWorker:
         except Exception as e:
             logger.error("MooncakeXferMetadata transfer failed for %s: %s", req_ids, e)
             self.xfer_stats.record_failed_recv()
-            for req_id in req_ids:
-                self._pd_trace_pull_started.pop(req_id, None)
+            self._account_failed_pull_tasks(pull_metas, list(outstanding_req_ids))
             return
 
     def process_pulling_result(
         self,
         response: MooncakeXferResponse,
         pull_metas: dict[ReqId, PullReqMeta],
-    ):
+    ) -> set[ReqId]:
+        accounted_req_ids: set[ReqId] = set()
         ok_reqs: list[ReqId] = response.ok_reqs or []
 
         for req_id in ok_reqs:
             pull_meta = pull_metas[req_id]
             # No race because we are in async loop.
-            pull_meta.pull_tasks_count -= 1
+            if pull_meta.pull_tasks_count > 0:
+                pull_meta.pull_tasks_count -= 1
             if pull_meta.pull_tasks_count == 0:
-                ready_started = time.perf_counter()
-                self.finished_recving_reqs.add(pull_meta.d_req_id)
-                if envs.VLLM_MOONCAKE_PD_TRACE:
-                    pull_started = self._pd_trace_pull_started.pop(
-                        pull_meta.d_req_id, ready_started
-                    )
-                    logger.info(
-                        "MOONCAKE_PD_TRACE D_READY req=%s dp=%d pp=%d tp=%d "
-                        "wait_ms=%.3f",
-                        pull_meta.d_req_id,
-                        self.dp_rank,
-                        self.pp_rank,
-                        self.tp_rank,
-                        (ready_started - pull_started) * 1e3,
-                    )
+                if pull_meta.pull_failed:
+                    self._mark_pull_failed(pull_meta)
+                else:
+                    ready_started = time.perf_counter()
+                    self.finished_recving_reqs.add(pull_meta.d_req_id)
+                    if envs.VLLM_MOONCAKE_PD_TRACE:
+                        pull_started = self._pd_trace_pull_started.pop(
+                            pull_meta.d_req_id, ready_started
+                        )
+                        logger.info(
+                            "MOONCAKE_PD_TRACE D_READY req=%s dp=%d pp=%d tp=%d "
+                            "wait_ms=%.3f",
+                            pull_meta.d_req_id,
+                            self.dp_rank,
+                            self.pp_rank,
+                            self.tp_rank,
+                            (ready_started - pull_started) * 1e3,
+                        )
+            accounted_req_ids.add(req_id)
 
         if ok_reqs:
             logger.debug("pulling kv_caches for %s finished", ok_reqs)
 
         if response.err_reqs:
-            for req_id in response.err_reqs:
-                self._pd_trace_pull_started.pop(req_id, None)
+            err_reqs = list(response.err_reqs)
             logger.error(
                 "pulling kv_caches for %s failed: %s",
-                response.err_reqs,
+                err_reqs,
                 response.err_msg,
             )
+            self._account_failed_pull_tasks(pull_metas, err_reqs)
+            accounted_req_ids.update(err_reqs)
+        return accounted_req_ids
 
     async def _connect_to_prefiller_bootstrap(self, remote_bootstrap_addr: str):
         url = remote_bootstrap_addr + "/query"
@@ -2528,12 +2759,16 @@ class MooncakeConnectorWorker:
                     remote_engine_id = dp_entry["engine_id"]
                     self._remote_agents[remote_engine_id] = {
                         int(tp_rank): {
-                            int(pp_rank): worker_addr
-                            for pp_rank, worker_addr in tp_entry.items()
+                            int(pp_rank): {
+                                int(pcp_rank): worker_addr
+                                for pcp_rank, worker_addr in pp_entry.items()
+                            }
+                            for pp_rank, pp_entry in tp_entry.items()
                         }
                         for tp_rank, tp_entry in dp_entry["worker_addr"].items()
                     }
                     self._tp_size[remote_engine_id] = len(dp_entry["worker_addr"])
+                    self._pcp_size[remote_engine_id] = int(dp_entry.get("pcp_size", 1))
         except Exception as e:
             logger.error(
                 "Failed to connect to bootstrap server %s: %s",
@@ -2555,22 +2790,68 @@ class MooncakeConnectorWorker:
         )
         worker_addrs: list[str] = []
         selected_remote_pp: dict[int, list[int]] = {}
+        selected_remote_pcp: dict[tuple[int, int], list[int]] = {}
+        remote_pcp_size = self._pcp_size[remote_engine_id]
+        if self.pcp_size != remote_pcp_size and self.pcp_size != 1:
+            logger.error(
+                "Unsupported Mooncake PCP topology for engine %s: "
+                "producer=%d, consumer=%d",
+                remote_engine_id,
+                remote_pcp_size,
+                self.pcp_size,
+            )
+            for pull_meta in pull_metas.values():
+                pull_meta.pull_failed = True
+                self._mark_pull_failed(pull_meta)
+            return
         for remote_tp_rank in remote_tp_ranks:
-            pp_to_addr = self._remote_agents[remote_engine_id][remote_tp_rank]
-            if self.pp_size == len(pp_to_addr) and self.pp_rank in pp_to_addr:
+            pp_to_pcp = self._remote_agents[remote_engine_id][remote_tp_rank]
+            if self.pp_size == len(pp_to_pcp) and self.pp_rank in pp_to_pcp:
                 pp_ranks = [self.pp_rank]
             else:
-                pp_ranks = sorted(pp_to_addr)
+                pp_ranks = sorted(pp_to_pcp)
             selected_remote_pp[remote_tp_rank] = pp_ranks
-            worker_addrs.extend(pp_to_addr[pp_rank] for pp_rank in pp_ranks)
+            for pp_rank in pp_ranks:
+                pcp_to_addr = pp_to_pcp[pp_rank]
+                if self.pcp_size == remote_pcp_size:
+                    if self.pcp_rank not in pcp_to_addr:
+                        logger.error(
+                            "Missing producer PCP rank %d for TP=%d PP=%d",
+                            self.pcp_rank,
+                            remote_tp_rank,
+                            pp_rank,
+                        )
+                        for pull_meta in pull_metas.values():
+                            pull_meta.pull_failed = True
+                            self._mark_pull_failed(pull_meta)
+                        return
+                    pcp_ranks = [self.pcp_rank]
+                else:
+                    pcp_ranks = sorted(pcp_to_addr)
+                    if pcp_ranks != list(range(remote_pcp_size)):
+                        logger.error(
+                            "Incomplete producer PCP workers for TP=%d PP=%d: "
+                            "expected=%s, got=%s",
+                            remote_tp_rank,
+                            pp_rank,
+                            list(range(remote_pcp_size)),
+                            pcp_ranks,
+                        )
+                        for pull_meta in pull_metas.values():
+                            pull_meta.pull_failed = True
+                            self._mark_pull_failed(pull_meta)
+                        return
+                selected_remote_pcp[(remote_tp_rank, pp_rank)] = pcp_ranks
+                worker_addrs.extend(pcp_to_addr[rank] for rank in pcp_ranks)
 
         count = len(worker_addrs)
         logger.debug(
             "Receiving Mooncake KV for engine %s from producer TP ranks %s "
-            "and PP ranks %s",
+            "PP ranks %s and PCP ranks %s",
             remote_engine_id,
             remote_tp_ranks,
             selected_remote_pp,
+            selected_remote_pcp,
         )
         for pull_meta in pull_metas.values():
             pull_meta.pull_tasks_count = count
@@ -2784,6 +3065,11 @@ def should_launch_bootstrap_server(vllm_config: VllmConfig) -> bool:
     if get_tensor_model_parallel_rank() != 0:
         return False
     if get_pp_group().rank_in_group != 0:
+        return False
+    if (
+        getattr(parallel_config, "prefill_context_parallel_size", 1) > 1
+        and get_pcp_group().rank_in_group != 0
+    ):
         return False
 
     # In hybrid or external LB mode,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_utils.py
@@ -31,14 +31,17 @@ class RegisterWorkerPayload(BaseModel):
     dp_rank: int
     tp_rank: int
     pp_rank: int
+    pcp_rank: int = 0
+    pcp_size: int = 1
     addr: WorkerAddr
 
 
 @dataclass
 class EngineEntry:
     engine_id: EngineId
-    # {tp_rank: {pp_rank: worker_addr}}
-    worker_addr: dict[int, dict[int, WorkerAddr]]
+    pcp_size: int
+    # {tp_rank: {pp_rank: {pcp_rank: worker_addr}}}
+    worker_addr: dict[int, dict[int, dict[int, WorkerAddr]]]
 
 
 class MooncakeBootstrapServer:
@@ -92,6 +95,7 @@ class MooncakeBootstrapServer:
         if payload.dp_rank not in self.workers:
             self.workers[payload.dp_rank] = EngineEntry(
                 engine_id=payload.engine_id,
+                pcp_size=payload.pcp_size,
                 worker_addr={},
             )
 
@@ -104,29 +108,51 @@ class MooncakeBootstrapServer:
                     f"expected {dp_entry.engine_id}, got {payload.engine_id}"
                 ),
             )
+        if payload.pcp_size <= 0 or not 0 <= payload.pcp_rank < payload.pcp_size:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Invalid PCP topology: rank={payload.pcp_rank}, "
+                    f"size={payload.pcp_size}"
+                ),
+            )
+        if dp_entry.pcp_size != payload.pcp_size:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"PCP size mismatch for dp_rank={payload.dp_rank}: "
+                    f"expected {dp_entry.pcp_size}, got {payload.pcp_size}"
+                ),
+            )
         if payload.tp_rank not in dp_entry.worker_addr:
             dp_entry.worker_addr[payload.tp_rank] = {}
 
         tp_entry = dp_entry.worker_addr[payload.tp_rank]
-        if payload.pp_rank in tp_entry:
+        if payload.pp_rank not in tp_entry:
+            tp_entry[payload.pp_rank] = {}
+        pp_entry = tp_entry[payload.pp_rank]
+        if payload.pcp_rank in pp_entry:
             raise HTTPException(
                 status_code=400,
                 detail=(
                     f"Worker with dp_rank={payload.dp_rank}, "
-                    f"tp_rank={payload.tp_rank}, pp_rank={payload.pp_rank} "
+                    f"tp_rank={payload.tp_rank}, pp_rank={payload.pp_rank}, "
+                    f"pcp_rank={payload.pcp_rank} "
                     f"is already registered at "
-                    f"{tp_entry[payload.pp_rank]}, "
+                    f"{pp_entry[payload.pcp_rank]}, "
                     f"but still want to register at {payload.addr}"
                 ),
             )
 
-        tp_entry[payload.pp_rank] = payload.addr
+        pp_entry[payload.pcp_rank] = payload.addr
         logger.debug(
-            "Registered worker: engine_id=%s, dp_rank=%d, tp_rank=%d, pp_rank=%d at %s",
+            "Registered worker: engine_id=%s, dp_rank=%d, tp_rank=%d, "
+            "pp_rank=%d, pcp_rank=%d at %s",
             payload.engine_id,
             payload.dp_rank,
             payload.tp_rank,
             payload.pp_rank,
+            payload.pcp_rank,
             payload.addr,
         )
 

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -92,7 +92,51 @@ def _merge_dcp_topk_global(
     padding); the attention backend localizes them back to physical slots per
     rank.
     """
-    if dcp_world_size <= 1:
+    return _merge_cp_topk_global(
+        logits,
+        topk_indices,
+        topk_tokens,
+        dcp_rank,
+        dcp_world_size,
+        cp_interleave,
+        get_dcp_group(),
+        row_starts=row_starts,
+    )
+
+
+def _merge_pcp_topk_global(
+    logits: torch.Tensor,
+    topk_indices: torch.Tensor,
+    topk_tokens: int,
+    pcp_rank: int,
+    pcp_world_size: int,
+    cp_interleave: int,
+    row_starts: torch.Tensor | None = None,
+) -> None:
+    """Merge local sparse-indexer candidates across the prefill CP group."""
+    return _merge_cp_topk_global(
+        logits,
+        topk_indices,
+        topk_tokens,
+        pcp_rank,
+        pcp_world_size,
+        cp_interleave,
+        get_pcp_group(),
+        row_starts=row_starts,
+    )
+
+
+def _merge_cp_topk_global(
+    logits: torch.Tensor,
+    topk_indices: torch.Tensor,
+    topk_tokens: int,
+    cp_rank: int,
+    cp_world_size: int,
+    cp_interleave: int,
+    cp_group,
+    row_starts: torch.Tensor | None = None,
+) -> None:
+    if cp_world_size <= 1:
         return
 
     # CuteDSL-only path (no PyTorch fallback): Triton-pack each rank's
@@ -113,12 +157,12 @@ def _merge_dcp_topk_global(
         logits,
         topk_indices,
         packed,
-        dcp_rank,
-        dcp_world_size,
+        cp_rank,
+        cp_world_size,
         cp_interleave,
         row_starts,
     )
-    gathered = get_dcp_group().all_gather(packed, dim=1)
+    gathered = cp_group.all_gather(packed, dim=1)
     stable_topk_from_gathered_candidates_cutedsl(
         gathered, topk_tokens, out=topk_indices
     )
@@ -314,6 +358,8 @@ def sparse_attn_indexer(
     dcp_rank: int = 0,
     dcp_world_size: int = 1,
     cp_kv_cache_interleave_size: int = 1,
+    pcp_rank: int = 0,
+    pcp_world_size: int = 1,
     skip_topk_buffer_clear: bool = False,
 ) -> torch.Tensor:
     # careful! this will be None in dummy run
@@ -408,7 +454,7 @@ def sparse_attn_indexer(
     # [:num_tokens, :topk] region earlier in this forward, so skip the redundant
     # fill.
     if not skip_topk_buffer_clear:
-        topk_indices_buffer[: hidden_states.shape[0]] = -1
+        topk_indices_buffer[: q_quant.shape[0]] = -1
     if has_prefill:
         prefill_metadata = attn_metadata_narrowed.prefill
         assert prefill_metadata is not None
@@ -496,15 +542,26 @@ def sparse_attn_indexer(
                     topk_tokens,
                 )
 
-            _merge_dcp_topk_global(
-                logits,
-                topk_indices,
-                topk_tokens,
-                dcp_rank,
-                dcp_world_size,
-                cp_kv_cache_interleave_size,
-                row_starts=chunk.cu_seqlen_ks,
-            )
+            if pcp_world_size > 1:
+                _merge_pcp_topk_global(
+                    logits,
+                    topk_indices,
+                    topk_tokens,
+                    pcp_rank,
+                    pcp_world_size,
+                    cp_kv_cache_interleave_size,
+                    row_starts=chunk.cu_seqlen_ks,
+                )
+            else:
+                _merge_dcp_topk_global(
+                    logits,
+                    topk_indices,
+                    topk_tokens,
+                    dcp_rank,
+                    dcp_world_size,
+                    cp_kv_cache_interleave_size,
+                    row_starts=chunk.cu_seqlen_ks,
+                )
 
     if has_decode:
         decode_metadata = attn_metadata_narrowed.decode
@@ -688,6 +745,8 @@ def sparse_attn_indexer_fake(
     dcp_rank: int = 0,
     dcp_world_size: int = 1,
     cp_kv_cache_interleave_size: int = 1,
+    pcp_rank: int = 0,
+    pcp_world_size: int = 1,
     skip_topk_buffer_clear: bool = False,
 ) -> torch.Tensor:
     return topk_indices_buffer
@@ -745,8 +804,22 @@ class SparseAttnIndexer(CustomOp):
         parallel_config = get_current_vllm_config().parallel_config
         self.dcp_world_size = parallel_config.decode_context_parallel_size
         self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
+        self.pcp_world_size = parallel_config.prefill_context_parallel_size
+        self.pcp_rank = get_pcp_group().rank_in_group if self.pcp_world_size > 1 else 0
+        if self.pcp_world_size > 1 and self.dcp_world_size > 1:
+            raise NotImplementedError(
+                "SparseAttnIndexer does not yet support combined PCP and DCP."
+            )
         self.cp_kv_cache_interleave_size = parallel_config.cp_kv_cache_interleave_size
         self.use_pcp = parallel_config.prefill_context_parallel_size > 1
+        self.indexer_cp_interleave_size = self.cp_kv_cache_interleave_size
+        if self.pcp_world_size > 1:
+            compress_ratio = getattr(self.k_cache, "compress_ratio", 1)
+            if self.cp_kv_cache_interleave_size % compress_ratio != 0:
+                raise NotImplementedError(
+                    "PCP indexer interleave must be divisible by compression ratio."
+                )
+            self.indexer_cp_interleave_size //= compress_ratio
         if current_platform.is_cuda() and not has_deep_gemm():
             raise RuntimeError(
                 "Sparse Attention Indexer CUDA op requires DeepGEMM support in "
@@ -803,7 +876,9 @@ class SparseAttnIndexer(CustomOp):
             self.use_fp4_cache,
             self.dcp_rank,
             self.dcp_world_size,
-            self.cp_kv_cache_interleave_size,
+            self.indexer_cp_interleave_size,
+            self.pcp_rank,
+            self.pcp_world_size,
         )
 
     def forward_xpu(

--- a/vllm/model_executor/warmup/flashinfer_sparse_mla_warmup.py
+++ b/vllm/model_executor/warmup/flashinfer_sparse_mla_warmup.py
@@ -82,6 +82,12 @@ def _uses_v2_model_runner(runner: "GPUModelRunner") -> bool:
     return bool(getattr(vllm_config, "use_v2_model_runner", False))
 
 
+def _uses_prefill_context_parallelism(runner: "GPUModelRunner") -> bool:
+    vllm_config = getattr(runner, "vllm_config", None)
+    parallel_config = getattr(vllm_config, "parallel_config", None)
+    return getattr(parallel_config, "prefill_context_parallel_size", 1) > 1
+
+
 def _run_flashinfer_sparse_mla_decode_autotune(
     worker: "Worker",
     num_tokens: int,
@@ -223,6 +229,14 @@ def deepseek_v4_sparse_mla_attention_warmup(worker: "Worker") -> None:
     """Warm DSv4 sparse-MLA mixed prefill+decode attention."""
     runner = worker.model_runner
     if runner.is_pooling_model or not _has_deepseek_v4_sparse_mla_backend(runner):
+        return
+
+    if _uses_prefill_context_parallelism(runner):
+        logger.info(
+            "Skipping DeepSeek V4 sparse MLA mixed prefill+decode warmup "
+            "because prefill context parallelism only supports standalone "
+            "prefill batches."
+        )
         return
 
     max_tokens = worker.scheduler_config.max_num_batched_tokens

--- a/vllm/models/deepseek_v4/attention.py
+++ b/vllm/models/deepseek_v4/attention.py
@@ -26,6 +26,11 @@ from vllm.models.deepseek_v4.common.ops import (
     fused_indexer_q_rope_quant,
     fused_q_kv_rmsnorm,
 )
+from vllm.models.deepseek_v4.pcp_metadata import (
+    build_pcp_full_slot_mapping,
+    build_pcp_restored_req_indices,
+    build_pcp_restored_valid_mask,
+)
 
 if TYPE_CHECKING:
     from vllm.v1.attention.backends.mla.sparse_swa import (
@@ -37,7 +42,7 @@ from vllm.config import (
     VllmConfig,
     get_current_vllm_config,
 )
-from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.distributed import get_pcp_group, get_tensor_model_parallel_world_size
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
@@ -53,9 +58,17 @@ from vllm.utils.multi_stream_utils import (
 from vllm.v1.attention.backend import AttentionBackend, AttentionMetadata
 from vllm.v1.attention.backends.mla.indexer import (
     DeepseekV4IndexerBackend,
+    DeepseekV32IndexerMetadata,
     get_max_prefill_buffer_size,
 )
 from vllm.v1.attention.backends.mla.sparse_swa import DeepseekV4SWACache
+from vllm.v1.attention.backends.utils import (
+    get_pcp_local_indices_after_restore,
+    get_pcp_max_buffer_num_tokens,
+    get_pcp_num_local_tokens_from_restore_idx,
+    pcp_allgather_and_restore,
+    restore_pcp_local_tensor_to_padded_tokens,
+)
 from vllm.v1.kv_cache_interface import (
     KVCacheSpec,
     MLAAttentionSpec,
@@ -387,6 +400,13 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
 
         # Will be None on ROCm for now.
         self.aux_stream_list = aux_stream_list
+        self.pcp_world_size = vllm_config.parallel_config.prefill_context_parallel_size
+        self.pcp_rank = 0
+        if self.pcp_world_size > 1:
+            self.pcp_rank = get_pcp_group().rank_in_group
+        self.cp_kv_cache_interleave_size = (
+            vllm_config.parallel_config.cp_kv_cache_interleave_size
+        )
         # [0]: GEMM start / post-GEMM event0. [1..3]: GEMM done events;
         # [1] doubles as post-GEMM event1. Reuse is safe: GEMM fully joins
         # before post-GEMM starts.
@@ -394,9 +414,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
 
         assert cache_config is not None, "DeepseekV4 attention requires cache_config"
         # ---- Attention / KV-cache setup ----
-        self.max_num_batched_tokens = (
-            vllm_config.scheduler_config.max_num_batched_tokens
-        )
+        self.max_num_batched_tokens = get_pcp_max_buffer_num_tokens(vllm_config)
         self.max_model_len = vllm_config.model_config.max_model_len
 
         # Resolve the kv-cache dtype from this backend's block format. The same
@@ -652,31 +670,118 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
         )
         assert swa_metadata is not None
 
+        local_q_indices = None
+        num_padded_local_tokens = q.shape[0]
+        if swa_metadata.pcp_allgather_restore_idx is not None:
+            restore_idx = swa_metadata.pcp_allgather_restore_idx
+            num_local_tokens = get_pcp_num_local_tokens_from_restore_idx(
+                restore_idx, self.pcp_world_size
+            )
+            local_q_indices = get_pcp_local_indices_after_restore(
+                num_local_tokens,
+                self.pcp_rank,
+                restore_idx,
+            )
+            pcp_group = get_pcp_group()
+            q = pcp_allgather_and_restore(q, num_local_tokens, restore_idx, pcp_group)
+            kv = pcp_allgather_and_restore(kv, num_local_tokens, restore_idx, pcp_group)
+            positions = pcp_allgather_and_restore(
+                positions,
+                num_local_tokens,
+                restore_idx,
+                pcp_group,
+            )
+
         swa_kv_cache = self.swa_cache_layer.kv_cache
+        swa_storage_block_size = (
+            int(swa_kv_cache.shape[1])
+            if swa_kv_cache.dim() >= 3
+            else int(self.swa_cache_layer.block_size)
+        )
         # The fused insert ops require int64 position_ids; the runner's positions
         # buffer is already int64, so no cast is needed.
         assert positions.dtype == torch.int64
         cos_sin_cache = self.rotary_emb.cos_sin_cache
         cache_dtype = swa_kv_cache.dtype
+        slot_mapping = swa_metadata.slot_mapping
+        kv_insert_mask = None
+        pcp_prefill_metadata = None
+        if local_q_indices is not None:
+            assert swa_metadata.pcp_prefill_metadata is not None
+            pcp_prefill_metadata = swa_metadata.pcp_prefill_metadata
+            pcp_prefill_metadata.restored_swa_positions = positions
+            restored_valid_mask = build_pcp_restored_valid_mask(
+                positions=positions,
+                views=pcp_prefill_metadata.views,
+            )
+            pcp_prefill_metadata.restored_swa_valid_mask = restored_valid_mask
+            req_indices = build_pcp_restored_req_indices(
+                positions=positions,
+                views=pcp_prefill_metadata.views,
+            )
+            slot_mapping = build_pcp_full_slot_mapping(
+                positions=positions,
+                req_indices=req_indices,
+                block_table=swa_metadata.block_table,
+                block_size=swa_storage_block_size,
+                valid_mask=restored_valid_mask,
+                cp_world_size=self.pcp_world_size,
+                cp_rank=self.pcp_rank,
+                cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
+            )
+            kv_insert_mask = slot_mapping >= 0
 
         # kv is unchanged; attention reads kv solely via swa_kv_cache.
         if cache_dtype == torch.uint8:
+            if local_q_indices is not None:
+                from vllm.models.deepseek_v4.xpu.xpu_qnorm_rope_kv_fp8_insert import (
+                    xpu_qnorm_rope_kv_fp8_insert,
+                )
+
+                kv_roped = xpu_qnorm_rope_kv_fp8_insert(
+                    q,
+                    kv,
+                    swa_kv_cache,
+                    slot_mapping,
+                    positions,
+                    cos_sin_cache,
+                    self.eps,
+                    swa_storage_block_size,
+                    insert_mask=kv_insert_mask,
+                    return_kv_roped=True,
+                )
+                assert pcp_prefill_metadata is not None
+                assert kv_roped is not None
+                pcp_prefill_metadata.restored_swa_kv = kv_roped
+                if self.n_local_heads < self.padded_heads:
+                    q = F.pad(
+                        q,
+                        (0, 0, 0, self.padded_heads - self.n_local_heads),
+                        value=0.0,
+                    )
+                return restore_pcp_local_tensor_to_padded_tokens(
+                    q, local_q_indices, num_padded_local_tokens
+                )
+
             # fp8_ds_mla UE8M0 paged path. Horizontally fused:
             #   Q side:  per-head RMSNorm (no weight) + GPT-J RoPE, zero-filling
             #            the padding head slots; the kernel allocates and returns
             #            the padded q tensor.
             #   KV side: GPT-J RoPE + UE8M0 FP8 quant + paged cache insert.
             swa_kv_cache_2d = swa_kv_cache.view(swa_kv_cache.shape[0], -1)
-            return torch.ops._C.fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(
+            q = torch.ops._C.fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(
                 q,
                 kv,
                 swa_kv_cache_2d,
-                swa_metadata.slot_mapping,
+                slot_mapping,
                 positions,
                 cos_sin_cache,
                 self.padded_heads,
                 self.eps,
-                swa_metadata.block_size,
+                swa_storage_block_size,
+            )
+            return restore_pcp_local_tensor_to_padded_tokens(
+                q, local_q_indices, num_padded_local_tokens
             )
 
         # Plain-row path: the [num_blocks, block_size, 512] cache stores the KV
@@ -690,13 +795,15 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
                 q,
                 kv,
                 swa_kv_cache_3d,
-                swa_metadata.slot_mapping,
+                slot_mapping,
                 positions,
                 cos_sin_cache,
                 self.eps,
                 block_size,
             )
-            return q
+            return restore_pcp_local_tensor_to_padded_tokens(
+                q, local_q_indices, num_padded_local_tokens
+            )
 
         # per-tensor fp8 (torch.float8_e4m3fn)
         q_fp8 = torch.empty_like(q, dtype=torch.float8_e4m3fn)
@@ -705,7 +812,7 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
             kv,
             q_fp8,
             swa_kv_cache_3d,
-            swa_metadata.slot_mapping,
+            slot_mapping,
             positions,
             cos_sin_cache,
             self._flashinfer_fp8_kv_scale,
@@ -713,7 +820,9 @@ class DeepseekV4Attention(nn.Module, AttentionLayerBase, ABC):
             self.eps,
             block_size,
         )
-        return q_fp8
+        return restore_pcp_local_tensor_to_padded_tokens(
+            q_fp8, local_q_indices, num_padded_local_tokens
+        )
 
     def get_attn_backend(self) -> type[AttentionBackend]:
         return self.backend_cls
@@ -920,4 +1029,52 @@ class DeepseekV4Indexer(nn.Module):
             self.ln_events[1],
             self.aux_stream,
         )
-        return self.indexer_op(hidden_states, q_quant, k, weights)
+        attn_metadata = get_forward_context().attn_metadata
+        if not isinstance(attn_metadata, dict):
+            return self.indexer_op(hidden_states, q_quant, k, weights)
+        indexer_metadata = cast(
+            DeepseekV32IndexerMetadata, attn_metadata[self.k_cache.prefix]
+        )
+        if indexer_metadata.pcp_allgather_restore_idx is None:
+            return self.indexer_op(hidden_states, q_quant, k, weights)
+
+        compact_indices = indexer_metadata.pcp_compact_restored_indices
+        local_compact_indices = indexer_metadata.pcp_local_compact_indices
+        local_valid_mask = indexer_metadata.pcp_local_valid_mask
+        assert compact_indices is not None
+        assert local_compact_indices is not None
+        assert local_valid_mask is not None
+
+        restore_idx = indexer_metadata.pcp_allgather_restore_idx
+        num_local_tokens = get_pcp_num_local_tokens_from_restore_idx(
+            restore_idx, self.compressor.pcp_world_size
+        )
+        pcp_group = get_pcp_group()
+
+        def gather_and_compact(tensor: torch.Tensor) -> torch.Tensor:
+            restored = pcp_allgather_and_restore(
+                tensor,
+                num_local_tokens,
+                restore_idx,
+                pcp_group,
+            )
+            return torch.index_select(restored, 0, compact_indices)
+
+        if isinstance(q_quant, tuple):
+            q_quant = tuple(gather_and_compact(tensor) for tensor in q_quant)
+        else:
+            q_quant = gather_and_compact(q_quant)
+        weights = gather_and_compact(weights)
+
+        topk_indices = self.indexer_op(hidden_states, q_quant, k, weights)
+        global_topk = topk_indices[: compact_indices.numel()]
+        local_topk = torch.index_select(global_topk, 0, local_compact_indices)
+
+        # Preserve the model runner's PCP-local padded row layout. Padding can
+        # occur between requests, so scatter into the valid local rows instead
+        # of packing all results at the front of the shared buffer.
+        num_padded_local_rows = min(hidden_states.shape[0], topk_indices.shape[0])
+        topk_indices[:num_padded_local_rows].fill_(-1)
+        local_rows = torch.nonzero(local_valid_mask, as_tuple=False).flatten()
+        topk_indices.index_copy_(0, local_rows, local_topk)
+        return topk_indices

--- a/vllm/models/deepseek_v4/common/ops/__init__.py
+++ b/vllm/models/deepseek_v4/common/ops/__init__.py
@@ -4,6 +4,7 @@
 from .cache_utils import (
     build_flashinfer_mixed_sparse_indices,
     combine_topk_swa_indices,
+    combine_topk_swa_indices_with_positions,
     compute_global_topk_indices_and_lens,
     dequantize_and_gather_k_cache,
     quantize_and_insert_k_cache,
@@ -18,6 +19,7 @@ __all__ = [
     "MXFP4_BLOCK_SIZE",
     "build_flashinfer_mixed_sparse_indices",
     "combine_topk_swa_indices",
+    "combine_topk_swa_indices_with_positions",
     "compute_global_topk_indices_and_lens",
     "dequantize_and_gather_k_cache",
     "fused_indexer_q_rope_quant",

--- a/vllm/models/deepseek_v4/common/ops/cache_utils.py
+++ b/vllm/models/deepseek_v4/common/ops/cache_utils.py
@@ -392,6 +392,8 @@ def dequantize_and_gather_k_cache(
     block_size: int,
     offset: int,
     use_fnuz: bool = False,
+    *,
+    force_triton: bool = False,
 ) -> None:
     """Dequantize and gather a paged DSv4 K cache.
 
@@ -400,7 +402,7 @@ def dequantize_and_gather_k_cache(
     ``current_platform.is_fp8_fnuz()`` for ``swa_k_cache`` (C++ encoder
     writes FNUZ on gfx942 and OCP on gfx950).
     """
-    if has_cutedsl():
+    if not force_triton and has_cutedsl():
         # lazily import, otherwise some tests fail due to CUDA driver init failure.
         from vllm.models.deepseek_v4.nvidia.ops.dequant_gather_k_cutedsl import (
             dequantize_and_gather_k_cache_cutedsl,
@@ -564,6 +566,57 @@ def combine_topk_swa_indices(
     return combined_indices, combined_lens
 
 
+def combine_topk_swa_indices_with_positions(
+    topk_indices: torch.Tensor,
+    query_positions: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    seq_lens: torch.Tensor,
+    gather_lens: torch.Tensor,
+    window_size: int,
+    compress_ratio: int,
+    topk: int,
+    M: int,
+    N: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Combine compressed/SWA indices for non-contiguous PCP query positions."""
+    num_tokens = topk_indices.shape[0]
+    num_reqs = seq_lens.shape[0]
+    combined_topk = (
+        (topk + window_size + _SPARSE_PREFILL_TOPK_ALIGNMENT - 1)
+        // _SPARSE_PREFILL_TOPK_ALIGNMENT
+        * _SPARSE_PREFILL_TOPK_ALIGNMENT
+    )
+    combined_indices = torch.full(
+        (num_tokens, combined_topk),
+        fill_value=-1,
+        dtype=torch.int32,
+        device=topk_indices.device,
+    )
+    combined_lens = torch.empty(
+        num_tokens, dtype=torch.int32, device=topk_indices.device
+    )
+
+    num_workers = 128
+    _combine_topk_swa_indices_with_positions_kernel[(num_reqs, num_workers)](
+        combined_indices,
+        combined_indices.stride(0),
+        combined_lens,
+        topk_indices,
+        topk_indices.stride(0),
+        query_positions,
+        query_start_loc,
+        seq_lens,
+        gather_lens,
+        M,
+        N,
+        TOP_K=topk,
+        COMPRESS_RATIO=compress_ratio,
+        WINDOW_SIZE=window_size,
+        PADDED_TOP_K=triton.next_power_of_2(topk_indices.shape[-1]),
+    )
+    return combined_indices, combined_lens
+
+
 @triton.jit
 def _combine_topk_swa_indices_kernel(
     combined_indices_ptr,
@@ -635,6 +688,67 @@ def _combine_topk_swa_indices_kernel(
 
         combined_len = topk_len + swa_len
         tl.store(combined_lens_ptr + token_idx, combined_len)
+
+
+@triton.jit
+def _combine_topk_swa_indices_with_positions_kernel(
+    combined_indices_ptr,
+    combined_indices_stride,
+    combined_lens_ptr,
+    topk_indices_ptr,
+    topk_indices_stride,
+    query_positions_ptr,
+    query_start_loc_ptr,
+    seq_lens_ptr,
+    gather_lens_ptr,
+    M,
+    N,
+    TOP_K: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    WINDOW_SIZE: tl.constexpr,
+    PADDED_TOP_K: tl.constexpr,
+):
+    batch_idx = tl.program_id(0)
+    worker_id = tl.program_id(1)
+    num_workers = tl.num_programs(1)
+
+    base = tl.load(query_start_loc_ptr)
+    query_start = tl.load(query_start_loc_ptr + batch_idx) - base
+    query_end = tl.load(query_start_loc_ptr + batch_idx + 1) - base
+    seq_len = tl.load(seq_lens_ptr + batch_idx)
+    gather_len = tl.load(gather_lens_ptr + batch_idx)
+    gather_start = seq_len - gather_len
+
+    for token_idx in range(query_start + worker_id, query_end, num_workers):
+        pos = tl.load(query_positions_ptr + token_idx)
+        token_valid = (pos >= gather_start) & (pos < seq_len)
+        topk_len = tl.minimum((pos + 1) // COMPRESS_RATIO, TOP_K)
+        topk_len = tl.where(token_valid, topk_len, 0)
+        swa_len = tl.minimum(pos + 1, WINDOW_SIZE)
+        swa_len = tl.where(token_valid, swa_len, 0)
+
+        offset = tl.arange(0, PADDED_TOP_K)
+        mask = offset < topk_len
+        topk_indices = tl.load(
+            topk_indices_ptr + token_idx * topk_indices_stride + offset,
+            mask=mask,
+        )
+        tl.store(
+            combined_indices_ptr + token_idx * combined_indices_stride + offset,
+            topk_indices + M * batch_idx,
+            mask=mask,
+        )
+        offset = tl.arange(0, WINDOW_SIZE)
+        tl.store(
+            combined_indices_ptr
+            + token_idx * combined_indices_stride
+            + topk_len
+            + offset,
+            M * batch_idx + N + offset + pos - swa_len + 1 - gather_start,
+            mask=offset < swa_len,
+        )
+
+        tl.store(combined_lens_ptr + token_idx, topk_len + swa_len)
 
 
 def build_flashinfer_mixed_sparse_indices(

--- a/vllm/models/deepseek_v4/compressor.py
+++ b/vllm/models/deepseek_v4/compressor.py
@@ -4,10 +4,12 @@
 from dataclasses import dataclass
 from typing import Any, ClassVar, cast
 
+import numpy as np
 import torch
 from torch import nn
 
 from vllm.config import VllmConfig, get_current_vllm_config
+from vllm.distributed.parallel_state import get_pcp_group
 from vllm.forward_context import get_forward_context
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.layernorm import RMSNorm
@@ -20,7 +22,14 @@ from vllm.models.deepseek_v4.common.ops.fused_indexer_q import MXFP4_BLOCK_SIZE
 from vllm.models.deepseek_v4.common.ops.save_partial_states import (
     save_partial_states,
 )
+from vllm.models.deepseek_v4.pcp_metadata import (
+    build_pcp_compressed_slot_mapping,
+    build_pcp_full_slot_mapping,
+    build_pcp_restored_req_indices,
+    build_pcp_restored_valid_mask,
+)
 from vllm.platforms import current_platform
+from vllm.utils.torch_utils import np_to_pinned_tensor
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionCGSupport,
@@ -28,7 +37,12 @@ from vllm.v1.attention.backend import (
     CommonAttentionMetadata,
     MultipleOf,
 )
-from vllm.v1.attention.backends.utils import split_decodes_and_prefills
+from vllm.v1.attention.backends.utils import (
+    get_pcp_max_buffer_num_tokens,
+    get_pcp_num_local_tokens_from_restore_idx,
+    pcp_allgather_and_restore,
+    split_decodes_and_prefills,
+)
 from vllm.v1.kv_cache_interface import (
     KVCacheSpec,
     MLAAttentionSpec,
@@ -90,6 +104,19 @@ class CompressorMetadata:
 
     token_to_req_indices: torch.Tensor | None = None  # [num_tokens]
     num_decode_tokens: int | None = None
+    pcp_allgather_restore_idx: torch.Tensor | None = None
+    pcp_request_views: list[Any] | None = None
+
+
+class _SlotMappingMetadataOverride:
+    """Proxy metadata while replacing only the slot mapping used by kernels."""
+
+    def __init__(self, base: Any, slot_mapping: torch.Tensor) -> None:
+        self._base = base
+        self.slot_mapping = slot_mapping
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._base, name)
 
 
 class CompressorMetadataBuilder(AttentionMetadataBuilder):
@@ -99,10 +126,13 @@ class CompressorMetadataBuilder(AttentionMetadataBuilder):
         super().__init__(*args, **kwargs)
         assert isinstance(self.kv_cache_spec, SlidingWindowMLASpec | MLAAttentionSpec)
         mla_spec = cast(SlidingWindowMLASpec | MLAAttentionSpec, self.kv_cache_spec)
-        self.block_size = mla_spec.block_size
+        self.block_size = mla_spec.storage_block_size
+        self.pcp_world_size = (
+            self.vllm_config.parallel_config.prefill_context_parallel_size
+        )
 
         self.token_to_req_indices = torch.zeros(
-            self.vllm_config.scheduler_config.max_num_batched_tokens,
+            get_pcp_max_buffer_num_tokens(self.vllm_config),
             dtype=torch.int32,
             device=self.device,
         )
@@ -113,9 +143,22 @@ class CompressorMetadataBuilder(AttentionMetadataBuilder):
         common_attn_metadata: CommonAttentionMetadata,
         fast_build: bool = False,
     ) -> CompressorMetadata:
-        token_to_req_indices = common_attn_metadata.token_to_req_indices(
-            self.token_to_req_indices
-        )
+        pcp_restore_idx = common_attn_metadata.pcp_allgather_restore_idx
+        if pcp_restore_idx is None:
+            token_to_req_indices = common_attn_metadata.token_to_req_indices(
+                self.token_to_req_indices
+            )
+        else:
+            query_lens = np.diff(
+                np.asarray(common_attn_metadata.query_start_loc_cpu, dtype=np.int32)
+            ) * self.pcp_world_size
+            req_indices = np.repeat(
+                np.arange(common_attn_metadata.num_reqs, dtype=np.int32), query_lens
+            )
+            token_to_req_indices = self.token_to_req_indices[: req_indices.shape[0]]
+            token_to_req_indices.copy_(
+                np_to_pinned_tensor(req_indices), non_blocking=True
+            )
         num_decode_tokens = None
         if _prefer_two_stage_compressor():
             _, _, num_decode_tokens, _ = split_decodes_and_prefills(
@@ -127,6 +170,8 @@ class CompressorMetadataBuilder(AttentionMetadataBuilder):
             block_size=self.block_size,
             token_to_req_indices=token_to_req_indices,
             num_decode_tokens=num_decode_tokens,
+            pcp_allgather_restore_idx=pcp_restore_idx,
+            pcp_request_views=common_attn_metadata.pcp_request_views,
         )
 
 
@@ -224,6 +269,13 @@ class DeepseekCompressor(nn.Module):
         self.device = current_platform.device_type
         self.max_num_reqs = vllm_config.scheduler_config.max_num_seqs
         self.max_model_len = vllm_config.model_config.max_model_len
+        self.pcp_world_size = vllm_config.parallel_config.prefill_context_parallel_size
+        self.pcp_rank = 0
+        if self.pcp_world_size > 1:
+            self.pcp_rank = get_pcp_group().rank_in_group
+        self.cp_kv_cache_interleave_size = (
+            vllm_config.parallel_config.cp_kv_cache_interleave_size
+        )
 
         self.overlap = compress_ratio == 4
         self.coff = 1 + self.overlap
@@ -329,6 +381,63 @@ class DeepseekCompressor(nn.Module):
         num_actual = slot_mapping.shape[0]
         block_table = state_metadata.block_table
         block_size = state_metadata.block_size
+        k_cache_slot_mapping = None
+        if state_metadata.pcp_allgather_restore_idx is not None:
+            restore_idx = state_metadata.pcp_allgather_restore_idx
+            pcp_group = get_pcp_group()
+            num_local_tokens = get_pcp_num_local_tokens_from_restore_idx(
+                restore_idx, pcp_group.world_size
+            )
+            kv_score = pcp_allgather_and_restore(
+                kv_score,
+                num_local_tokens,
+                restore_idx,
+                pcp_group,
+            )
+            positions = pcp_allgather_and_restore(
+                positions,
+                num_local_tokens,
+                restore_idx,
+                pcp_group,
+            )
+            kv, score = kv_score.split(
+                [self.coff * self.head_dim, self.coff * self.head_dim], dim=-1
+            )
+            assert state_metadata.pcp_request_views is not None
+            restored_valid_mask = build_pcp_restored_valid_mask(
+                positions=positions,
+                views=state_metadata.pcp_request_views,
+            )
+            restored_req_indices = build_pcp_restored_req_indices(
+                positions=positions,
+                views=state_metadata.pcp_request_views,
+            )
+            slot_mapping = build_pcp_full_slot_mapping(
+                positions=positions,
+                req_indices=restored_req_indices,
+                block_table=block_table,
+                block_size=block_size,
+                valid_mask=restored_valid_mask,
+                cp_world_size=self.pcp_world_size,
+                cp_rank=self.pcp_rank,
+                cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
+            )
+            num_actual = slot_mapping.shape[0]
+            k_cache_metadata = cast(Any, attn_metadata[self.k_cache_prefix])
+            k_cache_layer = self._static_forward_context[self.k_cache_prefix]
+            kv_cache = k_cache_layer.kv_cache
+            if hasattr(k_cache_metadata, "block_table"):
+                k_cache_slot_mapping = build_pcp_compressed_slot_mapping(
+                    positions=positions,
+                    req_indices=restored_req_indices,
+                    block_table=k_cache_metadata.block_table,
+                    block_size=int(kv_cache.shape[1]),
+                    compress_ratio=self.compress_ratio,
+                    valid_mask=restored_valid_mask,
+                    cp_world_size=self.pcp_world_size,
+                    cp_rank=self.pcp_rank,
+                    cp_kv_cache_interleave_size=(self.cp_kv_cache_interleave_size),
+                )
 
         # [num_blocks, block_size, kv_dim+score_dim], where kv_dim == score_dim
         state_cache = self.state_cache.kv_cache
@@ -370,6 +479,11 @@ class DeepseekCompressor(nn.Module):
         k_cache_metadata = cast(Any, attn_metadata[self.k_cache_prefix])
         k_cache_layer = self._static_forward_context[self.k_cache_prefix]
         kv_cache = k_cache_layer.kv_cache
+        if k_cache_slot_mapping is not None:
+            k_cache_metadata = _SlotMappingMetadataOverride(
+                k_cache_metadata,
+                k_cache_slot_mapping,
+            )
 
         # Plain-row V4 reads a contiguous bf16 / per-tensor fp8 cache row; the
         # fp8_ds_mla path uses the UE8M0 paged uint8 layout.

--- a/vllm/models/deepseek_v4/compressor.py
+++ b/vllm/models/deepseek_v4/compressor.py
@@ -60,6 +60,10 @@ class CompressorBackend(AttentionBackend):
     def __init__(self):
         super().__init__()
 
+    @classmethod
+    def supports_pcp(cls) -> bool:
+        return True
+
     @staticmethod
     def get_name() -> str:
         return "CompressorBackend"

--- a/vllm/models/deepseek_v4/nvidia/flashmla.py
+++ b/vllm/models/deepseek_v4/nvidia/flashmla.py
@@ -9,12 +9,18 @@ from vllm.forward_context import get_forward_context
 from vllm.models.deepseek_v4.attention import DeepseekV4Attention
 from vllm.models.deepseek_v4.common.ops import (
     combine_topk_swa_indices,
+    combine_topk_swa_indices_with_positions,
     compute_global_topk_indices_and_lens,
     dequantize_and_gather_k_cache,
 )
 from vllm.models.deepseek_v4.nvidia.ops.o_proj import (
     compute_fp8_einsum_recipe,
     deep_gemm_fp8_o_proj,
+)
+from vllm.models.deepseek_v4.pcp_metadata import (
+    compact_pcp_sparse_indices,
+    compact_pcp_sparse_prefill_queries,
+    overlay_pcp_restored_swa_kv_workspace,
 )
 from vllm.models.deepseek_v4.sparse_mla import (
     DeepseekV4FlashMLABackend,
@@ -24,16 +30,27 @@ from vllm.v1.attention.ops.flashmla import (
     flash_mla_sparse_fwd,
     flash_mla_with_kvcache,
 )
+from vllm.v1.worker.cp_utils import guard_dsv4_pcp_prefill_runtime_metadata
 from vllm.v1.worker.workspace import current_workspace_manager
 
 if TYPE_CHECKING:
     from vllm.v1.attention.backends.mla.sparse_swa import DeepseekSparseSWAMetadata
 
 
+def _kv_cache_storage_block_size(
+    k_cache: torch.Tensor | None,
+    fallback: int,
+) -> int:
+    if k_cache is not None and k_cache.dim() >= 3:
+        return int(k_cache.shape[1])
+    return int(fallback)
+
+
 class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
     """FlashMLA sparse MLA attention layer for DeepSeek V4 (CUDA)."""
 
     backend_cls = DeepseekV4FlashMLABackend
+    supports_pcp = True
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -249,6 +266,12 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
         num_prefill_tokens = swa_metadata.num_prefill_tokens
         num_decodes = swa_metadata.num_decodes
         num_decode_tokens = swa_metadata.num_decode_tokens
+        is_pcp_prefill = swa_metadata.pcp_allgather_restore_idx is not None
+        guard_dsv4_pcp_prefill_runtime_metadata(
+            pcp_allgather_restore_idx=swa_metadata.pcp_allgather_restore_idx,
+            num_prefill_tokens=num_prefill_tokens,
+            runtime_metadata=swa_metadata.pcp_prefill_metadata,
+        )
 
         # Use pre-computed prefill metadata.
         seq_lens = swa_metadata.prefill_seq_lens
@@ -293,27 +316,55 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
                 # Gather compressed KV
                 assert attn_metadata is not None
                 block_table = attn_metadata.block_table[num_decodes:]
+                compressed_cache_block_size = _kv_cache_storage_block_size(
+                    compressed_k_cache,
+                    attn_metadata.block_size // self.compress_ratio,
+                )
                 dequantize_and_gather_k_cache(
                     kv[:chunk_size],
                     compressed_k_cache,
                     seq_lens=seq_lens[chunk_start:chunk_end] // self.compress_ratio,
                     gather_lens=None,
                     block_table=block_table[chunk_start:chunk_end],
-                    block_size=attn_metadata.block_size // self.compress_ratio,
+                    block_size=compressed_cache_block_size,
                     offset=0,
                 )
 
             # Gather SWA KV
             swa_block_table = swa_metadata.block_table[num_decodes:]
+            swa_cache_block_size = _kv_cache_storage_block_size(
+                swa_k_cache,
+                swa_metadata.block_size,
+            )
             dequantize_and_gather_k_cache(
                 kv[:chunk_size],
                 swa_k_cache,
                 seq_lens=seq_lens[chunk_start:chunk_end],
                 gather_lens=gather_lens[chunk_start:chunk_end],
                 block_table=swa_block_table[chunk_start:chunk_end],
-                block_size=swa_metadata.block_size,
+                block_size=swa_cache_block_size,
                 offset=chunk_N,
+                force_triton=is_pcp_prefill,
             )
+            if is_pcp_prefill:
+                assert swa_metadata.pcp_prefill_metadata is not None
+                pcp_metadata = swa_metadata.pcp_prefill_metadata
+                assert pcp_metadata.restored_swa_kv is not None
+                assert pcp_metadata.restored_swa_positions is not None
+                assert pcp_metadata.restored_swa_valid_mask is not None
+                overlay_pcp_restored_swa_kv_workspace(
+                    out=kv[:chunk_size],
+                    restored_kv=pcp_metadata.restored_swa_kv,
+                    restored_positions=pcp_metadata.restored_swa_positions,
+                    restored_valid_mask=pcp_metadata.restored_swa_valid_mask,
+                    views=pcp_metadata.views,
+                    chunk_start=chunk_start,
+                    chunk_end=chunk_end,
+                    seq_lens=seq_lens[chunk_start:chunk_end],
+                    gather_lens=gather_lens[chunk_start:chunk_end],
+                    chunk_n=chunk_N,
+                    chunk_m=chunk_M,
+                )
 
             # Combine the topk indices and SWA indices for gathered KV cache
             query_start = (
@@ -323,11 +374,53 @@ class DeepseekV4FlashMLAAttention(DeepseekV4Attention):
                 query_start_loc_cpu[num_decodes + chunk_end] - prefill_token_base
             )
 
+            chunk_query_start_loc = query_start_loc[
+                num_decodes + chunk_start : num_decodes + chunk_end + 1
+            ]
+            if is_pcp_prefill:
+                combined_indices, combined_lens = (
+                    combine_topk_swa_indices_with_positions(
+                        topk_indices[query_start:query_end],
+                        positions[query_start:query_end],
+                        chunk_query_start_loc,
+                        seq_lens[chunk_start:chunk_end],
+                        gather_lens[chunk_start:chunk_end],
+                        self.window_size,
+                        self.compress_ratio,
+                        top_k,
+                        chunk_M,
+                        chunk_N,
+                    )
+                )
+                combined_indices, combined_lens = compact_pcp_sparse_indices(
+                    combined_indices, combined_lens
+                )
+                chunk_output = output[query_start:query_end]
+                chunk_output.zero_()
+                pcp_q, pcp_indices, pcp_lens, valid_rows = (
+                    compact_pcp_sparse_prefill_queries(
+                        q[query_start:query_end],
+                        combined_indices,
+                        combined_lens,
+                    )
+                )
+                if valid_rows.numel() > 0:
+                    pcp_out = output.new_empty((pcp_q.shape[0], *output.shape[1:]))
+                    flash_mla_sparse_fwd(
+                        q=pcp_q,
+                        kv=kv.view(-1, 1, q.shape[-1]),
+                        indices=pcp_indices.unsqueeze(1),
+                        sm_scale=self.scale,
+                        attn_sink=self.attn_sink,
+                        topk_length=pcp_lens,
+                        out=pcp_out,
+                    )
+                    chunk_output.index_copy_(0, valid_rows, pcp_out)
+                continue
+
             combined_indices, combined_lens = combine_topk_swa_indices(
                 topk_indices[query_start:query_end],
-                query_start_loc[
-                    num_decodes + chunk_start : num_decodes + chunk_end + 1
-                ],
+                chunk_query_start_loc,
                 seq_lens[chunk_start:chunk_end],
                 gather_lens[chunk_start:chunk_end],
                 self.window_size,

--- a/vllm/models/deepseek_v4/pcp_metadata.py
+++ b/vllm/models/deepseek_v4/pcp_metadata.py
@@ -1,0 +1,631 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""DeepSeek V4 prefill PCP metadata helpers."""
+
+from dataclasses import dataclass
+from typing import Literal
+
+import torch
+
+from vllm.v1.worker.cp_utils import PCPInterleaveRequestView
+
+
+@dataclass(frozen=True)
+class DeepseekV4PcpQueryPlan:
+    """Indexer query rows after PCP all-gather, restore, and padding removal."""
+
+    restored_valid_mask: torch.Tensor
+    compact_restored_indices: torch.Tensor
+    local_compact_indices: torch.Tensor
+    local_valid_mask: torch.Tensor
+    num_local_tokens: int
+
+
+@dataclass(frozen=True)
+class DeepseekV4PcpSwaSegment:
+    query_start: int
+    query_end: int
+    kv_start: int
+    kv_end: int
+    sparse_rows: int
+    q_rows: torch.Tensor
+    shifted_indices: torch.Tensor
+    topk_lens: torch.Tensor
+    valid_mask: torch.Tensor
+
+
+@dataclass(frozen=True)
+class DeepseekV4PcpSparseRows:
+    q_rows: torch.Tensor
+    sparse_rows: int
+    valid_query_mask: torch.Tensor
+    rows_min: int
+    rows_max: int
+
+
+@dataclass
+class DeepseekV4PcpPrefillMetadata:
+    cp_size: int
+    cp_rank: int
+    strategy: Literal["dual_chunk"]
+    views: list[PCPInterleaveRequestView]
+    local_query_start_loc: torch.Tensor
+    local_seq_lens: torch.Tensor
+    local_swa_indices: torch.Tensor | None
+    local_swa_valid_lens: torch.Tensor | None
+    local_c4_indices: torch.Tensor | None
+    local_c128_indices: torch.Tensor | None
+    global_slot_mapping: torch.Tensor
+    compressor_write_locs_global: torch.Tensor | None
+    restore_idx: torch.Tensor | None
+    debug_global_positions: torch.Tensor | None
+    sparse_rows: DeepseekV4PcpSparseRows | None = None
+    swa_segments: list[DeepseekV4PcpSwaSegment] | None = None
+    restored_swa_kv: torch.Tensor | None = None
+    restored_swa_positions: torch.Tensor | None = None
+    restored_swa_valid_mask: torch.Tensor | None = None
+
+
+def build_pcp_full_slot_mapping(
+    *,
+    positions: torch.Tensor,
+    req_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    valid_mask: torch.Tensor | None = None,
+    cp_world_size: int = 1,
+    cp_rank: int = 0,
+    cp_kv_cache_interleave_size: int = 1,
+) -> torch.Tensor:
+    """Map restored PCP positions to slots owned by this CP rank.
+
+    DeepSeek V4 cache groups do not all use the scheduler block size: SWA uses
+    64-token pages, C4/C128 use compressed storage pages, and compressor state
+    groups use 4/8-token pages. CP ownership is nevertheless defined in the
+    original token coordinate system by ``cp_kv_cache_interleave_size``. Map to
+    that rank-local coordinate first, then address this cache group's pages.
+    """
+    return _build_pcp_owned_slot_mapping(
+        positions=positions,
+        req_indices=req_indices,
+        block_table=block_table,
+        block_size=block_size,
+        valid_mask=valid_mask,
+        cp_world_size=cp_world_size,
+        cp_rank=cp_rank,
+        cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
+        compress_ratio=1,
+    )
+
+
+def build_pcp_compressed_slot_mapping(
+    *,
+    positions: torch.Tensor,
+    req_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    compress_ratio: int,
+    valid_mask: torch.Tensor | None = None,
+    cp_world_size: int = 1,
+    cp_rank: int = 0,
+    cp_kv_cache_interleave_size: int = 1,
+) -> torch.Tensor:
+    """Map restored PCP boundaries to compressed slots owned by this CP rank."""
+    return _build_pcp_owned_slot_mapping(
+        positions=positions,
+        req_indices=req_indices,
+        block_table=block_table,
+        block_size=block_size,
+        valid_mask=valid_mask,
+        cp_world_size=cp_world_size,
+        cp_rank=cp_rank,
+        cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
+        compress_ratio=compress_ratio,
+    )
+
+
+def _build_pcp_owned_slot_mapping(
+    *,
+    positions: torch.Tensor,
+    req_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    valid_mask: torch.Tensor | None,
+    cp_world_size: int,
+    cp_rank: int,
+    cp_kv_cache_interleave_size: int,
+    compress_ratio: int,
+) -> torch.Tensor:
+    """Translate global token positions into one rank's local cache pages."""
+    if positions.numel() == 0:
+        return torch.empty_like(positions, dtype=torch.long)
+
+    if block_size <= 0:
+        raise ValueError(f"block_size must be positive, got {block_size}")
+    if cp_world_size <= 0 or not 0 <= cp_rank < cp_world_size:
+        raise ValueError(
+            f"invalid CP topology: world_size={cp_world_size}, rank={cp_rank}"
+        )
+    if cp_kv_cache_interleave_size <= 0:
+        raise ValueError(
+            "cp_kv_cache_interleave_size must be positive, got "
+            f"{cp_kv_cache_interleave_size}"
+        )
+    if compress_ratio <= 0:
+        raise ValueError(f"compress_ratio must be positive, got {compress_ratio}")
+    if (
+        cp_world_size > 1
+        and compress_ratio > 1
+        and cp_kv_cache_interleave_size % compress_ratio != 0
+    ):
+        raise ValueError(
+            "compressed PCP cache ownership requires CP interleave size to be "
+            f"divisible by compress_ratio, got interleave="
+            f"{cp_kv_cache_interleave_size}, ratio={compress_ratio}"
+        )
+
+    req_indices = req_indices[: positions.numel()].to(
+        device=positions.device, dtype=torch.long
+    )
+    positions_long = positions.to(dtype=torch.long)
+    slot_mapping = torch.full_like(positions_long, -1)
+
+    valid = (positions_long >= 0) & (req_indices >= 0)
+    if compress_ratio > 1:
+        valid &= (positions_long + 1) % compress_ratio == 0
+    if valid_mask is not None:
+        valid &= valid_mask[: positions.numel()].to(
+            device=positions.device, dtype=torch.bool
+        )
+    if not valid.any():
+        return slot_mapping
+
+    cp_cycle = cp_world_size * cp_kv_cache_interleave_size
+    cycle_indices = positions_long // cp_cycle
+    cycle_offsets = positions_long % cp_cycle
+    owner_ranks = cycle_offsets // cp_kv_cache_interleave_size
+    valid &= owner_ranks == cp_rank
+
+    local_positions = (
+        cycle_indices * cp_kv_cache_interleave_size
+        + cycle_offsets % cp_kv_cache_interleave_size
+    )
+    storage_positions = local_positions // compress_ratio
+    block_indices = storage_positions // block_size
+    block_offsets = storage_positions % block_size
+    valid &= block_indices < block_table.shape[1]
+    valid &= req_indices < block_table.shape[0]
+    if not valid.any():
+        return slot_mapping
+
+    valid_req_indices = req_indices[valid]
+    valid_block_indices = block_indices[valid]
+    physical_blocks = block_table[valid_req_indices, valid_block_indices].to(
+        dtype=torch.long
+    )
+    valid_physical = physical_blocks >= 0
+    if valid_physical.any():
+        valid_slots = (
+            physical_blocks[valid_physical] * block_size
+            + block_offsets[valid][valid_physical]
+        )
+        valid_positions = torch.nonzero(valid, as_tuple=False).flatten()[valid_physical]
+        slot_mapping[valid_positions] = valid_slots
+    return slot_mapping
+
+
+def build_pcp_restored_req_indices(
+    *,
+    positions: torch.Tensor,
+    views: list[PCPInterleaveRequestView],
+) -> torch.Tensor:
+    """Build request indices aligned to a PCP all-gather restored buffer."""
+    req_indices = torch.full_like(positions, -1, dtype=torch.long)
+    row_start = 0
+    for view in views:
+        row_end = row_start + int(view.restore_idx.numel())
+        req_indices[row_start : min(row_end, positions.numel())] = int(view.req_idx)
+        row_start = row_end
+        if row_start >= positions.numel():
+            break
+    return req_indices
+
+
+def build_pcp_restored_valid_mask(
+    *,
+    positions: torch.Tensor,
+    views: list[PCPInterleaveRequestView],
+) -> torch.Tensor:
+    """Mark real restored rows and exclude per-rank padding rows."""
+    valid_mask = torch.zeros_like(positions, dtype=torch.bool)
+    row_start = 0
+    for view in views:
+        row_end = row_start + int(view.restore_idx.numel())
+        # Restored rows are sorted in request-local token order.  The view's
+        # ``global_seq_len`` is the scheduled query length, while ``positions``
+        # contains absolute model positions.  Comparing the two is wrong for a
+        # chunk with an existing prefix.  Padding follows the real query rows,
+        # so validity is determined by row count instead.
+        valid_end = min(row_start + int(view.global_seq_len), row_end)
+        valid_mask[row_start:valid_end] = True
+        row_start = row_end
+        if row_start >= positions.numel():
+            break
+    return valid_mask
+
+
+def build_pcp_query_plan(
+    *,
+    pcp_allgather_restore_idx: torch.Tensor,
+    views: list[PCPInterleaveRequestView],
+    pcp_world_size: int,
+    pcp_rank: int,
+) -> DeepseekV4PcpQueryPlan:
+    """Build compact global query rows and this rank's selection from them."""
+    restore_len = pcp_allgather_restore_idx.numel()
+    if pcp_world_size <= 1 or restore_len % pcp_world_size != 0:
+        raise ValueError(
+            "invalid PCP query topology: "
+            f"restore_len={restore_len}, world_size={pcp_world_size}"
+        )
+    if not 0 <= pcp_rank < pcp_world_size:
+        raise ValueError(f"invalid PCP rank {pcp_rank} for world_size={pcp_world_size}")
+
+    restored_valid_mask = build_pcp_restored_valid_mask(
+        positions=pcp_allgather_restore_idx,
+        views=views,
+    )
+    compact_restored_indices = torch.nonzero(
+        restored_valid_mask, as_tuple=False
+    ).flatten()
+
+    num_local_tokens = restore_len // pcp_world_size
+    local_concat_indices = torch.arange(
+        num_local_tokens,
+        dtype=pcp_allgather_restore_idx.dtype,
+        device=pcp_allgather_restore_idx.device,
+    )
+    local_concat_indices += pcp_rank * num_local_tokens
+    inverse_restore = torch.empty_like(pcp_allgather_restore_idx)
+    inverse_restore.scatter_(
+        0,
+        pcp_allgather_restore_idx,
+        torch.arange(
+            restore_len,
+            dtype=pcp_allgather_restore_idx.dtype,
+            device=pcp_allgather_restore_idx.device,
+        ),
+    )
+    local_restored_indices = torch.index_select(
+        inverse_restore, 0, local_concat_indices
+    )
+
+    restored_to_compact = torch.full_like(pcp_allgather_restore_idx, -1)
+    restored_to_compact[compact_restored_indices] = torch.arange(
+        compact_restored_indices.numel(),
+        dtype=pcp_allgather_restore_idx.dtype,
+        device=pcp_allgather_restore_idx.device,
+    )
+    local_compact_indices = torch.index_select(
+        restored_to_compact, 0, local_restored_indices
+    )
+    local_valid_mask = local_compact_indices >= 0
+
+    return DeepseekV4PcpQueryPlan(
+        restored_valid_mask=restored_valid_mask,
+        compact_restored_indices=compact_restored_indices,
+        local_compact_indices=local_compact_indices[local_valid_mask],
+        local_valid_mask=local_valid_mask,
+        num_local_tokens=num_local_tokens,
+    )
+
+
+def compact_pcp_sparse_indices(
+    indices: torch.Tensor,
+    lengths: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Keep the sparse kernel valid prefix free of padding sentinels."""
+    if indices.numel() == 0:
+        return indices, lengths
+
+    offsets = torch.arange(indices.shape[1], device=indices.device)
+    valid_prefix = offsets.unsqueeze(0) < lengths.unsqueeze(1)
+    valid_indices = valid_prefix & (indices >= 0)
+    new_lengths = valid_indices.sum(dim=1).to(lengths.dtype)
+    if torch.equal(new_lengths, lengths):
+        return indices, lengths
+
+    compacted = torch.full_like(indices, -1)
+    compacted_offsets = valid_indices.to(torch.long).cumsum(dim=1) - 1
+    row_ids = torch.arange(indices.shape[0], device=indices.device).unsqueeze(1)
+    row_ids = row_ids.expand_as(indices)
+    compacted[row_ids[valid_indices], compacted_offsets[valid_indices]] = indices[
+        valid_indices
+    ]
+    return compacted, new_lengths
+
+
+def compact_pcp_sparse_prefill_queries(
+    q: torch.Tensor,
+    indices: torch.Tensor,
+    lengths: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Remove PCP query rows that have no locally addressable KV."""
+    valid_rows = torch.nonzero(lengths > 0, as_tuple=False).flatten()
+    return (
+        q.index_select(0, valid_rows),
+        indices.index_select(0, valid_rows),
+        lengths.index_select(0, valid_rows),
+        valid_rows,
+    )
+
+
+def overlay_pcp_restored_swa_kv_workspace(
+    *,
+    out: torch.Tensor,
+    restored_kv: torch.Tensor,
+    restored_positions: torch.Tensor,
+    restored_valid_mask: torch.Tensor,
+    views: list[PCPInterleaveRequestView],
+    chunk_start: int,
+    chunk_end: int,
+    seq_lens: torch.Tensor,
+    gather_lens: torch.Tensor,
+    chunk_n: int,
+    chunk_m: int,
+) -> None:
+    """Overlay all-gather restored current-step SWA KV into a dense workspace."""
+    if chunk_start >= chunk_end:
+        return
+
+    flat_out = out.view(-1, out.shape[-1])
+    row_start = sum(int(view.restore_idx.numel()) for view in views[:chunk_start])
+    for req_offset, req_idx in enumerate(range(chunk_start, chunk_end)):
+        view = views[req_idx]
+        row_end = row_start + int(view.restore_idx.numel())
+        req_positions = restored_positions[row_start:row_end].to(torch.long)
+        req_valid = restored_valid_mask[row_start:row_end].to(torch.bool)
+        req_kv = restored_kv[row_start:row_end]
+
+        seq_len = int(seq_lens[req_offset].item())
+        gather_len = int(gather_lens[req_offset].item())
+        gather_start = seq_len - gather_len
+        req_valid = (
+            req_valid & (req_positions >= gather_start) & (req_positions < seq_len)
+        )
+        if req_valid.any():
+            valid_positions = req_positions[req_valid]
+            valid_kv = req_kv[req_valid]
+            target_rows = (
+                req_offset * chunk_m + chunk_n + valid_positions - gather_start
+            )
+            flat_out.index_copy_(0, target_rows.to(torch.long), valid_kv)
+
+        row_start = row_end
+
+
+def pcp_swa_torch_sparse_fwd(
+    *,
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    topk_length: torch.Tensor,
+    sm_scale: float,
+    attn_sink: torch.Tensor | None,
+    out: torch.Tensor,
+) -> None:
+    """Reference sparse SWA attention for PCP prefill segment fallback."""
+    out.zero_()
+    active_rows = topk_length > 0
+    if not active_rows.any():
+        return
+
+    q = q[active_rows]
+    indices = indices[active_rows]
+    topk_length = topk_length[active_rows]
+
+    num_rows, num_heads, _ = q.shape
+    max_topk = indices.shape[1]
+    valid_offsets = torch.arange(
+        max_topk, device=indices.device, dtype=topk_length.dtype
+    )
+    valid_mask = valid_offsets.unsqueeze(0) < topk_length.unsqueeze(1)
+    safe_indices = torch.where(indices >= 0, indices, torch.zeros_like(indices))
+    gathered_kv = kv.index_select(0, safe_indices.reshape(-1)).view(
+        num_rows, max_topk, kv.shape[1], kv.shape[-1]
+    )
+    gathered_kv = gathered_kv.squeeze(2).to(torch.float32)
+    q_float = q.to(torch.float32)
+    scores = torch.einsum("rhd,rkd->rhk", q_float, gathered_kv) * sm_scale
+    scores = scores.masked_fill(~valid_mask.unsqueeze(1), -float("inf"))
+    if attn_sink is not None:
+        sink = attn_sink[:num_heads].to(torch.float32).view(1, num_heads, 1)
+        sink = sink.expand(num_rows, -1, -1)
+        scores = torch.cat([scores, sink], dim=-1)
+
+    scores = torch.nan_to_num(
+        scores,
+        nan=torch.finfo(scores.dtype).min,
+        posinf=torch.finfo(scores.dtype).max,
+        neginf=torch.finfo(scores.dtype).min,
+    )
+    scores = scores - scores.max(dim=-1, keepdim=True).values
+    probs = torch.softmax(scores, dim=-1)
+    if attn_sink is not None:
+        probs = probs[..., :max_topk]
+    out[active_rows].copy_(
+        torch.einsum("rhk,rkd->rhd", probs, gathered_kv).to(out.dtype)
+    )
+
+
+def build_pcp_sparse_prefill_rows(
+    *,
+    combined_lens: torch.Tensor,
+    positions: torch.Tensor,
+    local_query_start_loc: torch.Tensor,
+    seq_lens: torch.Tensor,
+    gather_lens: torch.Tensor,
+    chunk_n: int,
+    chunk_m: int,
+) -> DeepseekV4PcpSparseRows:
+    """Map PCP query rows to compact rows in the gathered KV workspace."""
+    q_tokens = int(positions.numel())
+    q_rows = torch.empty(q_tokens, dtype=torch.long, device=positions.device)
+    chunk_size = int(seq_lens.numel())
+    for req_idx in range(chunk_size):
+        req_query_start = int(local_query_start_loc[req_idx].item())
+        req_query_end = int(local_query_start_loc[req_idx + 1].item())
+        if req_query_start == req_query_end:
+            continue
+        req_seq_len = int(seq_lens[req_idx].item())
+        req_gather_len = int(gather_lens[req_idx].item())
+        req_gather_start = req_seq_len - req_gather_len
+        req_positions = positions[req_query_start:req_query_end].to(torch.long)
+        req_valid = (req_positions >= req_gather_start) & (req_positions < req_seq_len)
+        req_rows = req_idx * chunk_m + chunk_n + req_positions - req_gather_start
+        req_rows = torch.where(req_valid, req_rows, torch.zeros_like(req_rows))
+        q_rows[req_query_start:req_query_end] = req_rows
+
+    valid_query_mask = combined_lens > 0
+    rows_min = 0
+    rows_max = -1
+    if q_tokens > 0 and valid_query_mask.any():
+        valid_rows = q_rows[valid_query_mask]
+        rows_min = int(valid_rows.min().item())
+        rows_max = int(valid_rows.max().item())
+        if rows_min < 0 or rows_max >= chunk_size * chunk_m:
+            raise ValueError(
+                "DeepSeek V4 PCP sparse prefill query rows are outside the "
+                "gathered KV workspace: "
+                f"min={rows_min}, max={rows_max}, "
+                f"workspace_rows={chunk_size * chunk_m}"
+            )
+        sparse_rows = rows_max + 1
+    else:
+        sparse_rows = 1
+    return DeepseekV4PcpSparseRows(
+        q_rows=q_rows,
+        sparse_rows=sparse_rows,
+        valid_query_mask=valid_query_mask,
+        rows_min=rows_min,
+        rows_max=rows_max,
+    )
+
+
+def build_pcp_swa_prefill_segments(
+    *,
+    combined_indices: torch.Tensor,
+    combined_lens: torch.Tensor,
+    positions: torch.Tensor,
+    local_query_start_loc: torch.Tensor,
+    seq_lens: torch.Tensor,
+    gather_lens: torch.Tensor,
+    chunk_n: int,
+    chunk_m: int,
+    window_size: int,
+    segment_size: int = 64,
+) -> list[DeepseekV4PcpSwaSegment]:
+    """Build compact local SWA segments for PCP sparse prefill.
+
+    FlashMLA sparse prefill consumes compact local row coordinates. PCP prefill
+    positions are global within the request, so each segment is rebased to the
+    smallest local KV window that covers its valid query rows.
+    """
+    segments: list[DeepseekV4PcpSwaSegment] = []
+    chunk_size = int(seq_lens.numel())
+    for req_idx in range(chunk_size):
+        req_query_start = int(local_query_start_loc[req_idx].item())
+        req_query_end = int(local_query_start_loc[req_idx + 1].item())
+        req_seq_len = int(seq_lens[req_idx].item())
+        req_gather_len = int(gather_lens[req_idx].item())
+        req_gather_start = req_seq_len - req_gather_len
+
+        seg_query_start = req_query_start
+        while seg_query_start < req_query_end:
+            tentative_query_end = min(seg_query_start + segment_size, req_query_end)
+            seg_positions_all = positions[seg_query_start:tentative_query_end].to(
+                torch.long
+            )
+            seg_lens_all = combined_lens[seg_query_start:tentative_query_end]
+            seg_valid_all = seg_lens_all > 0
+            if seg_positions_all.numel() > 1:
+                adjacent_valid = seg_valid_all[:-1] & seg_valid_all[1:]
+                position_breaks = adjacent_valid & (
+                    seg_positions_all[1:] != seg_positions_all[:-1] + 1
+                )
+                if position_breaks.any():
+                    first_break = int(position_breaks.nonzero()[0].item()) + 1
+                    seg_query_end = seg_query_start + first_break
+                else:
+                    seg_query_end = tentative_query_end
+            else:
+                seg_query_end = tentative_query_end
+
+            seg_positions = positions[seg_query_start:seg_query_end].to(torch.long)
+            seg_lens = combined_lens[seg_query_start:seg_query_end]
+            seg_valid = seg_lens > 0
+            if not seg_valid.any():
+                segments.append(
+                    DeepseekV4PcpSwaSegment(
+                        query_start=seg_query_start,
+                        query_end=seg_query_end,
+                        kv_start=0,
+                        kv_end=0,
+                        sparse_rows=1,
+                        q_rows=torch.zeros_like(seg_positions),
+                        shifted_indices=combined_indices[seg_query_start:seg_query_end],
+                        topk_lens=seg_lens,
+                        valid_mask=seg_valid,
+                    )
+                )
+                seg_query_start = seg_query_end
+                continue
+
+            valid_positions = seg_positions[seg_valid]
+            seg_base_pos = max(
+                req_gather_start,
+                int(valid_positions.min().item()) - window_size + 1,
+            )
+            seg_end_pos = int(valid_positions.max().item()) + 1
+            kv_start = req_idx * chunk_m + chunk_n + seg_base_pos - req_gather_start
+            kv_end = req_idx * chunk_m + chunk_n + seg_end_pos - req_gather_start
+            q_rows = seg_positions - seg_base_pos
+            q_rows = torch.where(seg_valid, q_rows, torch.zeros_like(q_rows))
+            sparse_rows = int(q_rows[seg_valid].max().item()) + 1
+
+            seg_indices = combined_indices[seg_query_start:seg_query_end]
+            shifted_indices = torch.where(
+                seg_indices >= 0,
+                seg_indices - kv_start,
+                seg_indices,
+            )
+            valid_offsets = torch.arange(
+                shifted_indices.shape[1],
+                device=shifted_indices.device,
+                dtype=seg_lens.dtype,
+            )
+            valid_index_mask = valid_offsets.unsqueeze(0) < seg_lens.unsqueeze(1)
+            valid_shifted_indices = shifted_indices[valid_index_mask]
+            if (valid_shifted_indices < 0).any() or (
+                valid_shifted_indices >= kv_end - kv_start
+            ).any():
+                raise ValueError(
+                    "DeepSeek V4 PCP SWA prefill segment indices are outside "
+                    "the rebased KV workspace"
+                )
+
+            segments.append(
+                DeepseekV4PcpSwaSegment(
+                    query_start=seg_query_start,
+                    query_end=seg_query_end,
+                    kv_start=kv_start,
+                    kv_end=kv_end,
+                    sparse_rows=sparse_rows,
+                    q_rows=q_rows,
+                    shifted_indices=shifted_indices,
+                    topk_lens=seg_lens,
+                    valid_mask=seg_valid,
+                )
+            )
+            seg_query_start = seg_query_end
+    return segments

--- a/vllm/models/deepseek_v4/sparse_mla.py
+++ b/vllm/models/deepseek_v4/sparse_mla.py
@@ -21,7 +21,10 @@ from vllm.v1.attention.backend import (
     MultipleOf,
 )
 from vllm.v1.attention.backends.mla.compressor_utils import get_compressed_slot_mapping
-from vllm.v1.attention.backends.utils import split_decodes_and_prefills
+from vllm.v1.attention.backends.utils import (
+    get_pcp_max_buffer_num_tokens,
+    split_decodes_and_prefills,
+)
 from vllm.v1.kv_cache_interface import AttentionSpec
 
 # Pad C128A topk width to this alignment. 128 covers both h_q=64 (B_TOPK=64) and
@@ -150,7 +153,7 @@ class DeepseekV4FlashMLAMetadataBuilder(
         self._init_reorder_batch_threshold(1, supports_spec_as_decode=True)
         self.topk_tokens = self.model_config.hf_config.index_topk
 
-        max_num_batched_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        max_num_batched_tokens = get_pcp_max_buffer_num_tokens(vllm_config)
         self.req_id_per_token_buffer = torch.empty(
             (max_num_batched_tokens,), dtype=torch.int32, device=device
         )

--- a/vllm/models/deepseek_v4/sparse_mla.py
+++ b/vllm/models/deepseek_v4/sparse_mla.py
@@ -52,6 +52,10 @@ class DeepseekV4FlashMLABackend(AttentionBackend):
         "fp8",  # alias for fp8_ds_mla
     ]
 
+    @classmethod
+    def supports_pcp(cls) -> bool:
+        return True
+
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
         return [256]

--- a/vllm/models/deepseek_v4/xpu/xpu_qnorm_rope_kv_fp8_insert.py
+++ b/vllm/models/deepseek_v4/xpu/xpu_qnorm_rope_kv_fp8_insert.py
@@ -116,7 +116,9 @@ def xpu_qnorm_rope_kv_fp8_insert(
     cos_sin_cache: torch.Tensor,  # [max_pos, ROPE_DIM]
     eps: float,
     block_size: int,
-):
+    insert_mask: torch.Tensor | None = None,
+    return_kv_roped: bool = False,
+) -> torch.Tensor | None:
     """XPU Triton: qnorm+rope on Q, rope on KV, then FP8 UE8M0 quant+insert."""
     from vllm.models.deepseek_v4.common.ops.cache_utils import (
         quantize_and_insert_k_cache,
@@ -151,9 +153,18 @@ def xpu_qnorm_rope_kv_fp8_insert(
     # swa_kv_cache may be [num_blocks, block_size, 584] or [num_blocks, flat]
     # quantize_and_insert_k_cache expects [num_blocks, block_bytes] uint8
     cache_2d = swa_kv_cache.view(swa_kv_cache.shape[0], -1)
-    quantize_and_insert_k_cache(
-        kv_roped,
-        cache_2d,
-        slot_mapping,
-        block_size=block_size,
-    )
+    if insert_mask is not None:
+        kv_to_insert = kv_roped[insert_mask]
+        slot_mapping = slot_mapping[insert_mask]
+    else:
+        kv_to_insert = kv_roped
+    if kv_to_insert.numel() > 0:
+        quantize_and_insert_k_cache(
+            kv_to_insert,
+            cache_2d,
+            slot_mapping,
+            block_size=block_size,
+        )
+    if return_kv_roped:
+        return kv_roped
+    return None

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from vllm.platforms.interface import DeviceCapability
     from vllm.v1.attention.backends.utils import KVCacheLayoutType
     from vllm.v1.kv_cache_interface import AttentionSpec, KVQuantMode
+    from vllm.v1.worker.cp_utils import PCPInterleaveRequestView
 
 from vllm.v1.kv_cache_interface import get_kv_quant_mode
 
@@ -451,6 +452,16 @@ class CommonAttentionMetadata:
     dcp_local_seq_lens_cpu: torch.Tensor | None = None
     """Sequence lengths of the local rank in decode context parallelism world"""
 
+    pcp_allgather_restore_idx: torch.Tensor | None = None
+    """Indices that restore PCP all-gathered tensors to global token order."""
+
+    pcp_full_seq_lens: torch.Tensor | None = None
+    pcp_full_seq_lens_cpu: torch.Tensor | None = None
+    """Full per-request sequence lengths before PCP splits prefill tokens."""
+
+    pcp_request_views: list["PCPInterleaveRequestView"] | None = None
+    """Request-level dual-chunk layout for model-specific PCP metadata."""
+
     positions: torch.Tensor | None = None
     """(num_actual_tokens,) token positions.  Optional; set when the caller
     has positions available so that builders can pre-compute position-dependent
@@ -568,6 +579,7 @@ class CommonAttentionMetadata:
             query_start_loc=self.query_start_loc[: num_actual_reqs + 1],
             query_start_loc_cpu=self.query_start_loc_cpu[: num_actual_reqs + 1],
             seq_lens=self.seq_lens[:num_actual_reqs],
+            seq_lens_cpu_upper_bound=maybe_slice_reqs(self.seq_lens_cpu_upper_bound),
             _seq_lens_cpu=self._seq_lens_cpu[:num_actual_reqs]
             if self._seq_lens_cpu is not None
             else None,
@@ -589,6 +601,15 @@ class CommonAttentionMetadata:
             encoder_seq_lens_cpu=maybe_slice_reqs(self.encoder_seq_lens_cpu),
             dcp_local_seq_lens=maybe_slice_reqs(self.dcp_local_seq_lens),
             dcp_local_seq_lens_cpu=maybe_slice_reqs(self.dcp_local_seq_lens_cpu),
+            pcp_allgather_restore_idx=self.pcp_allgather_restore_idx,
+            pcp_full_seq_lens=maybe_slice_reqs(self.pcp_full_seq_lens),
+            pcp_full_seq_lens_cpu=maybe_slice_reqs(self.pcp_full_seq_lens_cpu),
+            pcp_request_views=self.pcp_request_views[:num_actual_reqs]
+            if self.pcp_request_views is not None
+            else None,
+            positions=self.positions[:num_actual_tokens]
+            if self.positions is not None
+            else None,
             is_prefilling=maybe_slice_reqs(self.is_prefilling),
             rswa_prefix_lens=maybe_slice_reqs(self.rswa_prefix_lens),
         )

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -25,6 +25,7 @@ from vllm.v1.attention.backend import (
 )
 from vllm.v1.attention.backends.mla.compressor_utils import get_compressed_slot_mapping
 from vllm.v1.attention.backends.utils import (
+    get_cp_local_seq_lens,
     get_dcp_local_seq_lens,
     split_decodes_and_prefills,
 )
@@ -217,6 +218,7 @@ class DeepseekV32IndexerMetadata:
     seq_lens: torch.Tensor
     max_seq_len: int
     slot_mapping: torch.Tensor
+    block_table: torch.Tensor
 
     # New for MLA (compared to FlashAttention)
     # For handling prefill decode split
@@ -227,6 +229,10 @@ class DeepseekV32IndexerMetadata:
 
     decode: DeepSeekV32IndexerDecodeMetadata | None = None
     prefill: DeepseekV32IndexerPrefillMetadata | None = None
+    pcp_allgather_restore_idx: torch.Tensor | None = None
+    pcp_compact_restored_indices: torch.Tensor | None = None
+    pcp_local_compact_indices: torch.Tensor | None = None
+    pcp_local_valid_mask: torch.Tensor | None = None
 
 
 def get_max_prefill_buffer_size(vllm_config: VllmConfig):
@@ -263,6 +269,12 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
         self.pcp_world_size = parallel_config.prefill_context_parallel_size
         self.use_pcp = self.pcp_world_size > 1
+        self.pcp_rank = get_pcp_group().rank_in_group if self.pcp_world_size > 1 else 0
+        if self.pcp_world_size > 1 and self.dcp_world_size > 1:
+            raise NotImplementedError(
+                "DeepSeek V4 sparse indexer does not yet support combined "
+                "PCP and DCP. Use PCP with decode_context_parallel_size=1."
+            )
         self.cp_kv_cache_interleave_size = parallel_config.cp_kv_cache_interleave_size
         # The DCP sparse-indexer code is parameterized by interleave size, but
         # interleave > 1 is not yet validated end-to-end (gsm8k parity fails),
@@ -344,6 +356,12 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             dtype=torch.int32,
             device=self.device,
         )
+        self.pcp_query_start_loc_cpu = torch.zeros(
+            (scheduler_config.max_num_seqs + 1,), dtype=torch.int32, device="cpu"
+        )
+        self.pcp_query_start_loc = torch.zeros_like(
+            self.pcp_query_start_loc_cpu, device=self.device
+        )
         max_num_blocks_per_req = cdiv(
             self.vllm_config.model_config.max_model_len,
             self.kv_cache_spec.block_size * get_kv_cache_shard_count(),
@@ -372,6 +390,16 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 "DCP is not supported with sparse indexer KV compression "
                 f"(compress_ratio={self.compress_ratio})."
             )
+        if (
+            self.pcp_world_size > 1
+            and self.cp_kv_cache_interleave_size % self.compress_ratio != 0
+        ):
+            raise NotImplementedError(
+                "DeepSeek V4 PCP indexer requires cp_kv_cache_interleave_size "
+                "to be divisible by the indexer compression ratio, got "
+                f"interleave={self.cp_kv_cache_interleave_size}, "
+                f"compress_ratio={self.compress_ratio}."
+            )
 
         # Pre-allocate buffers for CUDA graph compatibility when
         if self.compress_ratio > 1:
@@ -395,7 +423,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         num_decodes: int,
         seq_lens_is_buffer_view: bool,
     ) -> torch.Tensor:
-        local_seq_lens = get_dcp_local_seq_lens(
+        local_seq_lens = get_cp_local_seq_lens(
             seq_lens,
             self.dcp_world_size,
             self.dcp_rank,
@@ -606,6 +634,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         slot_mapping = common_attn_metadata.slot_mapping
         block_table = common_attn_metadata.block_table_tensor
         dcp_local_seq_lens = common_attn_metadata.dcp_local_seq_lens
+        pcp_enabled = common_attn_metadata.pcp_allgather_restore_idx is not None
 
         num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
             split_decodes_and_prefills(
@@ -619,26 +648,76 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         assert num_decodes + num_prefills == num_reqs
         assert num_decode_tokens + num_prefill_tokens == num_tokens
 
+        pcp_query_plan = None
+        if pcp_enabled:
+            if num_decodes:
+                raise NotImplementedError(
+                    "DeepSeek V4 PCP sparse indexer currently supports standalone "
+                    "prefill batches only."
+                )
+            assert common_attn_metadata.pcp_request_views is not None
+            assert common_attn_metadata.pcp_full_seq_lens is not None
+            assert common_attn_metadata.pcp_full_seq_lens_cpu is not None
+            from vllm.models.deepseek_v4.pcp_metadata import build_pcp_query_plan
+
+            pcp_query_plan = build_pcp_query_plan(
+                pcp_allgather_restore_idx=(
+                    common_attn_metadata.pcp_allgather_restore_idx
+                ),
+                views=common_attn_metadata.pcp_request_views,
+                pcp_world_size=self.pcp_world_size,
+                pcp_rank=self.pcp_rank,
+            )
+            query_lens_cpu = torch.tensor(
+                [
+                    int(view.global_seq_len)
+                    for view in common_attn_metadata.pcp_request_views
+                ],
+                dtype=torch.int32,
+            )
+            self.pcp_query_start_loc_cpu[0] = 0
+            torch.cumsum(
+                query_lens_cpu,
+                dim=0,
+                out=self.pcp_query_start_loc_cpu[1 : num_reqs + 1],
+            )
+            self.pcp_query_start_loc[: num_reqs + 1].copy_(
+                self.pcp_query_start_loc_cpu[: num_reqs + 1],
+                non_blocking=True,
+            )
+            query_start_loc = self.pcp_query_start_loc[: num_reqs + 1]
+            query_start_loc_cpu = self.pcp_query_start_loc_cpu[: num_reqs + 1]
+            seq_lens = common_attn_metadata.pcp_full_seq_lens[:num_reqs]
+            num_tokens = int(query_lens_cpu.sum().item())
+            num_prefill_tokens = num_tokens
+
         compressed_slot_mapping = slot_mapping
         compressed_seq_lens = seq_lens
         if self.compress_ratio > 1:
-            padded_num_tokens = num_tokens
-            if self.pcp_world_size > 1:
-                padded_num_tokens = slot_mapping.shape[0] // self.pcp_world_size
-            compressed_slot_mapping = get_compressed_slot_mapping(
-                num_tokens,
-                query_start_loc,
-                seq_lens,
-                block_table,
-                self.kv_cache_spec.storage_block_size,
-                self.compress_ratio,
-                out=self.compressed_slot_mapping_buffer,
-            )
-            if self.pcp_world_size > 1:
-                compressed_slot_mapping = get_pcp_group().all_gather(
-                    self.compressed_slot_mapping_buffer[:padded_num_tokens],
-                    dim=0,
+            if pcp_enabled:
+                # The compressor owns PCP cache insertion and overrides this
+                # metadata with an owner-aware mapping.  The indexer custom op
+                # only needs the restored compact query-row count here.
+                compressed_slot_mapping = self.compressed_slot_mapping_buffer[
+                    :num_tokens
+                ]
+                compressed_slot_mapping.fill_(-1)
+            else:
+                compressed_slot_mapping = get_compressed_slot_mapping(
+                    num_tokens,
+                    query_start_loc,
+                    seq_lens,
+                    block_table,
+                    self.kv_cache_spec.storage_block_size,
+                    self.compress_ratio,
+                    out=self.compressed_slot_mapping_buffer,
                 )
+                if self.use_pcp:
+                    padded_num_tokens = slot_mapping.shape[0] // self.pcp_world_size
+                    compressed_slot_mapping = get_pcp_group().all_gather(
+                        self.compressed_slot_mapping_buffer[:padded_num_tokens],
+                        dim=0,
+                    )
             compressed_seq_lens = seq_lens // self.compress_ratio
 
         prefill_metadata = None
@@ -646,8 +725,12 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             # This CPU value is an upper bound for async-spec extend rows.  It
             # is safe for chunking/allocation because CUDA metadata below is
             # built from exact device seq_lens and gather ignores the tail.
-            assert common_attn_metadata.seq_lens_cpu_upper_bound is not None
-            seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
+            if pcp_enabled:
+                assert common_attn_metadata.pcp_full_seq_lens_cpu is not None
+                seq_lens_cpu = common_attn_metadata.pcp_full_seq_lens_cpu[:num_reqs]
+            else:
+                assert common_attn_metadata.seq_lens_cpu_upper_bound is not None
+                seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
             compressed_seq_lens_cpu = (
                 seq_lens_cpu // self.compress_ratio
                 if self.compress_ratio > 1
@@ -659,8 +742,6 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             max_logits_bytes = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
             # Upper bound is exact for prefill rows (the `[num_decodes:]`
             # slice below).
-            assert common_attn_metadata.seq_lens_cpu_upper_bound is not None
-            seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
             chunk_specs = split_indexer_prefill_chunks(
                 compressed_seq_lens_cpu[num_decodes:],
                 prefill_query_lens_cpu,
@@ -683,9 +764,15 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                     self.compress_ratio,
                     query_slice=query_slice,
                     skip_kv_gather=query_slice.start > 0,
-                    dcp_rank=self.dcp_rank,
-                    dcp_world_size=self.dcp_world_size,
-                    cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
+                    dcp_rank=(self.pcp_rank if pcp_enabled else self.dcp_rank),
+                    dcp_world_size=(
+                        self.pcp_world_size if pcp_enabled else self.dcp_world_size
+                    ),
+                    cp_kv_cache_interleave_size=(
+                        self.cp_kv_cache_interleave_size // self.compress_ratio
+                        if pcp_enabled
+                        else self.cp_kv_cache_interleave_size
+                    ),
                 )
                 # Skip when total_seq_lens is 0 (i.e., no compressed token).
                 if metadata is not None:
@@ -812,12 +899,29 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             seq_lens=common_attn_metadata.seq_lens,
             max_seq_len=common_attn_metadata.max_seq_len,
             slot_mapping=compressed_slot_mapping,
+            block_table=common_attn_metadata.block_table_tensor,
             num_decodes=num_decodes,
             num_decode_tokens=num_decode_tokens,
             num_prefills=num_prefills,
             num_prefill_tokens=num_prefill_tokens,
             prefill=prefill_metadata,
             decode=decode_metadata,
+            pcp_allgather_restore_idx=(
+                common_attn_metadata.pcp_allgather_restore_idx if pcp_enabled else None
+            ),
+            pcp_compact_restored_indices=(
+                pcp_query_plan.compact_restored_indices
+                if pcp_query_plan is not None
+                else None
+            ),
+            pcp_local_compact_indices=(
+                pcp_query_plan.local_compact_indices
+                if pcp_query_plan is not None
+                else None
+            ),
+            pcp_local_valid_mask=(
+                pcp_query_plan.local_valid_mask if pcp_query_plan is not None else None
+            ),
         )
 
         return attn_metadata

--- a/vllm/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm/v1/attention/backends/mla/sparse_swa.py
@@ -110,6 +110,10 @@ class DeepseekV4SWACache(torch.nn.Module, AttentionLayerBase):
 
 
 class DeepseekSparseSWABackend(AttentionBackend):
+    @classmethod
+    def supports_pcp(cls) -> bool:
+        return True
+
     @staticmethod
     def get_name() -> str:
         return "DEEPSEEK_SPARSE_SWA"

--- a/vllm/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm/v1/attention/backends/mla/sparse_swa.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from dataclasses import dataclass, field
-from typing import ClassVar, cast
+from typing import TYPE_CHECKING, ClassVar, cast
 
 import torch
 
 from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
+from vllm.distributed import get_pcp_group
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
@@ -17,7 +18,10 @@ from vllm.v1.attention.backend import (
     CommonAttentionMetadata,
     MultipleOf,
 )
-from vllm.v1.attention.backends.utils import split_decodes_and_prefills
+from vllm.v1.attention.backends.utils import (
+    get_pcp_max_buffer_num_tokens,
+    split_decodes_and_prefills,
+)
 from vllm.v1.attention.ops.flashmla import FlashMLASchedMeta, get_mla_metadata
 from vllm.v1.kv_cache_interface import (
     KVCacheSpec,
@@ -25,6 +29,9 @@ from vllm.v1.kv_cache_interface import (
     SlidingWindowMLASpec,
     get_kv_quant_mode,
 )
+
+if TYPE_CHECKING:
+    from vllm.models.deepseek_v4.pcp_metadata import DeepseekV4PcpPrefillMetadata
 
 # DeepseekV4 decode layer types, keyed by compress_ratio. Each type has a distinct
 # (topk, extra_topk, extra_page_block_size) config, so they cannot share a
@@ -183,10 +190,13 @@ class DeepseekSparseSWAMetadata:
     prefill_seq_lens: torch.Tensor | None = None
     prefill_seq_lens_cpu: torch.Tensor | None = None
     prefill_gather_lens: torch.Tensor | None = None
+    prefill_gather_lens_cpu: torch.Tensor | None = None
     prefill_query_lens_cpu: torch.Tensor | None = None
     prefill_window_size: int = 0
     prefill_max_model_len: int = 0
     prefill_max_num_batched_tokens: int = 0
+    pcp_allgather_restore_idx: torch.Tensor | None = None
+    pcp_prefill_metadata: "DeepseekV4PcpPrefillMetadata | None" = None
 
     # Per-layer-type FlashMLA tile-scheduler metadata. One FlashMLASchedMeta
     # per present DeepseekV4 layer type, shared across all ~60 layers of that type
@@ -232,6 +242,8 @@ class DeepseekSparseSWAMetadata:
         gather_lens_cpu = self.prefill_query_lens_cpu + torch.clamp(
             prefix_lens_cpu, min=0, max=self.prefill_window_size - 1
         )
+        if self.prefill_gather_lens_cpu is not None:
+            gather_lens_cpu = self.prefill_gather_lens_cpu
         compressed_lens_cpu = (
             torch.zeros_like(self.prefill_seq_lens_cpu)
             if compress_ratio <= 1
@@ -303,9 +315,7 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         self.compress_ratio = mla_spec.compress_ratio
         self.block_size = mla_spec.block_size
         self.max_model_len = self.vllm_config.model_config.max_model_len
-        self.max_num_batched_tokens = (
-            self.vllm_config.scheduler_config.max_num_batched_tokens
-        )
+        self.max_num_batched_tokens = get_pcp_max_buffer_num_tokens(self.vllm_config)
 
         # Handle MTP: adjust decode_threshold like the indexer does
         spec_config = self.vllm_config.speculative_config
@@ -334,7 +344,7 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         for ratio in compress_ratios:
             self._layer_types.add(_layer_type_for(int(ratio)))
 
-        max_tokens = self.vllm_config.scheduler_config.max_num_batched_tokens
+        max_tokens = self.max_num_batched_tokens
         self.token_to_req_indices = torch.zeros(
             max_tokens,
             dtype=torch.int32,
@@ -406,6 +416,14 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
         block_table = common_attn_metadata.block_table_tensor
         slot_mapping = common_attn_metadata.slot_mapping
+        pcp_enabled = common_attn_metadata.pcp_allgather_restore_idx is not None
+        prefill_seq_lens = seq_lens
+        prefill_seq_lens_cpu = seq_lens_cpu
+        if pcp_enabled:
+            assert common_attn_metadata.pcp_full_seq_lens is not None
+            assert common_attn_metadata.pcp_full_seq_lens_cpu is not None
+            prefill_seq_lens = common_attn_metadata.pcp_full_seq_lens
+            prefill_seq_lens_cpu = common_attn_metadata.pcp_full_seq_lens_cpu
 
         # Split into decode and prefill portions using configurable threshold
         (num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens) = (
@@ -413,6 +431,11 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
                 common_attn_metadata, decode_threshold=self.decode_threshold
             )
         )
+        if pcp_enabled and num_decodes:
+            raise NotImplementedError(
+                "DeepSeek V4 PCP currently supports standalone prefill batches "
+                "only; mixed decode/prefill and decode rows are not supported."
+            )
 
         # NOTE: Ensure all metadata tensors maintain fixed memory addresses
         # for CUDA graph compatibility.
@@ -477,7 +500,7 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         # Prefill SWA indices live in paged coordinates. `token_offset` lets
         # the kernel read is_valid_token / token_to_req_indices at absolute
         # prefill positions while writing output starting at index 0.
-        if num_prefill_tokens > 0:
+        if num_prefill_tokens > 0 and not pcp_enabled:
             prefill_swa_indices = self.prefill_swa_indices[:num_prefill_tokens]
             prefill_swa_lens = self.prefill_swa_lens[:num_prefill_tokens]
             _compute_swa_indices_and_lens_kernel[(num_prefill_tokens,)](
@@ -500,10 +523,15 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         deepseek_v4_fields = self._build_deepseek_v4_metadata(
             num_decodes,
             num_prefills,
-            seq_lens,
-            seq_lens_cpu,
+            prefill_seq_lens,
+            prefill_seq_lens_cpu,
             query_start_loc,
             query_start_loc_cpu,
+            slot_mapping,
+            common_attn_metadata.positions,
+            common_attn_metadata.pcp_allgather_restore_idx,
+            common_attn_metadata.pcp_request_views,
+            pcp_enabled,
         )
 
         # Per-layer-type tile-scheduler plan holders. Empty FlashMLASchedMeta
@@ -518,18 +546,19 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
             query_start_loc_cpu=query_start_loc_cpu,
             block_table=block_table,
             slot_mapping=slot_mapping,
+            pcp_allgather_restore_idx=common_attn_metadata.pcp_allgather_restore_idx,
             is_valid_token=is_valid_token,
             token_to_req_indices=token_to_req_indices,
             decode_swa_indices=decode_swa_indices[:num_decode_tokens],
             decode_swa_lens=self.decode_swa_lens[:num_decode_tokens],
             prefill_swa_indices=(
                 self.prefill_swa_indices[:num_prefill_tokens]
-                if num_prefill_tokens > 0
+                if num_prefill_tokens > 0 and not pcp_enabled
                 else None
             ),
             prefill_swa_lens=(
                 self.prefill_swa_lens[:num_prefill_tokens]
-                if num_prefill_tokens > 0
+                if num_prefill_tokens > 0 and not pcp_enabled
                 else None
             ),
             block_size=self.block_size,
@@ -585,7 +614,12 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         seq_lens_cpu: torch.Tensor | None,
         query_start_loc: torch.Tensor,
         query_start_loc_cpu: torch.Tensor,
-    ) -> dict[str, torch.Tensor | int | None]:
+        slot_mapping: torch.Tensor,
+        positions: torch.Tensor | None,
+        pcp_allgather_restore_idx: torch.Tensor | None,
+        pcp_request_views: list | None,
+        pcp_enabled: bool,
+    ) -> dict[str, object]:
         """Pre-compute DeepseekV4 prefill metadata during the metadata build phase.
 
         Returns a dict of keyword arguments to pass to the
@@ -594,27 +628,33 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         Note: C128A sparse metadata is computed by the FlashMLASparse builder
         (which owns the C128A block_table), not here.
         """
-        result: dict[str, torch.Tensor | int | None] = {}
+        result: dict[str, object] = {}
 
         # --- Prefill query metadata (single Triton kernel + CPU slicing) ---
         if num_prefills > 0:
             assert seq_lens_cpu is not None
-            pfx_gather_lens = torch.empty(
-                num_prefills, dtype=torch.int32, device=seq_lens.device
-            )
-            _compute_prefill_metadata_kernel[(1,)](
-                pfx_gather_lens,
-                seq_lens,
-                query_start_loc,
-                num_prefills,
-                num_decodes,
-                self.window_size,
-                BLOCK_SIZE=triton.next_power_of_2(num_prefills),
-            )
+            pfx_gather_lens_cpu = None
+            if pcp_enabled:
+                pfx_gather_lens = seq_lens[num_decodes:].contiguous()
+                pfx_gather_lens_cpu = seq_lens_cpu[num_decodes:].to(dtype=torch.int32)
+            else:
+                pfx_gather_lens = torch.empty(
+                    num_prefills, dtype=torch.int32, device=seq_lens.device
+                )
+                _compute_prefill_metadata_kernel[(1,)](
+                    pfx_gather_lens,
+                    seq_lens,
+                    query_start_loc,
+                    num_prefills,
+                    num_decodes,
+                    self.window_size,
+                    BLOCK_SIZE=triton.next_power_of_2(num_prefills),
+                )
 
             result["prefill_seq_lens"] = seq_lens[num_decodes:]
             result["prefill_seq_lens_cpu"] = seq_lens_cpu[num_decodes:]
             result["prefill_gather_lens"] = pfx_gather_lens
+            result["prefill_gather_lens_cpu"] = pfx_gather_lens_cpu
             result["prefill_query_lens_cpu"] = (
                 query_start_loc_cpu[num_decodes + 1 : num_decodes + num_prefills + 1]
                 - query_start_loc_cpu[num_decodes : num_decodes + num_prefills]
@@ -622,6 +662,39 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
             result["prefill_window_size"] = self.window_size
             result["prefill_max_model_len"] = self.max_model_len
             result["prefill_max_num_batched_tokens"] = self.max_num_batched_tokens
+            if pcp_enabled:
+                from vllm.models.deepseek_v4.pcp_metadata import (
+                    DeepseekV4PcpPrefillMetadata,
+                )
+
+                assert pcp_allgather_restore_idx is not None
+                assert pcp_request_views is not None
+                base = query_start_loc_cpu[num_decodes]
+                local_query_start_loc = query_start_loc[
+                    num_decodes : num_decodes + num_prefills + 1
+                ] - int(base.item())
+                try:
+                    pcp_rank = get_pcp_group().rank_in_group
+                except AssertionError:
+                    pcp_rank = 0
+                result["pcp_prefill_metadata"] = DeepseekV4PcpPrefillMetadata(
+                    cp_size=(
+                        self.vllm_config.parallel_config.prefill_context_parallel_size
+                    ),
+                    cp_rank=pcp_rank,
+                    strategy="dual_chunk",
+                    views=pcp_request_views,
+                    local_query_start_loc=local_query_start_loc,
+                    local_seq_lens=seq_lens[num_decodes:],
+                    local_swa_indices=None,
+                    local_swa_valid_lens=None,
+                    local_c4_indices=None,
+                    local_c128_indices=None,
+                    global_slot_mapping=slot_mapping,
+                    compressor_write_locs_global=None,
+                    restore_idx=pcp_allgather_restore_idx,
+                    debug_global_positions=positions,
+                )
 
         return result
 

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -884,44 +884,229 @@ def compute_causal_conv1d_metadata(
     return nums_dict, batch_ptr, token_chunk_offset_ptr
 
 
+def get_cp_local_seq_lens(
+    seq_lens: torch.Tensor,
+    cp_world_size: int = 1,
+    cp_rank: int | None = None,
+    cp_kv_cache_interleave_size: int = 1,
+) -> torch.Tensor:
+    """Return local sequence lengths for one context-parallel rank.
+
+    This generalizes the existing DCP helper to the combined context-parallel
+    rank space used by DCP and PCP. ``cp_world_size`` is the total number of
+    context-parallel shards and ``cp_rank`` selects one shard. When ``cp_rank``
+    is ``None``, the returned tensor contains every rank's local length.
+    """
+    seq_lens_i32 = seq_lens.to(torch.int32)
+    if cp_rank is None:
+        rank_offsets = torch.arange(
+            cp_world_size,
+            dtype=torch.int32,
+            device=seq_lens.device,
+        ).view(
+            *((1,) * seq_lens_i32.dim()),
+            cp_world_size,
+        )
+        seq_lens_tiled = seq_lens_i32.unsqueeze(-1)
+    else:
+        rank_offsets = torch.tensor(
+            cp_rank,
+            dtype=torch.int32,
+            device=seq_lens.device,
+        )
+        seq_lens_tiled = seq_lens_i32
+    base = (
+        seq_lens_tiled
+        // cp_kv_cache_interleave_size
+        // cp_world_size
+        * cp_kv_cache_interleave_size
+    )
+    remainder = seq_lens_tiled - base * cp_world_size
+    remainder = torch.clip(
+        remainder - rank_offsets * cp_kv_cache_interleave_size,
+        0,
+        cp_kv_cache_interleave_size,
+    )
+    return base + remainder
+
+
 def get_dcp_local_seq_lens(
     seq_lens: torch.Tensor,
     dcp_size: int = 1,
     dcp_rank: int | None = None,
     cp_kv_cache_interleave_size: int = 1,
 ) -> torch.Tensor:
-    """While using dcp, kv_cache size stored on each rank may be different,
-    use this function to calculate split decode seq_lens of each dcp rank.
-    Only consider dcp now, we can extend the case of cp based on this.
-    """
-    seq_lens_i32 = seq_lens.to(torch.int32)
-    if dcp_rank is None:
-        rank_offsets = torch.arange(
-            dcp_size,
-            dtype=torch.int32,
-            device=seq_lens.device,
-        ).view(
-            *((1,) * seq_lens_i32.dim()),
-            dcp_size,
-        )
-        seq_lens_tiled = seq_lens_i32.unsqueeze(-1)
-    else:
-        rank_offsets = torch.tensor(dcp_rank, dtype=torch.int32, device=seq_lens.device)
-        seq_lens_tiled = seq_lens_i32
-    base = (
-        seq_lens_tiled
-        // cp_kv_cache_interleave_size
-        // dcp_size
-        * cp_kv_cache_interleave_size
+    """Return local sequence lengths for one DCP rank."""
+    return get_cp_local_seq_lens(
+        seq_lens=seq_lens,
+        cp_world_size=dcp_size,
+        cp_rank=dcp_rank,
+        cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
     )
-    remainder = seq_lens_tiled - base * dcp_size
-    remainder = torch.clip(
-        remainder - rank_offsets * cp_kv_cache_interleave_size,
+
+
+def pcp_kv_allgather_and_restore(
+    key: torch.Tensor,
+    value: torch.Tensor,
+    num_actual_tokens: int,
+    pcp_allgather_restore_idx: torch.Tensor,
+    pcp_group: Any,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """All-gather PCP-local KV tensors and restore original token order."""
+    return (
+        pcp_allgather_and_restore(
+            key, num_actual_tokens, pcp_allgather_restore_idx, pcp_group
+        ),
+        pcp_allgather_and_restore(
+            value, num_actual_tokens, pcp_allgather_restore_idx, pcp_group
+        ),
+    )
+
+
+def pcp_allgather_and_restore(
+    tensor: torch.Tensor,
+    num_actual_tokens: int,
+    pcp_allgather_restore_idx: torch.Tensor,
+    pcp_group: Any,
+) -> torch.Tensor:
+    """All-gather a PCP-local token tensor and restore original token order."""
+    gathered = pcp_group.all_gather(tensor[:num_actual_tokens].contiguous(), dim=0)
+    return torch.index_select(gathered, 0, pcp_allgather_restore_idx)
+
+
+def get_pcp_num_local_tokens_from_restore_idx(
+    pcp_allgather_restore_idx: torch.Tensor,
+    pcp_world_size: int,
+) -> int:
+    """Return the pre-padding local token count represented by a restore index."""
+    restore_len = pcp_allgather_restore_idx.numel()
+    assert restore_len % pcp_world_size == 0, (
+        "PCP restore index length must be divisible by PCP world size, "
+        f"got restore_len={restore_len}, pcp_world_size={pcp_world_size}."
+    )
+    return restore_len // pcp_world_size
+
+
+def get_pcp_max_buffer_num_tokens(vllm_config) -> int:
+    max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+    pcp_world_size = vllm_config.parallel_config.prefill_context_parallel_size
+    if pcp_world_size <= 1:
+        return max_num_tokens
+    max_num_reqs = vllm_config.scheduler_config.max_num_seqs
+    return max_num_tokens + max_num_reqs * 2 * pcp_world_size
+
+
+def get_pcp_local_indices_after_restore(
+    num_local_tokens: int,
+    pcp_rank: int,
+    pcp_allgather_restore_idx: torch.Tensor,
+) -> torch.Tensor:
+    """Indices in restored PCP order that correspond to this rank's local tokens."""
+    local_concat_indices = torch.arange(
+        num_local_tokens,
+        dtype=pcp_allgather_restore_idx.dtype,
+        device=pcp_allgather_restore_idx.device,
+    )
+    local_concat_indices += pcp_rank * num_local_tokens
+    inverse = torch.empty_like(pcp_allgather_restore_idx)
+    inverse.scatter_(
         0,
-        cp_kv_cache_interleave_size,
+        pcp_allgather_restore_idx,
+        torch.arange(
+            pcp_allgather_restore_idx.numel(),
+            dtype=pcp_allgather_restore_idx.dtype,
+            device=pcp_allgather_restore_idx.device,
+        ),
     )
-    dcp_local_seq_lens = base + remainder
-    return dcp_local_seq_lens
+    return torch.index_select(inverse, 0, local_concat_indices)
+
+
+def restore_pcp_local_tensor_to_padded_tokens(
+    tensor: torch.Tensor,
+    local_indices: torch.Tensor | None,
+    num_padded_local_tokens: int,
+) -> torch.Tensor:
+    """Restore this PCP rank's local tensor and preserve padded batch shape."""
+    if local_indices is None:
+        return tensor
+    tensor = torch.index_select(tensor, 0, local_indices)
+    if tensor.shape[0] == num_padded_local_tokens:
+        return tensor
+    assert tensor.shape[0] < num_padded_local_tokens
+    padded_tensor = tensor.new_zeros((num_padded_local_tokens, *tensor.shape[1:]))
+    padded_tensor[: tensor.shape[0]].copy_(tensor)
+    return padded_tensor
+
+
+def get_pcp_part_indices(
+    cu_num_tokens: torch.Tensor,
+    selected_shards: int,
+    total_shards: int,
+    *,
+    return_head: bool = False,
+    return_tail: bool = False,
+) -> tuple[np.ndarray | None, np.ndarray | None]:
+    """Return head/tail token indices for PCP chunk selection.
+
+    Each request is split into ``total_shards`` equal shards. The first
+    ``selected_shards`` shards are selected from the head, and the same number
+    can be selected from the tail.
+    """
+    cu_num_tokens_np = np.asarray(cu_num_tokens, dtype=np.int64)
+    starts = cu_num_tokens_np[:-1]
+    ends = cu_num_tokens_np[1:]
+    select_len = (ends - starts) * selected_shards // total_shards
+    select_num_tokens = int(cu_num_tokens_np[-1] * selected_shards // total_shards)
+
+    seq_ids = np.repeat(np.arange(len(select_len)), select_len)
+    local_start = np.concatenate([[0], np.cumsum(select_len)[:-1]])
+    local_offsets = np.arange(select_num_tokens) - local_start[seq_ids]
+
+    head_indices = None
+    tail_indices = None
+    if return_head:
+        head_indices = starts[seq_ids] + local_offsets
+    if return_tail:
+        tail_start = ends - select_len
+        tail_indices = tail_start[seq_ids] + local_offsets
+    return head_indices, tail_indices
+
+
+def get_pcp_query_indices(
+    cu_num_tokens: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    head_indices, tail_indices = get_pcp_part_indices(
+        cu_num_tokens,
+        1,
+        2,
+        return_head=True,
+        return_tail=True,
+    )
+    assert head_indices is not None
+    assert tail_indices is not None
+    return torch.from_numpy(head_indices), torch.from_numpy(tail_indices)
+
+
+def get_pcp_kv_indices(
+    cu_num_tokens: torch.Tensor,
+    pcp_rank: int,
+    pcp_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    kv_head_indices, _ = get_pcp_part_indices(
+        cu_num_tokens,
+        pcp_rank + 1,
+        2 * pcp_size,
+        return_head=True,
+    )
+    kv_tail_indices, _ = get_pcp_part_indices(
+        cu_num_tokens,
+        2 * pcp_size - pcp_rank,
+        2 * pcp_size,
+        return_head=True,
+    )
+    assert kv_head_indices is not None
+    assert kv_tail_indices is not None
+    return torch.from_numpy(kv_head_indices), torch.from_numpy(kv_tail_indices)
 
 
 def mamba_get_block_table_tensor(

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -631,9 +631,11 @@ def resolve_kv_cache_block_sizes(
 
     - ``scheduler_block_size`` is the token-alignment invariant used by the
       scheduler (e.g. for ``num_computed_tokens`` rounding). Single group:
-      ``cache_config.block_size * dcp``. Multiple groups: LCM of every
-      group's effective block size. Attention groups are scaled by DCP;
-      Mamba groups keep their full per-rank state and are not scaled.
+      ``cache_config.block_size * dcp * legacy_pcp``. Multiple groups: LCM of
+      every group's effective block size. Attention groups are scaled by DCP
+      and legacy-runner PCP; Mamba groups keep their full per-rank state and
+      are not scaled. MRV2 PCP uses virtual batches and therefore does not
+      scale scheduler blocks.
     - ``hash_block_size`` is the granularity at which ``Request.block_hashes``
       is computed. Single group: equals scheduler block size. Multiple groups:
       ``cache_config.prefix_match_unit`` override if set, else the GCD of
@@ -644,14 +646,19 @@ def resolve_kv_cache_block_sizes(
     """
     cache_config = vllm_config.cache_config
     dcp = vllm_config.parallel_config.decode_context_parallel_size
+    pcp = (
+        1
+        if vllm_config.use_v2_model_runner
+        else vllm_config.parallel_config.prefill_context_parallel_size
+    )
     groups = kv_cache_config.kv_cache_groups
 
     if len(groups) <= 1:
-        bs = cache_config.block_size * dcp
+        bs = cache_config.block_size * dcp * pcp
         return bs, bs
 
     group_block_sizes = [
-        g.kv_cache_spec.block_size * dcp
+        g.kv_cache_spec.block_size * dcp * pcp
         if isinstance(g.kv_cache_spec, AttentionSpec)
         else g.kv_cache_spec.block_size
         for g in groups

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -360,7 +360,9 @@ class Scheduler(SchedulerInterface):
             log_stats=self.log_stats,
             enable_kv_cache_events=self.enable_kv_cache_events,
             dcp_world_size=self.dcp_world_size,
-            pcp_world_size=1,
+            pcp_world_size=(
+                1 if vllm_config.use_v2_model_runner else self.pcp_world_size
+            ),
             scheduler_block_size=self.block_size,
             hash_block_size=hash_block_size,
             metrics_collector=self.kv_metrics_collector,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -75,8 +75,8 @@ class SingleTypeKVCacheManager(ABC):
         self.block_size = kv_cache_spec.block_size
         self.dcp_world_size = dcp_world_size
         self.pcp_world_size = pcp_world_size
-        if dcp_world_size > 1:
-            self.block_size *= dcp_world_size
+        if dcp_world_size * pcp_world_size > 1:
+            self.block_size *= dcp_world_size * pcp_world_size
         self.kv_cache_spec = kv_cache_spec
         self.block_pool = block_pool
         self.enable_caching = enable_caching
@@ -674,10 +674,10 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             "and chunked local attention groups"
         )
         block_size = kv_cache_spec.block_size
-        if dcp_world_size > 1:
-            # DCP shards each block's KV across ranks; hashes must be viewed at
-            # the sharded block size.
-            block_size *= dcp_world_size
+        if dcp_world_size * pcp_world_size > 1:
+            # DCP/legacy PCP shard each block's KV across ranks; hashes must be
+            # viewed at the sharded block size. MRV2 passes pcp_world_size=1.
+            block_size *= dcp_world_size * pcp_world_size
         block_hashes = resolve_block_hashes(
             block_hashes,
             block_pool.hash_block_size,

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -1,22 +1,388 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 
+import numpy as np
 import torch
 
 from vllm.config import VllmConfig, get_layers_from_vllm_config
-from vllm.distributed import get_dcp_group
-from vllm.logger import init_logger
+from vllm.distributed import get_dcp_group, get_pcp_group
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.utils import split_decodes_prefills_and_extends
+from vllm.v1.utils import CpuGpuBuffer
 
 if TYPE_CHECKING:
     from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 else:
     AttentionLayerBase = object
 
-logger = init_logger(__name__)
+
+DSV4_PCP_PREFILL_UNSUPPORTED_ERROR = (
+    "DeepSeek-V4 prefill PCP requires dsv4 PCP runtime metadata path; "
+    "legacy sparse backend remap path is unsupported."
+)
+
+
+@dataclass(frozen=True)
+class PCPInterleaveRequestView:
+    req_idx: int
+    global_seq_len: int
+    local_token_count: int
+    local_query_start: int
+    local_query_end: int
+    global_positions: torch.Tensor
+    local_positions: torch.Tensor
+    restore_idx: torch.Tensor
+    global_slot_mapping: torch.Tensor
+    local_kv_base: int
+    local_kv_len: int
+
+
+def guard_dsv4_pcp_prefill_runtime_metadata(
+    *,
+    pcp_allgather_restore_idx: torch.Tensor | None,
+    num_prefill_tokens: int,
+    runtime_metadata: object | None,
+) -> None:
+    """Fail closed before DeepSeek V4 sparse backends use legacy PCP remap."""
+    if (
+        pcp_allgather_restore_idx is not None
+        and num_prefill_tokens > 0
+        and runtime_metadata is None
+    ):
+        raise NotImplementedError(DSV4_PCP_PREFILL_UNSUPPORTED_ERROR)
+
+
+def _cpu_long_tensor(data: np.ndarray | torch.Tensor) -> torch.Tensor:
+    if isinstance(data, torch.Tensor):
+        return data.detach().to(device="cpu", dtype=torch.long)
+    return torch.as_tensor(data, dtype=torch.long, device="cpu")
+
+
+def build_pcp_interleave_request_views(
+    *,
+    original_token_counts: np.ndarray | torch.Tensor,
+    local_token_counts: np.ndarray | torch.Tensor,
+    local_positions: np.ndarray | torch.Tensor,
+    restore_idx: torch.Tensor,
+    pcp_world_size: int,
+    global_slot_mapping: torch.Tensor,
+    local_valid_mask: np.ndarray | torch.Tensor | None = None,
+) -> list[PCPInterleaveRequestView]:
+    """Build per-request PCP views from the current local-rank token layout.
+
+    The current V1 PCP manager uses a dual-chunk head/tail layout. The view keeps
+    the request-local selected global positions, compact local positions, and the
+    per-request restore slice together so model-specific metadata builders do not
+    need to rediscover those relationships from raw buffers.
+    """
+    original_counts = _cpu_long_tensor(original_token_counts)
+    local_counts = _cpu_long_tensor(local_token_counts)
+    positions = _cpu_long_tensor(local_positions)
+    valid_mask = (
+        _cpu_long_tensor(local_valid_mask).to(dtype=torch.bool)
+        if local_valid_mask is not None
+        else None
+    )
+    slots = global_slot_mapping.detach().to(device="cpu", dtype=torch.long)
+    restore = restore_idx.detach().to(device="cpu", dtype=torch.long)
+
+    num_reqs = int(original_counts.numel())
+    original_starts = torch.empty(num_reqs, dtype=torch.long)
+    local_starts = torch.empty(num_reqs, dtype=torch.long)
+    padded_starts = torch.empty(num_reqs, dtype=torch.long)
+    if num_reqs == 0:
+        return []
+    original_starts[0] = 0
+    local_starts[0] = 0
+    padded_starts[0] = 0
+    if num_reqs > 1:
+        original_starts[1:] = torch.cumsum(original_counts, dim=0)[:-1]
+        local_starts[1:] = torch.cumsum(local_counts, dim=0)[:-1]
+        padded_starts[1:] = torch.cumsum(local_counts * pcp_world_size, dim=0)[:-1]
+
+    views: list[PCPInterleaveRequestView] = []
+    compact_start = 0
+    for req_idx in range(num_reqs):
+        global_seq_len = int(original_counts[req_idx].item())
+        local_count = int(local_counts[req_idx].item())
+        local_start = int(local_starts[req_idx].item())
+        local_end = local_start + local_count
+
+        req_positions = positions[local_start:local_end]
+        if valid_mask is None:
+            req_valid_mask = req_positions < global_seq_len
+        else:
+            req_valid_mask = valid_mask[local_start:local_end]
+
+        valid_positions = req_positions[req_valid_mask]
+        valid_count = int(valid_positions.numel())
+        original_start = int(original_starts[req_idx].item())
+        slot_indices = original_start + valid_positions
+        request_slots = slots[slot_indices] if valid_count > 0 else slots[:0]
+        compact_end = compact_start + valid_count
+
+        padded_start = int(padded_starts[req_idx].item())
+        padded_end = padded_start + local_count * pcp_world_size
+        views.append(
+            PCPInterleaveRequestView(
+                req_idx=req_idx,
+                global_seq_len=global_seq_len,
+                local_token_count=valid_count,
+                local_query_start=compact_start,
+                local_query_end=compact_end,
+                global_positions=valid_positions,
+                local_positions=torch.arange(valid_count, dtype=torch.long),
+                restore_idx=restore[padded_start:padded_end],
+                global_slot_mapping=request_slots,
+                local_kv_base=compact_start,
+                local_kv_len=valid_count,
+            )
+        )
+        compact_start = compact_end
+    return views
+
+
+class PCPManager:
+    """Build per-rank token metadata for Prefill Context Parallelism.
+
+    PCP splits long prefill requests across ranks using a head/tail chunk
+    assignment. Decode requests are not split; they are replicated on every PCP
+    rank so mixed decode+prefill batches keep decode semantics unchanged.
+
+    The manager owns the small CPU/GPU buffers needed by the model runner to:
+
+    * replace scheduled token counts with the local PCP-rank token counts;
+    * build the local token positions for this PCP rank;
+    * mask padding after PCP all-gather;
+    * restore all-gathered hidden/KV tensors back to original request order.
+    """
+
+    def __init__(
+        self,
+        pcp_world_size: int,
+        pcp_rank: int,
+        max_buffer_num_tokens: int,
+        max_num_reqs: int,
+        device: torch.device,
+        pin_memory: bool = False,
+    ) -> None:
+        assert pcp_world_size > 1
+        assert 0 <= pcp_rank < pcp_world_size
+        self.pcp_world_size = pcp_world_size
+        self.pcp_rank = pcp_rank
+
+        self.pcp_allgather_restore_idx = CpuGpuBuffer(
+            max_buffer_num_tokens,
+            dtype=torch.int64,
+            device=device,
+            pin_memory=pin_memory,
+        )
+        self.pcp_padded_slot_mapping = torch.empty(
+            (max_buffer_num_tokens,),
+            dtype=torch.int64,
+            device=device,
+        )
+        self.pcp_padded_slot_mappings: dict[int, torch.Tensor] = {
+            0: self.pcp_padded_slot_mapping,
+        }
+        self.pcp_padded_positions = torch.empty(
+            (max_buffer_num_tokens,),
+            dtype=torch.int64,
+            device=device,
+        )
+        self.pcp_padded_query_start_loc = CpuGpuBuffer(
+            (max_num_reqs + 1,),
+            dtype=torch.int32,
+            device=device,
+            pin_memory=pin_memory,
+        )
+        self.num_pcp_pads_cpu_tensor = torch.zeros(
+            (max_num_reqs,), device="cpu", dtype=torch.int64
+        )
+        self.num_pcp_pads_cpu = self.num_pcp_pads_cpu_tensor.numpy()
+        self.pcp_unpad_mask = CpuGpuBuffer(
+            (max_buffer_num_tokens,),
+            dtype=torch.bool,
+            device=device,
+            pin_memory=pin_memory,
+        )
+        self.pcp_unpad_mask_cpu_tensor = self.pcp_unpad_mask.cpu
+        self.pcp_unpad_mask_gpu_tensor = self.pcp_unpad_mask.gpu
+        self.pcp_unpad_mask_cpu = self.pcp_unpad_mask_cpu_tensor.numpy()
+        self.pcp_local_unpad_mask = CpuGpuBuffer(
+            (max_buffer_num_tokens,),
+            dtype=torch.bool,
+            device=device,
+            pin_memory=pin_memory,
+        )
+        self.pcp_local_unpad_mask_cpu_tensor = self.pcp_local_unpad_mask.cpu
+        self.pcp_local_unpad_mask_gpu_tensor = self.pcp_local_unpad_mask.gpu
+        self.pcp_local_unpad_mask_cpu = self.pcp_local_unpad_mask_cpu_tensor.numpy()
+        self.pcp_local_token_indices = CpuGpuBuffer(
+            max_buffer_num_tokens,
+            dtype=torch.int64,
+            device=device,
+            pin_memory=pin_memory,
+        )
+        self.pcp_local_token_indices_cpu_tensor = self.pcp_local_token_indices.cpu
+        self.pcp_local_token_indices_gpu_tensor = self.pcp_local_token_indices.gpu
+        self.pcp_local_token_indices_cpu = (
+            self.pcp_local_token_indices_cpu_tensor.numpy()
+        )
+        self.pcp_request_views: list[PCPInterleaveRequestView] = []
+
+    def get_pcp_padded_slot_mapping(self, kv_cache_gid: int) -> torch.Tensor:
+        slot_mapping = self.pcp_padded_slot_mappings.get(kv_cache_gid)
+        if slot_mapping is None:
+            slot_mapping = torch.empty_like(self.pcp_padded_slot_mapping)
+            self.pcp_padded_slot_mappings[kv_cache_gid] = slot_mapping
+        return slot_mapping
+
+    @staticmethod
+    def _get_cumsum_and_arange(
+        num_scheduled_tokens: np.ndarray,
+        arange_np: np.ndarray,
+        cumsum_dtype: np.dtype | None = None,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Return cumulative token counts and per-request aranges.
+
+        Example: [2, 5, 3] -> ([2, 7, 10],
+        [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]).
+        """
+        cu_num_tokens = np.cumsum(num_scheduled_tokens, dtype=cumsum_dtype)
+        total_num_tokens = cu_num_tokens[-1]
+        cumsums_offsets = np.repeat(
+            cu_num_tokens - num_scheduled_tokens, num_scheduled_tokens
+        )
+        arange = arange_np[:total_num_tokens] - cumsums_offsets
+        return cu_num_tokens, arange
+
+    def update_tokens_for_pcp(
+        self,
+        tokens: np.ndarray,
+        arange_np: np.ndarray,
+        num_reqs: int,
+        reorder_batch_threshold: int | None = None,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Update token counts and positions for this PCP rank.
+
+        Args:
+            tokens: Scheduled token counts per request before PCP splitting.
+            arange_np: Reusable arange buffer large enough for the padded batch.
+            num_reqs: Number of active requests in the prefix of ``tokens``.
+            reorder_batch_threshold: Decode/prefill split threshold used by MLA
+                metadata builders. Requests with scheduled tokens less than or
+                equal to this threshold are treated as decode requests.
+
+        Returns:
+            ``(pcp_tokens, pcp_positions)`` for this rank.
+        """
+        assert reorder_batch_threshold is not None, (
+            "PCP depends on reorder batch to split decode and prefill requests."
+        )
+        tokens = tokens[:num_reqs]
+        num_decode_reqs = int(np.sum(tokens <= reorder_batch_threshold))
+        num_decode_tokens = int(np.sum(tokens[:num_decode_reqs]))
+
+        num_padded_scheduled_tokens = np.ceil(
+            tokens / (2 * self.pcp_world_size)
+        ).astype(np.int32) * (2 * self.pcp_world_size)
+        num_padded_scheduled_tokens[:num_decode_reqs] = (
+            tokens[:num_decode_reqs] * self.pcp_world_size
+        )
+
+        self.num_pcp_pads_cpu[:num_reqs] = num_padded_scheduled_tokens - tokens
+
+        cu_padded_tokens, pcp_padded_arange = self._get_cumsum_and_arange(
+            num_padded_scheduled_tokens, arange_np
+        )
+        self.pcp_unpad_mask_cpu[: pcp_padded_arange.shape[0]] = (
+            pcp_padded_arange < np.repeat(tokens, num_padded_scheduled_tokens)
+        )
+        self.pcp_unpad_mask.copy_to_gpu(pcp_padded_arange.shape[0])
+
+        pcp_tokens = num_padded_scheduled_tokens // self.pcp_world_size
+        self.pcp_padded_query_start_loc.cpu[0] = 0
+        pcp_padded_query_start = np.cumsum(
+            pcp_tokens[:num_reqs] * self.pcp_world_size, dtype=np.int32
+        )
+        self.pcp_padded_query_start_loc.cpu[1 : num_reqs + 1].copy_(
+            torch.from_numpy(pcp_padded_query_start)
+        )
+        self.pcp_padded_query_start_loc.copy_to_gpu(num_reqs + 1)
+        pcp_chunk_sizes = (pcp_tokens // 2).clip(min=1)
+        pcp_chunk_sizes[:num_decode_reqs] = pcp_tokens[:num_decode_reqs]
+
+        _, pcp_arange = self._get_cumsum_and_arange(pcp_tokens, arange_np)
+        _, pcp_chunk_arange = self._get_cumsum_and_arange(pcp_chunk_sizes, arange_np)
+        pcp_head_chunk_mask = pcp_arange < np.repeat(pcp_chunk_sizes, pcp_tokens)
+
+        def get_current_rank_positions(
+            positions_start_loc: int | np.ndarray, rank: int
+        ) -> np.ndarray:
+            positions = np.zeros(len(pcp_head_chunk_mask), dtype=np.int32)
+            head_start_loc = positions_start_loc + rank * pcp_chunk_sizes
+            tail_start_loc = (
+                positions_start_loc
+                + (2 * self.pcp_world_size - rank - 1) * pcp_chunk_sizes
+            )
+            positions[pcp_head_chunk_mask] = pcp_chunk_arange + np.repeat(
+                head_start_loc, pcp_chunk_sizes
+            )
+            positions[~pcp_head_chunk_mask] = (
+                pcp_chunk_arange[num_decode_tokens:]
+                + np.repeat(tail_start_loc, pcp_chunk_sizes)[num_decode_tokens:]
+            )
+            return positions
+
+        positions = get_current_rank_positions(0, self.pcp_rank)
+        if num_decode_reqs > 0:
+            positions[:num_decode_tokens] = self._get_cumsum_and_arange(
+                tokens[:num_decode_reqs], arange_np
+            )[1]
+        original_cu_tokens = np.cumsum(tokens, dtype=np.int64)
+        original_start_loc = np.roll(original_cu_tokens, 1)
+        original_start_loc[0] = 0
+        num_local_tokens = positions.shape[0]
+        local_valid_mask = positions < np.repeat(tokens, pcp_tokens)
+        self.pcp_local_unpad_mask_cpu[:num_local_tokens] = local_valid_mask
+        self.pcp_local_unpad_mask.copy_to_gpu(num_local_tokens)
+        self.pcp_local_token_indices_cpu[:num_local_tokens] = positions.astype(
+            np.int64
+        ) + np.repeat(original_start_loc, pcp_tokens)
+        self.pcp_local_token_indices_cpu[:num_local_tokens][~local_valid_mask] = 0
+        self.pcp_local_token_indices.copy_to_gpu(num_local_tokens)
+
+        padded_pos_start_loc = np.roll(cu_padded_tokens, 1)
+        padded_pos_start_loc[0] = 0
+        all_positions = np.concatenate(
+            [
+                get_current_rank_positions(padded_pos_start_loc, rank)
+                for rank in range(self.pcp_world_size)
+            ]
+        )
+        restore_idx = all_positions.argsort()
+        self.pcp_allgather_restore_idx.np[: restore_idx.shape[0]] = restore_idx
+        self.pcp_allgather_restore_idx.copy_to_gpu(restore_idx.shape[0])
+        identity_slot_mapping = torch.arange(
+            int(tokens.sum(dtype=np.int64)),
+            dtype=torch.long,
+            device="cpu",
+        )
+        self.pcp_request_views = build_pcp_interleave_request_views(
+            original_token_counts=tokens,
+            local_token_counts=pcp_tokens[:num_reqs],
+            local_positions=positions[:num_local_tokens],
+            restore_idx=torch.from_numpy(restore_idx),
+            pcp_world_size=self.pcp_world_size,
+            global_slot_mapping=identity_slot_mapping,
+            local_valid_mask=local_valid_mask,
+        )
+
+        return pcp_tokens[:num_reqs], positions
 
 
 def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
@@ -54,11 +420,16 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
 
 def get_kv_cache_shard_count() -> int:
     try:
+        pcp_world_size = get_pcp_group().world_size
+    except AssertionError:
+        # PCP might not be initialized in testing.
+        pcp_world_size = 1
+    try:
         dcp_world_size = get_dcp_group().world_size
     except AssertionError:
         # DCP might not be initialized in testing
         dcp_world_size = 1
-    return dcp_world_size
+    return dcp_world_size * pcp_world_size
 
 
 def get_dcp_dummy_context_len(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -44,6 +44,7 @@ from vllm.distributed.kv_transfer.kv_connector.utils import copy_kv_blocks
 from vllm.distributed.parallel_state import (
     GraphCaptureContext,
     get_dcp_group,
+    get_pcp_group,
     get_pp_group,
     get_tp_group,
     graph_capture,
@@ -146,7 +147,9 @@ from vllm.v1.attention.backends.mamba2_attn import Mamba2AttentionMetadataBuilde
 from vllm.v1.attention.backends.utils import (
     NULL_BLOCK_ID,
     create_fast_prefill_custom_backend,
-    get_dcp_local_seq_lens,
+    get_cp_local_seq_lens,
+    get_pcp_max_buffer_num_tokens,
+    pcp_allgather_and_restore,
     reorder_batch_to_split_decodes_and_prefills,
 )
 from vllm.v1.core.sched.output import NewRequestData
@@ -212,6 +215,7 @@ from vllm.v1.utils import CpuGpuBuffer, record_function_or_nullcontext
 from vllm.v1.worker import mamba_utils
 from vllm.v1.worker.block_table import SlotMappingMode
 from vllm.v1.worker.cp_utils import (
+    PCPManager,
     check_attention_cp_compatibility,
     get_dcp_dummy_context_len,
     prepare_dcp_dummy_context_metadata,
@@ -508,8 +512,13 @@ class GPUModelRunner(
         # Always set to false after the first forward pass
         self.calculate_kv_scales = self.cache_config.calculate_kv_scales
         self.dcp_world_size = self.parallel_config.decode_context_parallel_size
+        self.pcp_world_size = self.parallel_config.prefill_context_parallel_size
+        self.cp_world_size = self.dcp_world_size * self.pcp_world_size
         self.dcp_rank = 0 if self.dcp_world_size <= 1 else get_dcp_group().rank_in_group
+        self.pcp_rank = 0 if self.pcp_world_size <= 1 else get_pcp_group().rank_in_group
+        self.cp_rank = self.pcp_rank * self.dcp_world_size + self.dcp_rank
         self.max_num_tokens = scheduler_config.max_num_batched_tokens
+        self.max_buffer_num_tokens = get_pcp_max_buffer_num_tokens(vllm_config)
         self.max_num_reqs = scheduler_config.max_num_seqs
 
         # Broadcast PP output for external_launcher (torchrun)
@@ -767,9 +776,11 @@ class GPUModelRunner(
         self._encoder_timing_lock = threading.Lock()
 
         # Persistent buffers for CUDA graphs.
-        self.input_ids = self._make_buffer(self.max_num_tokens, dtype=torch.int32)
+        self.input_ids = self._make_buffer(
+            self.max_buffer_num_tokens, dtype=torch.int32
+        )
         self.positions = torch.zeros(
-            self.max_num_tokens, dtype=torch.int64, device=self.device
+            self.max_buffer_num_tokens, dtype=torch.int64, device=self.device
         )
         self.query_start_loc = self._make_buffer(
             self.max_num_reqs + 1, dtype=torch.int32
@@ -786,7 +797,9 @@ class GPUModelRunner(
         self.prev_num_draft_tokens = self._make_buffer(
             self.max_num_reqs, dtype=torch.int32
         )
-        self.req_indices = self._make_buffer(self.max_num_tokens, dtype=torch.int64)
+        self.req_indices = self._make_buffer(
+            self.max_buffer_num_tokens, dtype=torch.int64
+        )
         # Maps current batch position -> previous batch position (-1 for new reqs)
         self.prev_positions = self._make_buffer(self.max_num_reqs, dtype=torch.int64)
         self.num_scheduled_tokens = self._make_buffer(
@@ -794,17 +807,26 @@ class GPUModelRunner(
         )
 
         self.encoder_seq_lens = self._make_buffer(self.max_num_reqs, dtype=torch.int32)
-        if self.dcp_world_size > 1:
+        if self.cp_world_size > 1:
             self.dcp_local_seq_lens = self._make_buffer(
+                self.max_num_reqs, dtype=torch.int32
+            )
+        if self.pcp_world_size > 1:
+            self.pcp_full_seq_lens = self._make_buffer(
                 self.max_num_reqs, dtype=torch.int32
             )
         # Because inputs_embeds may be bfloat16 and we don't need a numpy
         # version of this tensor, avoid a RuntimeError by not creating a
         # numpy buffer.
         self.inputs_embeds = self._make_buffer(
-            self.max_num_tokens, self.inputs_embeds_size, dtype=self.dtype, numpy=False
+            self.max_buffer_num_tokens,
+            self.inputs_embeds_size,
+            dtype=self.dtype,
+            numpy=False,
         )
-        self.is_token_ids = self._make_buffer(self.max_num_tokens, dtype=torch.bool)
+        self.is_token_ids = self._make_buffer(
+            self.max_buffer_num_tokens, dtype=torch.bool
+        )
         self.discard_request_mask = self._make_buffer(
             self.max_num_reqs, dtype=torch.bool
         )
@@ -828,14 +850,15 @@ class GPUModelRunner(
             # 1D-RoPE.
             # See page 5 of https://arxiv.org/abs/2409.12191
             self.mrope_positions = self._make_buffer(
-                (3, self.max_num_tokens + 1), dtype=torch.int64
+                (3, self.max_buffer_num_tokens + 1), dtype=torch.int64
             )
 
         # Only relevant for models using XD-RoPE (e.g, HunYuan-VL)
         if self.uses_xdrope_dim > 0:
             # Similar to mrope but use assigned dimension number for RoPE, 4 as default.
             self.xdrope_positions = self._make_buffer(
-                (self.uses_xdrope_dim, self.max_num_tokens + 1), dtype=torch.int64
+                (self.uses_xdrope_dim, self.max_buffer_num_tokens + 1),
+                dtype=torch.int64,
             )
 
         # None in the first PP rank. The rest are set after load_model.
@@ -845,10 +868,20 @@ class GPUModelRunner(
         # every step. Keep in int64 to avoid overflow with long context.
         # - arange_np: immutable [0, 1, 2, ...] used as source for batched computation
         # - query_pos: CpuGpuBuffer for the computed batched arange result
-        arange_size = max(self.max_num_reqs + 1, self.max_num_tokens)
+        arange_size = max(self.max_num_reqs + 1, self.max_buffer_num_tokens)
         self.arange_np = np.arange(arange_size, dtype=np.int64)
         self.query_pos = self._make_buffer(arange_size, dtype=torch.int64)
         self._arange_scratch = np.empty(arange_size, dtype=np.int64)
+
+        if self.pcp_world_size > 1:
+            self.pcp_manager = PCPManager(
+                pcp_world_size=self.pcp_world_size,
+                pcp_rank=self.pcp_rank,
+                max_buffer_num_tokens=self.max_buffer_num_tokens,
+                max_num_reqs=self.max_num_reqs,
+                device=self.device,
+                pin_memory=PIN_MEMORY,
+            )
 
         # Layer pairings for cross-layer KV sharing.
         # If an Attention layer `layer_name` is in the keys of this dict, it
@@ -2061,12 +2094,35 @@ class GPUModelRunner(
         cu_num_tokens = self._get_cumsum_and_arange(
             num_scheduled_tokens, self.query_pos.np
         )
+        local_cu_num_tokens_for_pcp: np.ndarray | None = None
 
         # Get positions.
         positions_np = (
             self.input_batch.num_computed_tokens_cpu[req_indices]
             + self.query_pos.np[: cu_num_tokens[-1]]
         )
+
+        if self.pcp_world_size > 1:
+            assert not scheduler_output.scheduled_spec_decode_tokens, (
+                "PCP does not support speculative decoding yet."
+            )
+            assert not self.input_batch.req_prompt_embeds, (
+                "PCP does not support prompt embeddings yet."
+            )
+            assert not self.uses_mrope and self.uses_xdrope_dim == 0, (
+                "PCP does not support multimodal rotary positions yet."
+            )
+            (
+                total_num_scheduled_tokens,
+                req_indices,
+                cu_num_tokens,
+                positions_np,
+            ) = self._apply_pcp_token_sharding(
+                scheduler_output,
+                num_scheduled_tokens,
+                num_reqs,
+            )
+            local_cu_num_tokens_for_pcp = cu_num_tokens.copy()
 
         # Calculate M-RoPE positions.
         # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
@@ -2173,9 +2229,20 @@ class GPUModelRunner(
 
         # Record which requests should not be sampled,
         # so that we could clear the sampled tokens before returning
-        self.discard_request_mask.np[:num_reqs] = (
-            self.optimistic_seq_lens_cpu[:num_reqs].numpy() < num_tokens_np
-        )
+        if self.pcp_world_size > 1:
+            full_scheduled_tokens = (
+                num_scheduled_tokens[:num_reqs] * self.pcp_world_size
+                - self.pcp_manager.num_pcp_pads_cpu[:num_reqs]
+            )
+            self.discard_request_mask.np[:num_reqs] = (
+                self.input_batch.num_computed_tokens_cpu[:num_reqs]
+                + full_scheduled_tokens
+                < num_tokens_np
+            )
+        else:
+            self.discard_request_mask.np[:num_reqs] = (
+                self.optimistic_seq_lens_cpu[:num_reqs].numpy() < num_tokens_np
+            )
         self.discard_request_mask.copy_to_gpu(num_reqs)
 
         # Sync num_accepted_tokens from CPU (set by
@@ -2268,6 +2335,20 @@ class GPUModelRunner(
         )
         self.seq_lens[num_reqs:].fill_(0)
 
+        if self.pcp_world_size > 1:
+            self.positions[:total_num_scheduled_tokens].copy_(
+                torch.from_numpy(positions_np).to(
+                    self.device, dtype=torch.int64, non_blocking=True
+                )
+            )
+            assert local_cu_num_tokens_for_pcp is not None
+            self.query_start_loc.np[0] = 0
+            self.query_start_loc.np[1 : num_reqs + 1] = local_cu_num_tokens_for_pcp
+            self.query_start_loc.np[num_reqs + 1 :].fill(
+                local_cu_num_tokens_for_pcp[-1]
+            )
+            self.query_start_loc.copy_to_gpu()
+
         self.input_batch.block_table.compute_slot_mapping(
             num_reqs,
             self.query_start_loc.gpu[: num_reqs + 1],
@@ -2310,10 +2391,25 @@ class GPUModelRunner(
             # from these partial requests, we do so for simplicity.
             # We will ignore the sampled tokens from the partial requests.
             # TODO: Support prompt logprobs.
-            logits_indices = query_start_loc[1:] - 1
+            if self.pcp_world_size > 1:
+                logits_indices = (
+                    torch.from_numpy(cu_num_tokens).to(
+                        self.device, dtype=torch.int64, non_blocking=True
+                    )
+                    * self.pcp_world_size
+                    - self.pcp_manager.num_pcp_pads_cpu_tensor[:num_reqs].to(
+                        self.device, dtype=torch.int64, non_blocking=True
+                    )
+                    - 1
+                )
+            else:
+                logits_indices = query_start_loc[1:] - 1
             spec_decode_metadata = None
             num_sampled_tokens = np.ones(num_reqs, dtype=np.int32)
         else:
+            assert self.pcp_world_size == 1, (
+                "PCP does not support speculative decoding yet."
+            )
             # Get the number of draft tokens for each request.
             # Iterate over the dictionary rather than all requests since not all
             # requests have draft tokens.
@@ -2355,6 +2451,65 @@ class GPUModelRunner(
             spec_decode_metadata,
         )
 
+    def _apply_pcp_token_sharding(
+        self,
+        scheduler_output: "SchedulerOutput",
+        num_scheduled_tokens: np.ndarray,
+        num_reqs: int,
+    ) -> tuple[int, np.ndarray, np.ndarray, np.ndarray]:
+        """Replace global scheduled counts with this PCP rank's local view."""
+        pcp_num_scheduled_tokens, pcp_positions = (
+            self.pcp_manager.update_tokens_for_pcp(
+                num_scheduled_tokens[:num_reqs],
+                self.arange_np,
+                num_reqs,
+                reorder_batch_threshold=self.reorder_batch_threshold,
+            )
+        )
+        num_scheduled_tokens[:num_reqs] = pcp_num_scheduled_tokens
+        total_num_scheduled_tokens = int(
+            np.sum(num_scheduled_tokens[:num_reqs], dtype=np.int64)
+        )
+        scheduler_output.total_num_scheduled_tokens = total_num_scheduled_tokens
+        req_indices = np.repeat(
+            self.arange_np[:num_reqs], num_scheduled_tokens[:num_reqs]
+        )
+        cu_num_tokens = self._get_cumsum_and_arange(
+            num_scheduled_tokens[:num_reqs], self.query_pos.np
+        )
+        positions = (
+            self.input_batch.num_computed_tokens_cpu[req_indices]
+            + pcp_positions[:total_num_scheduled_tokens]
+        )
+        return (
+            total_num_scheduled_tokens,
+            req_indices,
+            cu_num_tokens,
+            positions,
+        )
+
+    def _update_pcp_full_seq_lens(
+        self,
+        num_reqs: int,
+        num_reqs_padded: int,
+    ) -> torch.Tensor:
+        """Reconstruct full sequence lengths from this rank's padded PCP view."""
+        local_scheduled_tokens = (
+            self.optimistic_seq_lens_cpu[:num_reqs]
+            - self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs]
+        )
+        torch.add(
+            self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs],
+            local_scheduled_tokens * self.pcp_world_size,
+            out=self.pcp_full_seq_lens.cpu[:num_reqs],
+        )
+        self.pcp_full_seq_lens.cpu[:num_reqs] -= (
+            self.pcp_manager.num_pcp_pads_cpu_tensor[:num_reqs].to(dtype=torch.int32)
+        )
+        self.pcp_full_seq_lens.cpu[num_reqs:].fill_(0)
+        self.pcp_full_seq_lens.copy_to_gpu(num_reqs_padded)
+        return self.pcp_full_seq_lens.cpu[:num_reqs]
+
     def _build_attention_metadata(
         self,
         num_tokens: int,
@@ -2382,6 +2537,13 @@ class GPUModelRunner(
         num_reqs_padded = num_reqs_padded or num_reqs
         assert num_reqs_padded is not None and num_tokens_padded is not None
 
+        full_seq_lens_cpu = self.optimistic_seq_lens_cpu[:num_reqs]
+        if self.pcp_world_size > 1:
+            full_seq_lens_cpu = self._update_pcp_full_seq_lens(
+                num_reqs,
+                num_reqs_padded,
+            )
+
         attn_metadata: PerLayerAttnMetadata = {}
         if ubatch_slices is not None:
             attn_metadata = [dict() for _ in range(len(ubatch_slices))]
@@ -2392,7 +2554,7 @@ class GPUModelRunner(
             # window size when capturing to make sure the correct kernel is selected.
             max_seq_len = self.max_model_len
         else:
-            max_seq_len = self.optimistic_seq_lens_cpu.numpy()[:num_reqs].max().item()
+            max_seq_len = full_seq_lens_cpu.numpy().max().item()
 
         kv_cache_groups = self.kv_cache_config.kv_cache_groups
 
@@ -2515,11 +2677,11 @@ class GPUModelRunner(
             rswa_prefix_lens=rswa_prefix_lens,
         )
 
-        if self.dcp_world_size > 1:
-            self.dcp_local_seq_lens.cpu[:num_reqs] = get_dcp_local_seq_lens(
-                self.optimistic_seq_lens_cpu[:num_reqs],
-                self.dcp_world_size,
-                self.dcp_rank,
+        if self.cp_world_size > 1:
+            self.dcp_local_seq_lens.cpu[:num_reqs] = get_cp_local_seq_lens(
+                full_seq_lens_cpu,
+                self.cp_world_size,
+                self.cp_rank,
                 self.parallel_config.cp_kv_cache_interleave_size,
             )
             self.dcp_local_seq_lens.cpu[num_reqs:].fill_(0)
@@ -2529,6 +2691,19 @@ class GPUModelRunner(
             cm_base.dcp_local_seq_lens_cpu = self.dcp_local_seq_lens.cpu[
                 :num_reqs_padded
             ]
+            if self.pcp_world_size > 1:
+                cm_base.pcp_allgather_restore_idx = (
+                    self.pcp_manager.pcp_allgather_restore_idx.gpu[
+                        : num_tokens * self.pcp_world_size
+                    ]
+                )
+                cm_base.pcp_full_seq_lens = self.pcp_full_seq_lens.gpu[:num_reqs_padded]
+                cm_base.pcp_full_seq_lens_cpu = self.pcp_full_seq_lens.cpu[
+                    :num_reqs_padded
+                ]
+                cm_base.pcp_request_views = self.pcp_manager.pcp_request_views[
+                    :num_reqs
+                ]
 
         if logits_indices is not None and self.cache_config.kv_sharing_fast_prefill:
             cm_base.num_logits_indices = logits_indices.size(0)
@@ -3973,6 +4148,23 @@ class GPUModelRunner(
             **model_kwargs,
         )
 
+    def _maybe_restore_pcp_hidden_states_for_logits(
+        self,
+        hidden_states: torch.Tensor,
+        num_local_tokens: int,
+    ) -> torch.Tensor:
+        if self.pcp_world_size <= 1:
+            return hidden_states
+
+        pcp_full_tokens = num_local_tokens * self.pcp_world_size
+        restore_idx = self.pcp_manager.pcp_allgather_restore_idx.gpu[:pcp_full_tokens]
+        return pcp_allgather_and_restore(
+            hidden_states,
+            num_local_tokens,
+            restore_idx,
+            get_pcp_group(),
+        )
+
     @staticmethod
     def _is_uniform_decode(
         max_num_scheduled_tokens: int,
@@ -4316,10 +4508,18 @@ class GPUModelRunner(
                 scheduler_output,
                 num_scheduled_tokens_np,
             )
+            if self.pcp_world_size > 1:
+                num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
+                num_tokens_unpadded = num_scheduled_tokens
+                max_num_scheduled_tokens = int(num_scheduled_tokens_np[:num_reqs].max())
 
             cascade_attn_prefix_lens = None
             # Disable cascade attention when using microbatching (DBO)
-            if self.cascade_attn_enabled and not self.parallel_config.use_ubatching:
+            if (
+                self.cascade_attn_enabled
+                and not self.parallel_config.use_ubatching
+                and self.pcp_world_size == 1
+            ):
                 # Pre-compute cascade attention prefix lengths
                 cascade_attn_prefix_lens = self._compute_cascade_attn_prefix_lens(
                     num_scheduled_tokens_np,
@@ -4556,12 +4756,20 @@ class GPUModelRunner(
                         kv_connector_output,
                     )
 
+                hidden_states = self._maybe_restore_pcp_hidden_states_for_logits(
+                    hidden_states,
+                    num_scheduled_tokens,
+                )
                 sample_hidden_states = hidden_states[logits_indices]
                 logits = self.model.compute_logits(sample_hidden_states)
             else:
                 # Rare case.
                 assert not self.is_pooling_model
 
+                hidden_states = self._maybe_restore_pcp_hidden_states_for_logits(
+                    hidden_states,
+                    num_scheduled_tokens,
+                )
                 sample_hidden_states = hidden_states[logits_indices]
                 if not get_pp_group().is_last_rank:
                     all_gather_tensors = {


### PR DESCRIPTION
## Purpose

Enable DeepSeek-V4 Prefill Context Parallelism (PCP) on the current `iaas_main` path, including end-to-end Mooncake PD transfer from a PCP-sharded Prefill worker to a non-PCP Decode worker.

This change:

- adds the DeepSeek-V4 PCP metadata and reindexing path for C4, C128, SWA, compressor state, and sparse-MLA/indexer data;
- extends the V1 PCP manager and scheduler/KV accounting so each PCP rank operates on compact local token and slot views and restores full request order where required;
- declares PCP support for the DeepSeek-V4 compressor, sparse SWA, and sparse FlashMLA backends;
- makes Mooncake bootstrap identity and transfer planning PCP-aware, including TP/PP/PCP address mapping and PCP2 producer fan-in to a PCP1 consumer;
- requires every expected PCP shard and rejects invalid or incomplete topology instead of silently transferring partial KV state;
- preserves PCP1 behavior and explicitly rejects unsupported PCP combinations such as speculative decoding, prompt embeddings, and multimodal rotary positions.

### Why this does not duplicate an existing PR

No existing PR was found in `bytedance-iaas/vllm` for this head branch or for the searched DeepSeek-V4 PCP / Prefill Context Parallel + Mooncake scope. This is a refresh of previously validated internal PCP behavior onto the current `iaas_main` abstractions and test layout; preserving the original commit identity was intentionally not required.

Base: `iaas_main@d86d2d03cd8a05b5b89269b54daff5f5419d2579`  
Head: `20bce687d4061db07f389914441d930468fe2054`

## Test Plan

### Targeted unit and source validation

```bash
python -m pytest -q \
  tests/v1/worker/test_pcp_utils.py \
  tests/v1/worker/test_pcp_interleave_metadata.py \
  tests/models/deepseek_v4/test_pcp_reindex.py

git diff --check iaas/iaas_main...HEAD
```

Additional targeted selections cover Mooncake connector/bootstrap behavior, scheduler and KV accounting, GPU model-runner PCP guards, backend capability declarations, and mixed warmup behavior. Changed Python files were also checked with Ruff and `compileall` in the matching development image.

### H20 end-to-end validation

- Environment: Claw, namespace `hank`.
- Model: DeepSeek-V4 Flash.
- Prefill: one Pod, 8 x H20, `TP2 + PP2 + PCP2`.
- Decode: one Pod, 8 x H20, unchanged `TP1 + DP8 + EP + deepep_low_latency + MTP4`, `PCP1`.
- Transfer: Mooncake PD.
- Final runtime image:
  `iaas-gpu-cn-beijing.cr.volces.com/serving/vllm:v0.26.0.post20260813.iaas.dev.202608132254-cu130`
- Runtime digest:
  `sha256:66e268ce6824ddbc1adb3233e85c683827c99518808333477c7c3a99b0c64354`
- Build workflow: https://github.com/bytedance-iaas/vllm/actions/runs/31712528038

The comparison keeps Prefill and Decode at 8 GPUs each and changes only Prefill PCP from PCP1 to PCP2. Long-context measurements use three formal runs after all Decode DP ranks are warm.

## Test Result

### Unit and static checks

- `77 passed`: targeted PCP, Mooncake, scheduler/KV, model-runner, and warmup source-hotfix gate.
- `12 passed`: matching-image backend capability and metadata gate.
- `50 passed`: final development-image PCP helper, metadata, and DeepSeek-V4 reindex suite.
- Ruff, `compileall`, `git diff --check`: passed.

### H20 long-context Prefill result

| Input workload | PCP1 median | PCP2 final-image median | Latency improvement | Aggregate input TPS improvement | Correctness |
|---|---:|---:|---:|---:|---|
| 512K + 1 output token | 68.100 s | 51.808 s | 23.92% | 31.45% | 3/3 exact |
| 1,048,575 input + 1 output token | 206.035 s | 142.143 s | 31.01% | 44.95% | 3/3 exact |

The legal 1M boundary is 1,048,575 input tokens plus one output token. The final immutable image stayed within `+0.10%` at 512K and `+0.92%` at 1M versus the source-hotfix PCP2 baseline.

### Decode guardrail

- Workload: 8 requests, each 128K input + 1,500 output tokens.
- Result: 8/8 exact.
- TPOT p50/p99: `5.002 / 6.980 ms`.
- TTFT p50/p99: `10.863 / 10.942 s`.
- Clean final observation window: no Traceback, AssertionError, OOM, CUDA/NCCL failure, HTTP 5xx, fatal error, or serving-rank restart increase.

### Model evaluation

This change does not modify model weights or sampling semantics. Deterministic long-context requests were checked for exact completion/token accounting, and all six formal 512K/1M corpus hashes matched the source-hotfix PCP2 validation for the same seeds. The 128K decode guard also completed exactly on all eight requests.

### AI assistance

AI assistance was used to analyze the upstream/current-branch differences, port the implementation, add and run targeted tests, execute the H20 validation workflow, and draft this PR description. A human submitter must review the code and evidence, and is responsible for the final design and merge decision.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose and user-visible behavior are described.
- [x] The change is checked against existing internal PRs and is not a duplicate.
- [x] Test commands and results are included.
- [x] Model-affecting behavior has end-to-end correctness and performance evidence.
- [x] Unsupported combinations and fail-closed behavior are documented.
- [x] AI assistance is disclosed and human review is required before marking ready.

</details>
