### PR TITLE
ci: publish ByteIAAS images in zstd and nydus formats

### DIFF
--- a/.github/workflows/_byteiaas-build-and-publish-image.yml
+++ b/.github/workflows/_byteiaas-build-and-publish-image.yml
@@ -380,27 +380,9 @@ jobs:
         if: ${{ steps.image-formats.outputs.zstd == 'true' }}
         run: |
           set -euo pipefail
-          python3 - \
+          python3 scripts/ci/verify_byteiaas_image_format.py --format zstd \
             "${IMAGE_REPO}:${{ steps.image-tags.outputs.openai_zstd_image_tag }}" \
-            "${IMAGE_REPO}:${{ steps.image-tags.outputs.openai_devel_zstd_image_tag }}" <<'PY'
-          import json
-          import subprocess
-          import sys
-
-          for target in sys.argv[1:]:
-              raw = subprocess.check_output(
-                  ["docker", "buildx", "imagetools", "inspect", "--raw", target]
-              )
-              manifest = json.loads(raw)
-              media_types = {
-                  layer.get("mediaType", "") for layer in manifest.get("layers", [])
-              }
-              if not any("zstd" in media_type for media_type in media_types):
-                  raise SystemExit(
-                      f"expected zstd layer media types for {target}, got {media_types}"
-                  )
-              print(f"Verified zstd image {target}: {sorted(media_types)}")
-          PY
+            "${IMAGE_REPO}:${{ steps.image-tags.outputs.openai_devel_zstd_image_tag }}"
 
       - name: Install nydus tooling
         if: ${{ steps.image-formats.outputs.nydus == 'true' }}
@@ -469,30 +451,5 @@ jobs:
             nydusify check --target "${target}"
             docker buildx imagetools inspect "${target}"
           done
-          python3 - "${targets[@]}" <<'PY'
-          import json
-          import subprocess
-          import sys
-
-          for target in sys.argv[1:]:
-              raw = subprocess.check_output(
-                  ["docker", "buildx", "imagetools", "inspect", "--raw", target]
-              )
-              manifest = json.loads(raw)
-              layers = manifest.get("layers", [])
-              media_types = [layer.get("mediaType", "") for layer in layers]
-              annotation_keys = {
-                  key
-                  for layer in layers
-                  for key in (layer.get("annotations", {}) or {})
-              }
-              has_nydus = any("nydus" in item for item in media_types) or any(
-                  "nydus" in key for key in annotation_keys
-              )
-              if not has_nydus:
-                  raise SystemExit(
-                      f"expected nydus markers for {target}; "
-                      f"layers={media_types}, annotations={sorted(annotation_keys)}"
-                  )
-              print(f"Verified nydus image {target}: {media_types}")
-          PY
+          python3 scripts/ci/verify_byteiaas_image_format.py --format nydus \
+            "${targets[@]}"

--- a/.github/workflows/_byteiaas-build-and-publish-image.yml
+++ b/.github/workflows/_byteiaas-build-and-publish-image.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: string
         default: ""
+      image_formats:
+        description: "CSV of image formats to build and push. Default: oci,zstd,nydus"
+        required: false
+        type: string
+        default: "oci,zstd,nydus"
 
 jobs:
   build-and-publish-image:
@@ -55,6 +60,7 @@ jobs:
       BYTEIAAS_HPC_OPS_REPO: https://github.com/wangyicong52/hpc-ops.git
       BYTEIAAS_HPC_OPS_REF: 915755b437257e1118a80f5cbb07509037faad05
       BYTEIAAS_VLLM_ROUTER_VERSION: "0.1.15"
+      IMAGE_FORMATS: ${{ inputs.image_formats }}
     steps:
       - name: Cleanup workspace
         run: sudo rm -rf "$GITHUB_WORKSPACE"/* || true
@@ -89,6 +95,7 @@ jobs:
           set -euo pipefail
           resolve_tag() {
             local image_flavor="$1"
+            local format_suffix="${2:-}"
             local tag_args=(
               --mode "${{ inputs.tag_mode }}"
               --image-flavor "${image_flavor}"
@@ -100,15 +107,51 @@ jobs:
             if [ -n "${BYTEIAAS_VLLM_VERSION}" ]; then
               tag_args+=(--vllm-version "${BYTEIAAS_VLLM_VERSION}")
             fi
+            if [ -n "${format_suffix}" ]; then
+              tag_args+=(--format-suffix "${format_suffix}")
+            fi
             python3 scripts/ci/get_byteiaas_image_tag.py "${tag_args[@]}"
           }
 
           OPENAI_IMAGE_TAG="$(resolve_tag openai)"
           OPENAI_DEVEL_IMAGE_TAG="$(resolve_tag openai-devel)"
+          OPENAI_ZSTD_IMAGE_TAG="$(resolve_tag openai zstd)"
+          OPENAI_DEVEL_ZSTD_IMAGE_TAG="$(resolve_tag openai-devel zstd)"
+          OPENAI_NYDUS_IMAGE_TAG="$(resolve_tag openai nydus)"
+          OPENAI_DEVEL_NYDUS_IMAGE_TAG="$(resolve_tag openai-devel nydus)"
           echo "openai_image_tag=${OPENAI_IMAGE_TAG}" >> "${GITHUB_OUTPUT}"
           echo "openai_devel_image_tag=${OPENAI_DEVEL_IMAGE_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "openai_zstd_image_tag=${OPENAI_ZSTD_IMAGE_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "openai_devel_zstd_image_tag=${OPENAI_DEVEL_ZSTD_IMAGE_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "openai_nydus_image_tag=${OPENAI_NYDUS_IMAGE_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "openai_devel_nydus_image_tag=${OPENAI_DEVEL_NYDUS_IMAGE_TAG}" >> "${GITHUB_OUTPUT}"
           echo "Resolved openai image tag ${OPENAI_IMAGE_TAG}"
           echo "Resolved openai-devel image tag ${OPENAI_DEVEL_IMAGE_TAG}"
+
+      - name: Validate requested image formats
+        id: image-formats
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os
+
+          raw = os.environ.get("IMAGE_FORMATS", "oci,zstd,nydus")
+          formats = [item.strip() for item in raw.split(",") if item.strip()]
+          if not formats:
+              formats = ["oci", "zstd", "nydus"]
+          allowed = {"oci", "zstd", "nydus"}
+          unknown = sorted(set(formats) - allowed)
+          if unknown:
+              raise SystemExit(
+                  f"unknown image formats: {unknown}; allowed: {sorted(allowed)}"
+              )
+          selected = set(formats)
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              for image_format in sorted(allowed):
+                  enabled = str(image_format in selected).lower()
+                  output.write(f"{image_format}={enabled}\n")
+          print(f"Requested image formats: {formats}")
+          PY
 
       - name: Set up Docker Buildx with local Docker Hub mirror
         id: buildx
@@ -135,6 +178,8 @@ jobs:
           final_base_image="nvidia/cuda:${{ inputs.cuda_version }}-base-ubuntu${ubuntu_version}"
           openai_metadata_file="/tmp/byteiaas-vllm-openai-image.json"
           openai_devel_metadata_file="/tmp/byteiaas-vllm-openai-devel-image.json"
+          openai_zstd_metadata_file="/tmp/byteiaas-vllm-openai-zstd-image.json"
+          openai_devel_zstd_metadata_file="/tmp/byteiaas-vllm-openai-devel-zstd-image.json"
           build_cpus="$(nproc)"
           build_max_jobs="${BYTEIAAS_BUILD_MAX_JOBS:-${build_cpus}}"
           default_nvcc_threads=4
@@ -189,13 +234,29 @@ jobs:
             fi
           }
 
+          buildx_from_local_cache() {
+            local cache_name="$1"
+            shift
+            local cache_dir="${cache_root}/${cache_name}"
+            local cache_args=()
+            if [ -d "${cache_dir}" ]; then
+              cache_args+=(--cache-from "type=local,src=${cache_dir}")
+              echo "Reusing local BuildKit cache: ${cache_dir}"
+            else
+              echo "::error::Expected local BuildKit cache is missing: ${cache_dir}"
+              return 1
+            fi
+            docker buildx build --builder "${{ steps.buildx.outputs.name }}" "${cache_args[@]}" "$@"
+          }
+
           build_vllm_openai() {
-            local output_name="$1"
-            local metadata_path="$2"
-            buildx_with_local_cache openai \
+            local cache_mode="$1"
+            local output_options="$2"
+            local metadata_path="$3"
+            local build_args=(
               --target vllm-openai \
               --platform linux/amd64 \
-              --output "type=image,name=${output_name},push-by-digest=true,name-canonical=true,push=true" \
+              --output "type=image,name=${IMAGE_REPO},push-by-digest=true,name-canonical=true,push=true${output_options}" \
               -f docker/Dockerfile \
               --build-arg CUDA_VERSION=${{ inputs.cuda_version }} \
               --build-arg FINAL_BASE_IMAGE="${final_base_image}" \
@@ -228,37 +289,69 @@ jobs:
               --build-arg RUN_WHEEL_CHECK=false \
               --metadata-file "${metadata_path}" \
               .
+            )
+            if [ "${cache_mode}" = "write" ]; then
+              buildx_with_local_cache openai "${build_args[@]}"
+            else
+              buildx_from_local_cache openai "${build_args[@]}"
+            fi
           }
 
-          build_vllm_openai "${IMAGE_REPO}" "${openai_metadata_file}"
+          build_vllm_openai_devel() {
+            local cache_mode="$1"
+            local output_options="$2"
+            local base_digest="$3"
+            local metadata_path="$4"
+            local build_args=(
+              --platform linux/amd64
+              --output "type=image,name=${IMAGE_REPO},push-by-digest=true,name-canonical=true,push=true${output_options}"
+              -f docker/byteiaas-openai-devel.Dockerfile
+              --build-arg "VLLM_OPENAI_DEVEL_BASE_IMAGE=${IMAGE_REPO}@${base_digest}"
+              --build-arg CUDA_VERSION=${{ inputs.cuda_version }}
+              --build-arg max_jobs="${build_max_jobs}"
+              --build-arg nvcc_threads="${build_nvcc_threads}"
+              --build-arg HTTP_PROXY="${HTTP_PROXY}"
+              --build-arg HTTPS_PROXY="${HTTPS_PROXY}"
+              --build-arg ALL_PROXY="${ALL_PROXY}"
+              --build-arg NO_PROXY="${NO_PROXY}"
+              --build-arg http_proxy="${HTTP_PROXY}"
+              --build-arg https_proxy="${HTTPS_PROXY}"
+              --build-arg all_proxy="${ALL_PROXY}"
+              --build-arg no_proxy="${NO_PROXY}"
+              --metadata-file "${metadata_path}"
+              .
+            )
+            if [ "${cache_mode}" = "write" ]; then
+              buildx_with_local_cache openai-devel "${build_args[@]}"
+            else
+              buildx_from_local_cache openai-devel "${build_args[@]}"
+            fi
+          }
+
+          build_vllm_openai write "" "${openai_metadata_file}"
           openai_digest="$(python3 -c "import json; print(json.load(open('${openai_metadata_file}'))['containerimage.digest'])")"
           echo "Pushed openai digest: ${openai_digest}"
 
-          buildx_with_local_cache openai-devel \
-            --platform linux/amd64 \
-            --output "type=image,name=${IMAGE_REPO},push-by-digest=true,name-canonical=true,push=true" \
-            -f docker/byteiaas-openai-devel.Dockerfile \
-            --build-arg "VLLM_OPENAI_DEVEL_BASE_IMAGE=${IMAGE_REPO}@${openai_digest}" \
-            --build-arg CUDA_VERSION=${{ inputs.cuda_version }} \
-            --build-arg max_jobs="${build_max_jobs}" \
-            --build-arg nvcc_threads="${build_nvcc_threads}" \
-            --build-arg HTTP_PROXY="${HTTP_PROXY}" \
-            --build-arg HTTPS_PROXY="${HTTPS_PROXY}" \
-            --build-arg ALL_PROXY="${ALL_PROXY}" \
-            --build-arg NO_PROXY="${NO_PROXY}" \
-            --build-arg http_proxy="${HTTP_PROXY}" \
-            --build-arg https_proxy="${HTTPS_PROXY}" \
-            --build-arg all_proxy="${ALL_PROXY}" \
-            --build-arg no_proxy="${NO_PROXY}" \
-            --metadata-file "${openai_devel_metadata_file}" \
-            .
-
+          build_vllm_openai_devel write "" "${openai_digest}" "${openai_devel_metadata_file}"
           openai_devel_digest="$(python3 -c "import json; print(json.load(open('${openai_devel_metadata_file}'))['containerimage.digest'])")"
           echo "Pushed openai-devel digest: ${openai_devel_digest}"
           echo "openai_digest=${openai_digest}" >> "${GITHUB_OUTPUT}"
           echo "openai_devel_digest=${openai_devel_digest}" >> "${GITHUB_OUTPUT}"
 
-      - name: Create Volcengine image tags
+          if [ "${{ steps.image-formats.outputs.zstd }}" = "true" ]; then
+            zstd_output=",compression=zstd,compression-level=3,force-compression=true,oci-mediatypes=true"
+            build_vllm_openai read "${zstd_output}" "${openai_zstd_metadata_file}"
+            openai_zstd_digest="$(python3 -c "import json; print(json.load(open('${openai_zstd_metadata_file}'))['containerimage.digest'])")"
+            build_vllm_openai_devel read "${zstd_output}" "${openai_digest}" "${openai_devel_zstd_metadata_file}"
+            openai_devel_zstd_digest="$(python3 -c "import json; print(json.load(open('${openai_devel_zstd_metadata_file}'))['containerimage.digest'])")"
+            echo "Pushed openai zstd digest: ${openai_zstd_digest}"
+            echo "Pushed openai-devel zstd digest: ${openai_devel_zstd_digest}"
+            echo "openai_zstd_digest=${openai_zstd_digest}" >> "${GITHUB_OUTPUT}"
+            echo "openai_devel_zstd_digest=${openai_devel_zstd_digest}" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Create Volcengine OCI image tags
+        if: ${{ steps.image-formats.outputs.oci == 'true' }}
         run: |
           set -euo pipefail
           docker buildx imagetools create \
@@ -269,3 +362,137 @@ jobs:
             "${IMAGE_REPO}@${{ steps.build.outputs.openai_devel_digest }}"
           echo "Published openai image: ${IMAGE_REPO}:${{ steps.image-tags.outputs.openai_image_tag }}"
           echo "Published openai-devel image: ${IMAGE_REPO}:${{ steps.image-tags.outputs.openai_devel_image_tag }}"
+
+      - name: Create Volcengine zstd image tags
+        if: ${{ steps.image-formats.outputs.zstd == 'true' }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            -t "${IMAGE_REPO}:${{ steps.image-tags.outputs.openai_zstd_image_tag }}" \
+            "${IMAGE_REPO}@${{ steps.build.outputs.openai_zstd_digest }}"
+          docker buildx imagetools create \
+            -t "${IMAGE_REPO}:${{ steps.image-tags.outputs.openai_devel_zstd_image_tag }}" \
+            "${IMAGE_REPO}@${{ steps.build.outputs.openai_devel_zstd_digest }}"
+          echo "Published openai zstd image: ${IMAGE_REPO}:${{ steps.image-tags.outputs.openai_zstd_image_tag }}"
+          echo "Published openai-devel zstd image: ${IMAGE_REPO}:${{ steps.image-tags.outputs.openai_devel_zstd_image_tag }}"
+
+      - name: Verify pushed zstd images
+        if: ${{ steps.image-formats.outputs.zstd == 'true' }}
+        run: |
+          set -euo pipefail
+          python3 - \
+            "${IMAGE_REPO}:${{ steps.image-tags.outputs.openai_zstd_image_tag }}" \
+            "${IMAGE_REPO}:${{ steps.image-tags.outputs.openai_devel_zstd_image_tag }}" <<'PY'
+          import json
+          import subprocess
+          import sys
+
+          for target in sys.argv[1:]:
+              raw = subprocess.check_output(
+                  ["docker", "buildx", "imagetools", "inspect", "--raw", target]
+              )
+              manifest = json.loads(raw)
+              media_types = {
+                  layer.get("mediaType", "") for layer in manifest.get("layers", [])
+              }
+              if not any("zstd" in media_type for media_type in media_types):
+                  raise SystemExit(
+                      f"expected zstd layer media types for {target}, got {media_types}"
+                  )
+              print(f"Verified zstd image {target}: {sorted(media_types)}")
+          PY
+
+      - name: Install nydus tooling
+        if: ${{ steps.image-formats.outputs.nydus == 'true' }}
+        env:
+          NYDUS_VERSION: "2.3.0"
+        run: |
+          set -euo pipefail
+          tarball="nydus-static-v${NYDUS_VERSION}-linux-amd64.tgz"
+          url="https://github.com/dragonflyoss/nydus/releases/download/v${NYDUS_VERSION}/${tarball}"
+          retry() {
+            for attempt in 1 2 3 4 5; do
+              "$@" && return 0
+              echo "attempt ${attempt} failed; sleeping 15s"
+              sleep 15
+            done
+            return 1
+          }
+          retry curl -fL --retry 5 --retry-all-errors --retry-delay 2 \
+            -o "/tmp/${tarball}" "${url}"
+          tar -xzf "/tmp/${tarball}" -C /tmp
+          sudo install -m 0755 /tmp/nydus-static/nydusify /usr/local/bin/nydusify
+          sudo install -m 0755 /tmp/nydus-static/nydus-image /usr/local/bin/nydus-image
+          nydusify --version
+          nydus-image --version
+
+      - name: Convert and push nydus images
+        if: ${{ steps.image-formats.outputs.nydus == 'true' }}
+        run: |
+          set -euo pipefail
+          retry() {
+            for attempt in 1 2 3 4 5; do
+              "$@" && return 0
+              echo "attempt ${attempt} failed; sleeping 20s"
+              sleep 20
+            done
+            return 1
+          }
+          convert_image() {
+            local source_digest="$1"
+            local target_tag="$2"
+            local source="${IMAGE_REPO}@${source_digest}"
+            local target="${IMAGE_REPO}:${target_tag}"
+            echo "Converting ${source} to ${target}"
+            retry nydusify convert \
+              --nydus-image /usr/local/bin/nydus-image \
+              --source "${source}" \
+              --target "${target}"
+            echo "Published ${target}"
+          }
+          convert_image \
+            "${{ steps.build.outputs.openai_digest }}" \
+            "${{ steps.image-tags.outputs.openai_nydus_image_tag }}"
+          convert_image \
+            "${{ steps.build.outputs.openai_devel_digest }}" \
+            "${{ steps.image-tags.outputs.openai_devel_nydus_image_tag }}"
+
+      - name: Verify pushed nydus images
+        if: ${{ steps.image-formats.outputs.nydus == 'true' }}
+        run: |
+          set -euo pipefail
+          targets=(
+            "${IMAGE_REPO}:${{ steps.image-tags.outputs.openai_nydus_image_tag }}"
+            "${IMAGE_REPO}:${{ steps.image-tags.outputs.openai_devel_nydus_image_tag }}"
+          )
+          for target in "${targets[@]}"; do
+            nydusify check --target "${target}"
+            docker buildx imagetools inspect "${target}"
+          done
+          python3 - "${targets[@]}" <<'PY'
+          import json
+          import subprocess
+          import sys
+
+          for target in sys.argv[1:]:
+              raw = subprocess.check_output(
+                  ["docker", "buildx", "imagetools", "inspect", "--raw", target]
+              )
+              manifest = json.loads(raw)
+              layers = manifest.get("layers", [])
+              media_types = [layer.get("mediaType", "") for layer in layers]
+              annotation_keys = {
+                  key
+                  for layer in layers
+                  for key in (layer.get("annotations", {}) or {})
+              }
+              has_nydus = any("nydus" in item for item in media_types) or any(
+                  "nydus" in key for key in annotation_keys
+              )
+              if not has_nydus:
+                  raise SystemExit(
+                      f"expected nydus markers for {target}; "
+                      f"layers={media_types}, annotations={sorted(annotation_keys)}"
+                  )
+              print(f"Verified nydus image {target}: {media_types}")
+          PY

--- a/.github/workflows/byteiaas-release-dev.yml
+++ b/.github/workflows/byteiaas-release-dev.yml
@@ -17,6 +17,10 @@ on:
         description: "Optional vLLM version override for image tag generation"
         required: false
         default: ""
+      image_formats:
+        description: "CSV of image formats to build: oci,zstd,nydus"
+        required: false
+        default: "oci,zstd,nydus"
 
 concurrency:
   group: byteiaas-vllm-dev-${{ github.ref_name }}
@@ -39,4 +43,5 @@ jobs:
       cuda_version: "13.0.2"
       tag_mode: dev
       vllm_version: ${{ github.event_name == 'workflow_dispatch' && inputs.vllm_version || '' }}
+      image_formats: ${{ github.event_name == 'workflow_dispatch' && inputs.image_formats || 'oci,zstd,nydus' }}
     secrets: inherit

--- a/.github/workflows/byteiaas-release.yml
+++ b/.github/workflows/byteiaas-release.yml
@@ -15,6 +15,10 @@ on:
         description: "Optional vLLM version override for image tag generation"
         required: false
         default: ""
+      image_formats:
+        description: "CSV of image formats to build: oci,zstd,nydus"
+        required: false
+        default: "oci,zstd,nydus"
 
 concurrency:
   group: byteiaas-vllm-release-${{ github.event.inputs.release_tag || github.ref_name }}
@@ -79,4 +83,5 @@ jobs:
       tag_mode: release
       tag_value: ${{ needs.resolve-release.outputs.internal_tag }}
       vllm_version: ${{ github.event.inputs.vllm_version || '' }}
+      image_formats: ${{ github.event.inputs.image_formats || 'oci,zstd,nydus' }}
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,7 @@ inverse_std_variences = "inverse_std_variences"
 [tool.typos.default.extend-words]
 iy = "iy"
 indx = "indx"
+byted = "byted"
 # intel cpu features
 tme = "tme"
 dout = "dout"

--- a/scripts/ci/get_byteiaas_image_tag.py
+++ b/scripts/ci/get_byteiaas_image_tag.py
@@ -111,6 +111,7 @@ def build_tag(
     timestamp: str,
     tag_value: str,
     cuda_suffix: str,
+    format_suffix: str = "",
 ) -> str:
     if mode == "dev":
         tag = f"v{vllm_version}.iaas.dev.{timestamp}"
@@ -132,6 +133,10 @@ def build_tag(
 
     if cuda_suffix:
         tag = f"{tag}-{cuda_suffix}"
+    if format_suffix:
+        if not is_tag_safe_suffix(format_suffix):
+            raise SystemExit("--format-suffix must be a Docker tag-safe suffix")
+        tag = f"{tag}-{format_suffix}"
     return tag
 
 
@@ -163,6 +168,11 @@ def main() -> None:
         help="Explicit vLLM version. Defaults to BYTEIAAS_VLLM_VERSION or git.",
     )
     parser.add_argument(
+        "--format-suffix",
+        default="",
+        help="Optional image format suffix appended after the CUDA suffix.",
+    )
+    parser.add_argument(
         "--timestamp",
         default="",
         help="Optional deterministic timestamp in YYYYMMDDHHMM format.",
@@ -176,6 +186,7 @@ def main() -> None:
         timestamp=current_timestamp(args.timestamp),
         tag_value=args.tag_value,
         cuda_suffix=args.cuda_suffix,
+        format_suffix=args.format_suffix,
     )
     print(tag)
 

--- a/scripts/ci/test_get_byteiaas_image_tag.py
+++ b/scripts/ci/test_get_byteiaas_image_tag.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from get_byteiaas_image_tag import build_tag
+
+
+class GetByteiaasImageTagTest(unittest.TestCase):
+    def test_dev_openai_tag_preserves_existing_format(self) -> None:
+        self.assertEqual(
+            build_tag(
+                mode="dev",
+                image_flavor="openai",
+                vllm_version="0.10.1",
+                timestamp="202608141200",
+                tag_value="",
+                cuda_suffix="cu130",
+            ),
+            "v0.10.1.iaas.dev.202608141200-cu130",
+        )
+
+    def test_format_suffix_trails_flavor_and_cuda_suffixes(self) -> None:
+        self.assertEqual(
+            build_tag(
+                mode="dev",
+                image_flavor="openai-devel",
+                vllm_version="0.10.1",
+                timestamp="202608141200",
+                tag_value="",
+                cuda_suffix="cu130",
+                format_suffix="zstd",
+            ),
+            "v0.10.1.iaas.dev.202608141200-openai-devel-cu130-zstd",
+        )
+        self.assertEqual(
+            build_tag(
+                mode="release",
+                image_flavor="openai",
+                vllm_version="0.10.1",
+                timestamp="202608141200",
+                tag_value="0.10.1.post1",
+                cuda_suffix="cu130",
+                format_suffix="nydus",
+            ),
+            "v0.10.1.post1.byted.202608141200-cu130-nydus",
+        )
+
+    def test_format_suffix_must_be_tag_safe(self) -> None:
+        for value in ("-zstd", "zstd/", "zs td", "z$td"):
+            with (
+                self.subTest(value=value),
+                self.assertRaisesRegex(
+                    SystemExit, "--format-suffix must be a Docker tag-safe suffix"
+                ),
+            ):
+                build_tag(
+                    mode="dev",
+                    image_flavor="openai",
+                    vllm_version="0.10.1",
+                    timestamp="202608141200",
+                    tag_value="",
+                    cuda_suffix="cu130",
+                    format_suffix=value,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test_verify_byteiaas_image_format.py
+++ b/scripts/ci/test_verify_byteiaas_image_format.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from verify_byteiaas_image_format import image_repository, verify_image_format
+
+
+class VerifyByteiaasImageFormatTest(unittest.TestCase):
+    def test_image_repository_preserves_registry_port(self) -> None:
+        self.assertEqual(
+            image_repository("registry.example.com:5000/serving/vllm:tag"),
+            "registry.example.com:5000/serving/vllm",
+        )
+        self.assertEqual(
+            image_repository("registry.example.com/serving/vllm@sha256:index"),
+            "registry.example.com/serving/vllm",
+        )
+
+    def test_zstd_verification_follows_oci_index(self) -> None:
+        manifests: dict[str, dict[str, Any]] = {
+            "registry.example.com/serving/vllm:zstd": {
+                "mediaType": "application/vnd.oci.image.index.v1+json",
+                "manifests": [{"digest": "sha256:image"}],
+            },
+            "registry.example.com/serving/vllm@sha256:image": {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "layers": [
+                    {"mediaType": ("application/vnd.oci.image.layer.v1.tar+zstd")}
+                ],
+            },
+        }
+
+        markers = verify_image_format(
+            "registry.example.com/serving/vllm:zstd",
+            "zstd",
+            inspect=manifests.__getitem__,
+        )
+
+        self.assertEqual(markers, ["application/vnd.oci.image.layer.v1.tar+zstd"])
+
+    def test_nydus_verification_follows_nested_indexes(self) -> None:
+        manifests: dict[str, dict[str, Any]] = {
+            "registry.example.com/serving/vllm:nydus": {
+                "manifests": [{"digest": "sha256:platform"}],
+            },
+            "registry.example.com/serving/vllm@sha256:platform": {
+                "manifests": [{"digest": "sha256:image"}],
+            },
+            "registry.example.com/serving/vllm@sha256:image": {
+                "layers": [
+                    {
+                        "mediaType": "application/vnd.oci.image.layer.v1.tar",
+                        "annotations": {"containerd.io/snapshot/nydus-blob": "true"},
+                    }
+                ]
+            },
+        }
+
+        markers = verify_image_format(
+            "registry.example.com/serving/vllm:nydus",
+            "nydus",
+            inspect=manifests.__getitem__,
+        )
+
+        self.assertIn("containerd.io/snapshot/nydus-blob", markers)
+
+    def test_missing_format_marker_fails(self) -> None:
+        manifest = {
+            "registry.example.com/serving/vllm:zstd": {
+                "layers": [{"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip"}]
+            }
+        }
+
+        with self.assertRaisesRegex(ValueError, "expected zstd layer media types"):
+            verify_image_format(
+                "registry.example.com/serving/vllm:zstd",
+                "zstd",
+                inspect=manifest.__getitem__,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/verify_byteiaas_image_format.py
+++ b/scripts/ci/verify_byteiaas_image_format.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from collections.abc import Callable
+from typing import Any
+
+Manifest = dict[str, Any]
+InspectManifest = Callable[[str], Manifest]
+
+
+def image_repository(reference: str) -> str:
+    if "@" in reference:
+        return reference.rsplit("@", 1)[0]
+
+    prefix, separator, name = reference.rpartition("/")
+    if ":" in name:
+        name = name.rsplit(":", 1)[0]
+    return f"{prefix}{separator}{name}"
+
+
+def inspect_manifest(reference: str) -> Manifest:
+    raw = subprocess.check_output(
+        ["docker", "buildx", "imagetools", "inspect", "--raw", reference]
+    )
+    return json.loads(raw)
+
+
+def collect_layers(
+    reference: str,
+    inspect: InspectManifest = inspect_manifest,
+    seen: set[str] | None = None,
+) -> list[Manifest]:
+    if seen is None:
+        seen = set()
+    if reference in seen:
+        raise ValueError(f"manifest cycle detected at {reference}")
+    seen.add(reference)
+
+    manifest = inspect(reference)
+    layers = manifest.get("layers")
+    if isinstance(layers, list):
+        return layers
+
+    repository = image_repository(reference)
+    collected: list[Manifest] = []
+    for descriptor in manifest.get("manifests", []):
+        digest = descriptor.get("digest", "")
+        if digest:
+            collected.extend(
+                collect_layers(f"{repository}@{digest}", inspect=inspect, seen=seen)
+            )
+    return collected
+
+
+def verify_image_format(
+    reference: str,
+    image_format: str,
+    inspect: InspectManifest = inspect_manifest,
+) -> list[str]:
+    layers = collect_layers(reference, inspect=inspect)
+    media_types = sorted(
+        {layer.get("mediaType", "") for layer in layers if layer.get("mediaType")}
+    )
+
+    if image_format == "zstd":
+        if not any("zstd" in media_type.lower() for media_type in media_types):
+            raise ValueError(
+                f"expected zstd layer media types for {reference}, got {media_types}"
+            )
+        return media_types
+
+    if image_format == "nydus":
+        annotation_markers = {
+            str(marker)
+            for layer in layers
+            for marker in (
+                *(layer.get("annotations", {}) or {}).keys(),
+                *(layer.get("annotations", {}) or {}).values(),
+            )
+        }
+        markers = media_types + sorted(annotation_markers)
+        if not any("nydus" in marker.lower() for marker in markers):
+            raise ValueError(
+                f"expected nydus markers for {reference}; "
+                f"layers={media_types}, annotations={sorted(annotation_markers)}"
+            )
+        return markers
+
+    raise ValueError(f"unsupported image format: {image_format}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Verify ByteIAAS image layer formats in a remote registry."
+    )
+    parser.add_argument("--format", choices=["zstd", "nydus"], required=True)
+    parser.add_argument("references", nargs="+")
+    args = parser.parse_args()
+
+    for reference in args.references:
+        try:
+            markers = verify_image_format(reference, args.format)
+        except ValueError as error:
+            raise SystemExit(str(error)) from error
+        print(f"Verified {args.format} image {reference}: {markers}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- build and publish ByteIAAS `openai` and `openai-devel` images in OCI, zstd, and nydus formats by default
- preserve the existing OCI tag and append `-zstd` / `-nydus` for the new formats
- reuse the existing BuildKit `mode=max` local cache for zstd re-export, then convert the immutable OCI digest with `nydusify` for nydus
- validate requested format names and verify zstd/nydus manifest markers after publishing
- expose `image_formats` on development and release workflow dispatches

