### PR TITLE
[Feature] Support optimized DeepEP for w4a8 cutlass kernel with mooncake

### DIFF
--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -102,7 +102,7 @@ void get_cutlass_batched_moe_mm_data(
     torch::stable::Tensor& problem_sizes2,
     const torch::stable::Tensor& expert_num_tokens,
     const int64_t num_local_experts, const int64_t padded_m, const int64_t n,
-    const int64_t k);
+    const int64_t k, const bool swap_ab);
 
 // FP4/NVFP4 ops
 bool cutlass_scaled_mm_supports_fp4(int64_t cuda_device_capability);

--- a/csrc/libtorch_stable/quantization/w8a8/cutlass/moe/moe_data.cu
+++ b/csrc/libtorch_stable/quantization/w8a8/cutlass/moe/moe_data.cu
@@ -313,20 +313,20 @@ void get_cutlass_batched_moe_mm_data_caller(
     torch::stable::Tensor& problem_sizes2,
     const torch::stable::Tensor& expert_num_tokens,
     const int64_t num_local_experts, const int64_t padded_m, const int64_t n,
-    const int64_t k) {
+    const int64_t k, const bool swap_ab) {
   const torch::stable::accelerator::DeviceGuard device_guard(
       expert_offsets.get_device_index());
   auto stream = get_current_cuda_stream(expert_offsets.get_device_index());
 
-  if (num_local_experts * padded_m > SWAP_AB_THRESHOLD) {
-    compute_batched_moe_data<false><<<1, num_local_experts, 0, stream>>>(
+  if (swap_ab) {
+    compute_batched_moe_data<true><<<1, num_local_experts, 0, stream>>>(
         static_cast<int32_t*>(expert_offsets.data_ptr()),
         static_cast<int32_t*>(problem_sizes1.data_ptr()),
         static_cast<int32_t*>(problem_sizes2.data_ptr()),
         static_cast<const int32_t*>(expert_num_tokens.data_ptr()), padded_m, n,
         k);
   } else {
-    compute_batched_moe_data<true><<<1, num_local_experts, 0, stream>>>(
+    compute_batched_moe_data<false><<<1, num_local_experts, 0, stream>>>(
         static_cast<int32_t*>(expert_offsets.data_ptr()),
         static_cast<int32_t*>(problem_sizes1.data_ptr()),
         static_cast<int32_t*>(problem_sizes2.data_ptr()),

--- a/csrc/libtorch_stable/quantization/w8a8/cutlass/scaled_mm_entry.cu
+++ b/csrc/libtorch_stable/quantization/w8a8/cutlass/scaled_mm_entry.cu
@@ -109,7 +109,7 @@ void get_cutlass_batched_moe_mm_data_caller(
     torch::stable::Tensor& problem_sizes2,
     const torch::stable::Tensor& expert_num_tokens,
     const int64_t num_local_experts, const int64_t padded_m, const int64_t n,
-    const int64_t k);
+    const int64_t k, const bool swap_ab);
 #endif
 
 void cutlass_scaled_mm_azp_sm75(
@@ -358,16 +358,16 @@ void get_cutlass_batched_moe_mm_data(
     torch::stable::Tensor& problem_sizes2,
     const torch::stable::Tensor& expert_num_tokens,
     const int64_t num_local_experts, const int64_t padded_m, const int64_t n,
-    const int64_t k) {
+    const int64_t k, const bool swap_ab) {
   // This function currently gets compiled only if we have a valid cutlass moe
   // mm to run it for.
   int32_t version_num = get_sm_version_num();
 #if (defined ENABLE_CUTLASS_MOE_SM90 && ENABLE_CUTLASS_MOE_SM90) ||   \
     (defined ENABLE_CUTLASS_MOE_SM100 && ENABLE_CUTLASS_MOE_SM100) || \
     (defined ENABLE_CUTLASS_MOE_SM120 && ENABLE_CUTLASS_MOE_SM120)
-  get_cutlass_batched_moe_mm_data_caller(expert_offsets, problem_sizes1,
-                                         problem_sizes2, expert_num_tokens,
-                                         num_local_experts, padded_m, n, k);
+  get_cutlass_batched_moe_mm_data_caller(
+      expert_offsets, problem_sizes1, problem_sizes2, expert_num_tokens,
+      num_local_experts, padded_m, n, k, swap_ab);
   return;
 #endif
   STD_TORCH_CHECK_NOT_IMPLEMENTED(

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -176,7 +176,7 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
       "                             Tensor! problem_sizes2, "
       "                             Tensor expert_num_tokens, "
       "                             int num_local_experts, int padded_m, "
-      "                             int n, int k) -> ()");
+      "                             int n, int k, bool swap_ab) -> ()");
 
   // Check if cutlass scaled_mm supports block quantization (used by DeepSeekV3)
   ops.def(

--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -315,6 +315,79 @@ def test_moe_splitting_ops_deepep_ht_inductor_partition():
     ]
 
 
+@pytest.mark.parametrize(
+    "mode",
+    [CompilationMode.NONE, CompilationMode.VLLM_COMPILE],
+)
+def test_deepep_ht_piecewise_requires_forced_intranode(monkeypatch, mode):
+    env_name = "VLLM_DEEPEP_HIGH_THROUGHPUT_FORCE_INTRA_NODE"
+    monkeypatch.delenv(env_name, raising=False)
+    disabled = CompilationConfig(
+        mode=mode,
+        cudagraph_mode=CUDAGraphMode.PIECEWISE,
+    )
+    disabled.set_splitting_ops_for_v1(
+        all2all_backend="deepep_high_throughput",
+        data_parallel_size=2,
+    )
+    assert disabled.cudagraph_mode == CUDAGraphMode.NONE
+
+    monkeypatch.setenv(env_name, "1")
+    enabled = CompilationConfig(
+        mode=mode,
+        cudagraph_mode=CUDAGraphMode.PIECEWISE,
+    )
+    enabled.set_splitting_ops_for_v1(
+        all2all_backend="deepep_high_throughput",
+        data_parallel_size=2,
+    )
+    assert enabled.cudagraph_mode == CUDAGraphMode.PIECEWISE
+
+
+def test_deepep_ht_full_cudagraph_stays_disabled(monkeypatch):
+    monkeypatch.setenv(
+        "VLLM_DEEPEP_HIGH_THROUGHPUT_FORCE_INTRA_NODE",
+        "1",
+    )
+    config = CompilationConfig(
+        mode=CompilationMode.NONE,
+        cudagraph_mode=CUDAGraphMode.FULL_AND_PIECEWISE,
+    )
+    config.set_splitting_ops_for_v1(
+        all2all_backend="deepep_high_throughput",
+        data_parallel_size=2,
+    )
+    assert config.cudagraph_mode == CUDAGraphMode.NONE
+
+
+@pytest.mark.parametrize(
+    "pass_config",
+    [
+        PassConfig(fuse_attn_quant=True),
+        PassConfig(enable_sp=True),
+        PassConfig(fuse_gemm_comms=True),
+    ],
+)
+def test_deepep_ht_piecewise_cannot_be_promoted_to_full(
+    monkeypatch,
+    pass_config,
+):
+    monkeypatch.setenv(
+        "VLLM_DEEPEP_HIGH_THROUGHPUT_FORCE_INTRA_NODE",
+        "1",
+    )
+    config = CompilationConfig(
+        mode=CompilationMode.VLLM_COMPILE,
+        cudagraph_mode=CUDAGraphMode.PIECEWISE,
+        pass_config=pass_config,
+    )
+    config.set_splitting_ops_for_v1(
+        all2all_backend="deepep_high_throughput",
+        data_parallel_size=2,
+    )
+    assert config.cudagraph_mode == CUDAGraphMode.NONE
+
+
 def test_should_split():
     import torch
 

--- a/tests/kernels/moe/test_cutlass_moe.py
+++ b/tests/kernels/moe/test_cutlass_moe.py
@@ -2,10 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import copy
 import dataclasses
+import importlib
+import sys
 from math import prod
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -83,13 +85,30 @@ def test_cutlass_moe_supports_gelu_tanh_activation_metadata():
     "experts_cls",
     [CutlassExpertsFp8, CutlassExpertsW4A8Fp8],
 )
-def test_cutlass_permute_scratch_covers_naive_dp_ep_gather(experts_cls):
+@pytest.mark.parametrize(
+    ("parallel_overrides", "expected_dispatchers"),
+    [
+        ({"dp_size": 8, "ep_size": 1, "use_ep": False}, 8),
+        (
+            {
+                "dp_size": 2,
+                "ep_size": 8,
+                "use_ep": True,
+                "all2all_backend": "deepep_high_throughput",
+            },
+            8,
+        ),
+    ],
+)
+def test_cutlass_permute_scratch_covers_standard_dispatch_group(
+    experts_cls,
+    parallel_overrides,
+    expected_dispatchers,
+):
     config = make_dummy_moe_config()
     config.moe_parallel_config = dataclasses.replace(
         config.moe_parallel_config,
-        dp_size=8,
-        ep_size=8,
-        use_ep=True,
+        **parallel_overrides,
     )
     experts = object.__new__(experts_cls)
     object.__setattr__(experts, "moe_config", config)
@@ -112,7 +131,7 @@ def test_cutlass_permute_scratch_covers_naive_dp_ep_gather(experts_cls):
 
     assert result is scratch
     assert scratch_cls.call_args.kwargs["max_num_tokens"] == (
-        config.max_num_tokens * config.dp_size
+        config.max_num_tokens * expected_dispatchers
     )
 
 
@@ -394,6 +413,76 @@ def test_cutlass_w4a8_batched_workspace_and_finalize_contract():
     )
 
 
+@pytest.mark.parametrize(
+    ("experts_cls", "config_factory", "expects_counts"),
+    [
+        (CutlassExpertsW4A8Fp8, make_minimax_w4a8_config, False),
+        (
+            CutlassBatchedExpertsW4A8Fp8,
+            make_minimax_w4a8_deepep_ll_config,
+            True,
+        ),
+    ],
+)
+def test_cutlass_w4a8_only_forwards_expert_counts_for_batched_format(
+    experts_cls,
+    config_factory,
+    expects_counts,
+):
+    config = config_factory()
+    config.device = "cpu"
+    quant_config = make_w4a8_moe_quant_config(
+        w1_scale=torch.empty(16, 1, dtype=torch.float8_e4m3fn),
+        w2_scale=torch.empty(16, 1, dtype=torch.float8_e4m3fn),
+        g1_alphas=torch.empty(16, 6144, dtype=torch.float32),
+        g2_alphas=torch.empty(16, 6144, dtype=torch.float32),
+        gemm1_alpha=1.702,
+        gemm1_beta=1.0,
+        gemm1_clamp_limit=7.0,
+    )
+    batched_kwargs = (
+        {"max_num_tokens": 64, "num_dispatchers": 2} if expects_counts else {}
+    )
+    experts = experts_cls(
+        moe_config=config,
+        quant_config=quant_config,
+        b_strides1=torch.empty(16, dtype=torch.int64),
+        b_strides2=torch.empty(16, dtype=torch.int64),
+        group_size=128,
+        **batched_kwargs,
+    )
+    expert_num_tokens = torch.arange(16, dtype=torch.int32)
+    metadata = mk.ExpertTokensMetadata(
+        expert_num_tokens=expert_num_tokens,
+        expert_num_tokens_cpu=None,
+    )
+
+    with (
+        patch.object(experts, "_get_permute_scratch", return_value=None),
+        patch.object(cutlass_moe, "run_cutlass_moe_w4a8_fp8") as run_moe,
+    ):
+        experts.apply(
+            output=torch.empty(1),
+            hidden_states=torch.empty((1, 6144), dtype=torch.bfloat16),
+            w1=torch.empty(1),
+            w2=torch.empty(1),
+            topk_weights=torch.empty((1, 4)),
+            topk_ids=torch.empty((1, 4), dtype=torch.int64),
+            activation=MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+            global_num_experts=128,
+            expert_map=None,
+            a1q_scale=None,
+            a2_scale=None,
+            workspace13=torch.empty(1),
+            workspace2=torch.empty(1),
+            expert_tokens_meta=metadata,
+            apply_router_weight_on_input=False,
+        )
+
+    forwarded_counts = run_moe.call_args.args[27]
+    assert forwarded_counts is (expert_num_tokens if expects_counts else None)
+
+
 def test_deepep_ll_receiver_defers_batched_w4a8_input_quant():
     pytest.importorskip("deep_ep")
     from vllm.model_executor.layers.fused_moe.prepare_finalize.deepep_ll import (
@@ -427,6 +516,153 @@ def test_deepep_ll_receiver_defers_batched_w4a8_input_quant():
     assert metadata.expert_num_tokens_cpu is None
     assert topk_ids is None
     assert topk_weights is None
+
+
+def test_deepep_ht_receiver_preserves_per_token_quant_contract():
+    module_name = "vllm.model_executor.layers.fused_moe.prepare_finalize.deepep_ht"
+    with patch.dict(sys.modules, {"deep_ep": MagicMock()}):
+        deepep_ht = importlib.import_module(module_name)
+
+    prepare_finalize = object.__new__(deepep_ht.DeepEPHTPrepareAndFinalize)
+    prepare_finalize.rank_expert_offset = 0
+    expert_x = torch.randn((2, 256), dtype=torch.bfloat16)
+    expert_topk_ids = torch.tensor([[0], [1]], dtype=torch.int64)
+    quant_config = make_w4a8_moe_quant_config(
+        w1_scale=torch.empty(1),
+        w2_scale=torch.empty(1),
+        g1_alphas=torch.empty(1),
+        g2_alphas=torch.empty(1),
+    )
+    expected_scale = torch.empty((2, 1), dtype=torch.float32)
+
+    with patch.object(
+        deepep_ht,
+        "moe_kernel_quantize_input",
+        return_value=(expert_x, expected_scale),
+    ) as quantize:
+        result = prepare_finalize._receiver(
+            event=SimpleNamespace(event=None),
+            has_scales=False,
+            token_data=expert_x,
+            expert_topk_ids=expert_topk_ids,
+            num_experts=4,
+            expert_num_tokens_per_expert_list=[1, 1],
+            expert_topk_weights=torch.ones((2, 1)),
+            a1_scale=None,
+            quant_config=quant_config,
+            defer_input_quant=False,
+        )
+
+    assert quantize.call_args.kwargs["per_act_token_quant"] is True
+    assert result[1] is expected_scale
+    sys.modules.pop(module_name, None)
+
+
+@pytest.mark.parametrize(
+    ("is_capturing", "expected_worst_tokens"),
+    [(False, 0), (True, 16)],
+)
+def test_deepep_ht_dispatch_uses_static_capacity_during_capture(
+    is_capturing,
+    expected_worst_tokens,
+):
+    module_name = "vllm.model_executor.layers.fused_moe.prepare_finalize.deepep_ht"
+    with patch.dict(sys.modules, {"deep_ep": MagicMock()}):
+        deepep_ht = importlib.import_module(module_name)
+
+    prepare_finalize = object.__new__(deepep_ht.DeepEPHTPrepareAndFinalize)
+    prepare_finalize.buffer = MagicMock()
+    prepare_finalize.num_dispatchers_ = 8
+    prepare_finalize.rank_expert_offset = 0
+    prepare_finalize.async_prepare = True
+    prepare_finalize.sync_dbo_comm = False
+    prepare_finalize.num_rdma_ranks = 1
+    prepare_finalize.handles = [None, None]
+
+    tokens = torch.empty((2, 16), dtype=torch.bfloat16)
+    topk_ids = torch.zeros((2, 1), dtype=torch.int64)
+    topk_weights = torch.ones((2, 1))
+    prepare_finalize.buffer.get_dispatch_layout.return_value = (
+        MagicMock(),
+        None,
+        MagicMock(),
+        MagicMock(),
+        SimpleNamespace(event=None),
+    )
+    prepare_finalize.buffer.dispatch.return_value = (
+        tokens,
+        topk_ids,
+        topk_weights,
+        [],
+        MagicMock(),
+        SimpleNamespace(event=None),
+    )
+
+    with (
+        patch.object(
+            torch.cuda,
+            "is_current_stream_capturing",
+            return_value=is_capturing,
+        ),
+        patch.object(
+            deepep_ht.DeepEPHTPrepareAndFinalize,
+            "_get_dispatch_config",
+            return_value=None,
+        ),
+    ):
+        receiver = prepare_finalize._do_dispatch(
+            tokens=tokens,
+            token_scales=None,
+            rank_topk_ids=topk_ids,
+            rank_topk_weights=topk_weights,
+            num_experts=8,
+            a1_scale=None,
+            quant_config=MagicMock(is_block_quantized=False),
+            defer_input_quant=True,
+        )
+
+    assert (
+        prepare_finalize.buffer.dispatch.call_args.kwargs["num_worst_tokens"]
+        == expected_worst_tokens
+    )
+    assert receiver()[2] is None
+    sys.modules.pop(module_name, None)
+
+
+def test_deepep_ht_dispatch_rejects_internode_capture():
+    module_name = "vllm.model_executor.layers.fused_moe.prepare_finalize.deepep_ht"
+    with patch.dict(sys.modules, {"deep_ep": MagicMock()}):
+        deepep_ht = importlib.import_module(module_name)
+
+    prepare_finalize = object.__new__(deepep_ht.DeepEPHTPrepareAndFinalize)
+    prepare_finalize.buffer = MagicMock()
+    prepare_finalize.num_dispatchers_ = 8
+    prepare_finalize.num_rdma_ranks = 2
+
+    with (
+        patch.object(
+            torch.cuda,
+            "is_current_stream_capturing",
+            return_value=True,
+        ),
+        pytest.raises(
+            RuntimeError,
+            match="only supports intranode transport",
+        ),
+    ):
+        prepare_finalize._do_dispatch(
+            tokens=torch.empty((2, 16), dtype=torch.bfloat16),
+            token_scales=None,
+            rank_topk_ids=torch.zeros((2, 1), dtype=torch.int64),
+            rank_topk_weights=torch.ones((2, 1)),
+            num_experts=8,
+            a1_scale=None,
+            quant_config=MagicMock(is_block_quantized=False),
+            defer_input_quant=True,
+        )
+
+    prepare_finalize.buffer.dispatch.assert_not_called()
+    sys.modules.pop(module_name, None)
 
 
 MASKED_W4A8_ROUTING_CASES = [

--- a/tests/kernels/moe/test_cutlass_moe.py
+++ b/tests/kernels/moe/test_cutlass_moe.py
@@ -3,6 +3,7 @@
 import copy
 import dataclasses
 from math import prod
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
@@ -170,6 +171,92 @@ def make_minimax_w4a8_deepep_ll_config():
         all2all_backend="deepep_low_latency",
     )
     return config
+
+
+@pytest.mark.parametrize(
+    ("total_num_tokens", "expected"),
+    [
+        (0, "Kernel_128x16_1x1x1_Coop"),
+        (8, "Kernel_128x16_1x1x1_Coop"),
+        (128, "Kernel_256x16_1x1x1_Coop"),
+        (512, "Kernel_256x16_1x1x1_Coop"),
+        (1024, "Kernel_256x32_1x1x1_Coop"),
+        (2048, "Kernel_256x64_1x1x1_Coop"),
+        (4096, "Kernel_256x128_2x1x1_Coop"),
+        (8192, "Kernel_128x256_2x1x1_Coop"),
+    ],
+)
+def test_w4a8_batched_schedule_uses_expected_routed_rows(
+    total_num_tokens: int,
+    expected: str,
+):
+    assert (
+        cutlass_moe._select_w4a8_batched_schedule(
+            total_num_tokens=total_num_tokens,
+            topk=4,
+            global_num_experts=128,
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("total_num_tokens", "expected"),
+    [
+        (0, 16),
+        (512, 16),
+        (1024, 64),
+        (2048, 128),
+        (4096, 256),
+        (8192, 256),
+    ],
+)
+def test_w4a8_compact_programs_scale_with_expected_m(
+    total_num_tokens: int,
+    expected: int,
+):
+    assert (
+        cutlass_moe._select_w4a8_compact_programs(
+            total_num_tokens=total_num_tokens,
+            topk=4,
+            global_num_experts=128,
+        )
+        == expected
+    )
+
+
+def test_w4a8_batched_schedule_uses_dp_group_token_total():
+    dp_metadata = SimpleNamespace(
+        num_tokens_across_dp_cpu=torch.tensor([1, 3, 7, 9], dtype=torch.int32)
+    )
+    context = SimpleNamespace(dp_metadata=dp_metadata)
+
+    with (
+        patch.object(cutlass_moe, "is_forward_context_available", return_value=True),
+        patch.object(cutlass_moe, "get_forward_context", return_value=context),
+    ):
+        total_num_tokens = cutlass_moe._w4a8_batched_total_num_tokens(
+            local_num_tokens=1,
+            global_num_experts=128,
+            num_local_experts=32,
+        )
+
+    assert total_num_tokens == 20
+
+
+def test_w4a8_batched_schedule_fallback_uses_dispatcher_count():
+    with patch.object(
+        cutlass_moe,
+        "is_forward_context_available",
+        return_value=False,
+    ):
+        total_num_tokens = cutlass_moe._w4a8_batched_total_num_tokens(
+            local_num_tokens=64,
+            global_num_experts=128,
+            num_local_experts=16,
+        )
+
+    assert total_num_tokens == 512
 
 
 def make_minimax_w4a8_nixl_ep_config():
@@ -347,6 +434,8 @@ MASKED_W4A8_ROUTING_CASES = [
     pytest.param([8, 0, 0, 0], id="hot"),
     pytest.param([8, 8, 8, 8], id="uniform"),
     pytest.param([1, 8, 0, 3], id="skewed"),
+    pytest.param([16, 17, 32, 65], id="persistent-loop-boundaries"),
+    pytest.param([0, 64, 1, 17], id="persistent-loop-skewed"),
 ]
 
 
@@ -355,7 +444,7 @@ MASKED_W4A8_ROUTING_CASES = [
 def test_cutlass_w4a8_masked_per_token_quant_matches_full_flatten(counts):
     set_random_seed(7)
     num_experts = len(counts)
-    padded_m = 8
+    padded_m = max(8, max(counts))
     hidden = 256
     src = torch.randn(
         (num_experts, padded_m, hidden),
@@ -384,17 +473,21 @@ def test_cutlass_w4a8_masked_per_token_quant_matches_full_flatten(counts):
                 src[expert, :count],
                 use_per_token_if_dynamic=True,
             )
-            torch.testing.assert_close(
-                quant[expert, :count].float(),
-                ref_quant.float(),
-                rtol=0,
-                atol=0,
-            )
+            quantized = quant[expert, :count].float()
+            ref_quantized = ref_quant.float()
+            mismatch_rate = (quantized != ref_quantized).float().mean()
+            assert mismatch_rate <= 2.0e-3
             torch.testing.assert_close(
                 scales[expert, :count],
                 ref_scales,
                 rtol=2e-7,
                 atol=1e-9,
+            )
+            torch.testing.assert_close(
+                quantized * scales[expert, :count],
+                ref_quantized * ref_scales,
+                rtol=0,
+                atol=3e-1,
             )
         torch.testing.assert_close(
             quant[expert, count:].float(),
@@ -411,7 +504,7 @@ def test_cutlass_w4a8_masked_per_token_quant_matches_full_flatten(counts):
 def test_cutlass_w4a8_masked_minimax_activation_quant_matches_reference(counts):
     set_random_seed(11)
     num_experts = len(counts)
-    padded_m = 8
+    padded_m = max(8, max(counts))
     hidden = 256
     src = torch.randn(
         (num_experts, padded_m, hidden * 2),
@@ -487,9 +580,9 @@ def test_cutlass_w4a8_masked_minimax_activation_quant_matches_reference(counts):
 def test_cutlass_w4a8_masked_adapter_cuda_graph_replay():
     set_random_seed(13)
     num_experts = 4
-    padded_m = 8
+    padded_m = 65
     hidden = 256
-    counts = [0, 8, 1, 5]
+    counts = [0, 16, 17, 32]
     expert_num_tokens = torch.tensor(counts, dtype=torch.int32, device="cuda")
     a1 = torch.randn(
         (num_experts, padded_m, hidden),
@@ -546,6 +639,10 @@ def test_cutlass_w4a8_masked_adapter_cuda_graph_replay():
 
     a1.copy_(torch.randn_like(a1))
     mm1.copy_(torch.randn_like(mm1))
+    replay_counts = [65, 1, 32, 17]
+    expert_num_tokens.copy_(
+        torch.tensor(replay_counts, dtype=torch.int32, device="cuda")
+    )
     graph.replay()
 
     eager_a1_quant = torch.empty_like(a1_quant)
@@ -568,7 +665,7 @@ def test_cutlass_w4a8_masked_adapter_cuda_graph_replay():
         clamp_limit=7.0,
     )
 
-    for expert, count in enumerate(counts):
+    for expert, count in enumerate(replay_counts):
         if not count:
             continue
         torch.testing.assert_close(

--- a/tests/kernels/moe/test_cutlass_moe.py
+++ b/tests/kernels/moe/test_cutlass_moe.py
@@ -25,6 +25,8 @@ from vllm.model_executor.layers.fused_moe.config import (
     fp8_w8a8_moe_quant_config,
 )
 from vllm.model_executor.layers.fused_moe.experts.cutlass_moe import (
+    CutlassBatchedExpertsFp8,
+    CutlassBatchedExpertsW4A8Fp8,
     CutlassExpertsFp4,
     CutlassExpertsFp8,
     CutlassExpertsW4A8Fp8,
@@ -34,6 +36,10 @@ from vllm.model_executor.layers.fused_moe.oracle.w4a8 import (
     W4A8MoeBackend,
     make_w4a8_moe_quant_config,
     select_w4a8_moe_backend,
+)
+from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
+    TopKWeightAndReduceDelegate,
+    TopKWeightAndReduceNoOP,
 )
 from vllm.model_executor.layers.fused_moe.utils import moe_kernel_quantize_input
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
@@ -72,6 +78,68 @@ def test_cutlass_moe_supports_gelu_tanh_activation_metadata():
     assert CutlassExpertsFp4._supports_activation(MoEActivation.GELU_TANH_NO_MUL)
 
 
+@pytest.mark.parametrize(
+    "experts_cls",
+    [CutlassExpertsFp8, CutlassExpertsW4A8Fp8],
+)
+def test_cutlass_permute_scratch_covers_naive_dp_ep_gather(experts_cls):
+    config = make_dummy_moe_config()
+    config.moe_parallel_config = dataclasses.replace(
+        config.moe_parallel_config,
+        dp_size=8,
+        ep_size=8,
+        use_ep=True,
+    )
+    experts = object.__new__(experts_cls)
+    object.__setattr__(experts, "moe_config", config)
+    object.__setattr__(experts, "_permute_scratch", None)
+    scratch = object()
+
+    with (
+        patch.object(
+            cutlass_moe,
+            "moe_permute_unpermute_supported",
+            return_value=True,
+        ),
+        patch.object(
+            cutlass_moe,
+            "MoEPermuteScratch",
+            return_value=scratch,
+        ) as scratch_cls,
+    ):
+        result = experts._get_permute_scratch()
+
+    assert result is scratch
+    assert scratch_cls.call_args.kwargs["max_num_tokens"] == (
+        config.max_num_tokens * config.dp_size
+    )
+
+
+def test_cutlass_batched_permute_scratch_keeps_per_rank_capacity():
+    config = make_dummy_moe_config()
+    config.moe_parallel_config = dataclasses.replace(
+        config.moe_parallel_config,
+        dp_size=8,
+        ep_size=8,
+        use_ep=True,
+    )
+    experts = object.__new__(CutlassBatchedExpertsFp8)
+    object.__setattr__(experts, "moe_config", config)
+    object.__setattr__(experts, "_permute_scratch", None)
+
+    with (
+        patch.object(
+            cutlass_moe,
+            "moe_permute_unpermute_supported",
+            return_value=True,
+        ),
+        patch.object(cutlass_moe, "MoEPermuteScratch") as scratch_cls,
+    ):
+        experts._get_permute_scratch()
+
+    assert scratch_cls.call_args.kwargs["max_num_tokens"] == config.max_num_tokens
+
+
 def make_minimax_w4a8_config(intermediate_size: int = 3072):
     config = make_dummy_moe_config(
         num_experts=128,
@@ -92,6 +160,30 @@ def make_minimax_w4a8_config(intermediate_size: int = 3072):
     return config
 
 
+def make_minimax_w4a8_deepep_ll_config():
+    config = make_minimax_w4a8_config()
+    config.moe_parallel_config = dataclasses.replace(
+        config.moe_parallel_config,
+        dp_size=8,
+        ep_size=8,
+        use_ep=True,
+        all2all_backend="deepep_low_latency",
+    )
+    return config
+
+
+def make_minimax_w4a8_nixl_ep_config():
+    config = make_minimax_w4a8_config()
+    config.moe_parallel_config = dataclasses.replace(
+        config.moe_parallel_config,
+        dp_size=8,
+        ep_size=8,
+        use_ep=True,
+        all2all_backend="nixl_ep",
+    )
+    return config
+
+
 def get_w4a8_support(config):
     with patch.object(
         CutlassExpertsW4A8Fp8,
@@ -104,6 +196,21 @@ def get_w4a8_support(config):
             kInt4Static,
             kFp8DynamicTokenSym,
             mk.FusedMoEActivationFormat.Standard,
+        )
+
+
+def get_batched_w4a8_support(config):
+    with patch.object(
+        CutlassExpertsW4A8Fp8,
+        "_supports_current_device",
+        return_value=True,
+    ):
+        return CutlassBatchedExpertsW4A8Fp8.is_supported_config(
+            CutlassBatchedExpertsW4A8Fp8,
+            config,
+            kInt4Static,
+            kFp8DynamicTokenSym,
+            mk.FusedMoEActivationFormat.BatchedExperts,
         )
 
 
@@ -121,6 +228,373 @@ def test_cutlass_w4a8_supports_minimax_uninterleaved_swiglu_with_ep():
         backend, experts_cls = select_w4a8_moe_backend(config)
     assert backend is W4A8MoeBackend.CUTLASS
     assert experts_cls is CutlassExpertsW4A8Fp8
+
+
+def test_cutlass_w4a8_selects_batched_experts_for_deepep_ll():
+    config = make_minimax_w4a8_deepep_ll_config()
+    supported, reason = get_batched_w4a8_support(config)
+
+    assert supported
+    assert reason is None
+    with patch.object(
+        CutlassExpertsW4A8Fp8,
+        "_supports_current_device",
+        return_value=True,
+    ):
+        backend, experts_cls = select_w4a8_moe_backend(config)
+    assert backend is W4A8MoeBackend.CUTLASS
+    assert experts_cls is CutlassBatchedExpertsW4A8Fp8
+
+
+def test_cutlass_w4a8_rejects_batched_non_deepep_ll():
+    supported, reason = get_batched_w4a8_support(make_minimax_w4a8_nixl_ep_config())
+
+    assert not supported
+    assert reason is not None
+    assert "parallel config" in reason
+
+
+def test_cutlass_w4a8_batched_workspace_and_finalize_contract():
+    config = make_minimax_w4a8_deepep_ll_config()
+    config.device = "cpu"
+    quant_config = make_w4a8_moe_quant_config(
+        w1_scale=torch.empty(16, 1, dtype=torch.float8_e4m3fn),
+        w2_scale=torch.empty(16, 1, dtype=torch.float8_e4m3fn),
+        g1_alphas=torch.empty(16, 6144, dtype=torch.float32),
+        g2_alphas=torch.empty(16, 6144, dtype=torch.float32),
+        gemm1_alpha=1.702,
+        gemm1_beta=1.0,
+        gemm1_clamp_limit=7.0,
+    )
+    experts = CutlassBatchedExpertsW4A8Fp8(
+        moe_config=config,
+        quant_config=quant_config,
+        b_strides1=torch.empty(16, dtype=torch.int64),
+        b_strides2=torch.empty(16, dtype=torch.int64),
+        group_size=128,
+        max_num_tokens=64,
+        num_dispatchers=2,
+    )
+
+    assert isinstance(
+        experts.finalize_weight_and_reduce_impl(), TopKWeightAndReduceDelegate
+    )
+    assert experts.expects_unquantized_inputs
+    assert experts._get_permute_scratch() is None
+    assert isinstance(
+        CutlassExpertsW4A8Fp8(
+            moe_config=config,
+            quant_config=quant_config,
+            b_strides1=torch.empty(16, dtype=torch.int64),
+            b_strides2=torch.empty(16, dtype=torch.int64),
+            group_size=128,
+        ).finalize_weight_and_reduce_impl(),
+        TopKWeightAndReduceNoOP,
+    )
+    assert experts.workspace_shapes(
+        M=64,
+        N=3072 * 2,
+        K=6144,
+        topk=4,
+        global_num_experts=128,
+        local_num_experts=16,
+        expert_tokens_meta=None,
+        activation=MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+    ) == (
+        (16, 128, 6144),
+        (16, 128, 6144),
+        (16, 128, 6144),
+    )
+
+
+def test_deepep_ll_receiver_defers_batched_w4a8_input_quant():
+    pytest.importorskip("deep_ep")
+    from vllm.model_executor.layers.fused_moe.prepare_finalize.deepep_ll import (
+        DeepEPLLPrepareAndFinalize,
+    )
+
+    prepare_finalize = object.__new__(DeepEPLLPrepareAndFinalize)
+    prepare_finalize.use_fp8_dispatch = False
+    expert_x = torch.randn((4, 8, 256), dtype=torch.bfloat16)
+    expert_num_tokens = torch.tensor([0, 8, 1, 3], dtype=torch.int32)
+    quant_config = make_w4a8_moe_quant_config(
+        w1_scale=torch.empty(1),
+        w2_scale=torch.empty(1),
+        g1_alphas=torch.empty(1),
+        g2_alphas=torch.empty(1),
+    )
+
+    result = prepare_finalize._receiver(
+        expert_x,
+        expert_num_tokens,
+        a1_scale=None,
+        a1_dtype=torch.bfloat16,
+        quant_config=quant_config,
+        defer_input_quant=True,
+    )
+
+    received_x, received_scale, metadata, topk_ids, topk_weights = result
+    assert received_x is expert_x
+    assert received_scale is None
+    assert metadata.expert_num_tokens is expert_num_tokens
+    assert metadata.expert_num_tokens_cpu is None
+    assert topk_ids is None
+    assert topk_weights is None
+
+
+MASKED_W4A8_ROUTING_CASES = [
+    pytest.param([0, 0, 0, 0], id="empty"),
+    pytest.param([8, 0, 0, 0], id="hot"),
+    pytest.param([8, 8, 8, 8], id="uniform"),
+    pytest.param([1, 8, 0, 3], id="skewed"),
+]
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="requires CUDA")
+@pytest.mark.parametrize("counts", MASKED_W4A8_ROUTING_CASES)
+def test_cutlass_w4a8_masked_per_token_quant_matches_full_flatten(counts):
+    set_random_seed(7)
+    num_experts = len(counts)
+    padded_m = 8
+    hidden = 256
+    src = torch.randn(
+        (num_experts, padded_m, hidden),
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    quant = torch.full_like(src, 1.0, dtype=torch.float8_e4m3fn)
+    scales = torch.full(
+        (num_experts, padded_m, 1),
+        -1.0,
+        dtype=torch.float32,
+        device="cuda",
+    )
+    expert_num_tokens = torch.tensor(counts, dtype=torch.int32, device="cuda")
+
+    cutlass_moe._masked_per_token_fp8_quant(
+        src,
+        quant,
+        scales,
+        expert_num_tokens,
+    )
+
+    for expert, count in enumerate(counts):
+        if count:
+            ref_quant, ref_scales = ops.scaled_fp8_quant(
+                src[expert, :count],
+                use_per_token_if_dynamic=True,
+            )
+            torch.testing.assert_close(
+                quant[expert, :count].float(),
+                ref_quant.float(),
+                rtol=0,
+                atol=0,
+            )
+            torch.testing.assert_close(
+                scales[expert, :count],
+                ref_scales,
+                rtol=2e-7,
+                atol=1e-9,
+            )
+        torch.testing.assert_close(
+            quant[expert, count:].float(),
+            torch.ones_like(quant[expert, count:].float()),
+        )
+        torch.testing.assert_close(
+            scales[expert, count:],
+            -torch.ones_like(scales[expert, count:]),
+        )
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="requires CUDA")
+@pytest.mark.parametrize("counts", MASKED_W4A8_ROUTING_CASES)
+def test_cutlass_w4a8_masked_minimax_activation_quant_matches_reference(counts):
+    set_random_seed(11)
+    num_experts = len(counts)
+    padded_m = 8
+    hidden = 256
+    src = torch.randn(
+        (num_experts, padded_m, hidden * 2),
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    quant = torch.full(
+        (num_experts, padded_m, hidden),
+        1.0,
+        dtype=torch.float8_e4m3fn,
+        device="cuda",
+    )
+    scales = torch.full(
+        (num_experts, padded_m, 1),
+        -1.0,
+        dtype=torch.float32,
+        device="cuda",
+    )
+    expert_num_tokens = torch.tensor(counts, dtype=torch.int32, device="cuda")
+
+    cutlass_moe._masked_swigluoai_quant(
+        src,
+        quant,
+        scales,
+        expert_num_tokens,
+        alpha=1.702,
+        beta=1.0,
+        clamp_limit=7.0,
+    )
+
+    for expert, count in enumerate(counts):
+        if count:
+            ref_activation = torch.empty(
+                (count, hidden),
+                dtype=torch.bfloat16,
+                device="cuda",
+            )
+            cutlass_moe._apply_w4a8_moe_activation(
+                MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+                ref_activation,
+                src[expert, :count],
+                gemm1_alpha=1.702,
+                gemm1_beta=1.0,
+                gemm1_clamp_limit=7.0,
+            )
+            ref_quant, ref_scales = ops.scaled_fp8_quant(
+                ref_activation,
+                use_per_token_if_dynamic=True,
+            )
+            torch.testing.assert_close(
+                scales[expert, :count],
+                ref_scales,
+                rtol=5e-3,
+                atol=1e-6,
+            )
+            torch.testing.assert_close(
+                quant[expert, :count].float() * scales[expert, :count],
+                ref_quant.float() * ref_scales,
+                rtol=5e-3,
+                atol=3e-2,
+            )
+        torch.testing.assert_close(
+            quant[expert, count:].float(),
+            torch.ones_like(quant[expert, count:].float()),
+        )
+        torch.testing.assert_close(
+            scales[expert, count:],
+            -torch.ones_like(scales[expert, count:]),
+        )
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="requires CUDA")
+def test_cutlass_w4a8_masked_adapter_cuda_graph_replay():
+    set_random_seed(13)
+    num_experts = 4
+    padded_m = 8
+    hidden = 256
+    counts = [0, 8, 1, 5]
+    expert_num_tokens = torch.tensor(counts, dtype=torch.int32, device="cuda")
+    a1 = torch.randn(
+        (num_experts, padded_m, hidden),
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    mm1 = torch.randn(
+        (num_experts, padded_m, hidden * 2),
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    a1_quant = torch.empty_like(a1, dtype=torch.float8_e4m3fn)
+    a1_scales = torch.empty(
+        (num_experts, padded_m, 1),
+        dtype=torch.float32,
+        device="cuda",
+    )
+    a2_quant = torch.empty_like(a1_quant)
+    a2_scales = torch.empty_like(a1_scales)
+
+    cutlass_moe._masked_per_token_fp8_quant(
+        a1,
+        a1_quant,
+        a1_scales,
+        expert_num_tokens,
+    )
+    cutlass_moe._masked_swigluoai_quant(
+        mm1,
+        a2_quant,
+        a2_scales,
+        expert_num_tokens,
+        alpha=1.702,
+        beta=1.0,
+        clamp_limit=7.0,
+    )
+    graph = torch.cuda.CUDAGraph()
+    stream = torch.cuda.Stream()
+    with torch.cuda.graph(graph, stream=stream):
+        cutlass_moe._masked_per_token_fp8_quant(
+            a1,
+            a1_quant,
+            a1_scales,
+            expert_num_tokens,
+        )
+        cutlass_moe._masked_swigluoai_quant(
+            mm1,
+            a2_quant,
+            a2_scales,
+            expert_num_tokens,
+            alpha=1.702,
+            beta=1.0,
+            clamp_limit=7.0,
+        )
+
+    a1.copy_(torch.randn_like(a1))
+    mm1.copy_(torch.randn_like(mm1))
+    graph.replay()
+
+    eager_a1_quant = torch.empty_like(a1_quant)
+    eager_a1_scales = torch.empty_like(a1_scales)
+    eager_a2_quant = torch.empty_like(a2_quant)
+    eager_a2_scales = torch.empty_like(a2_scales)
+    cutlass_moe._masked_per_token_fp8_quant(
+        a1,
+        eager_a1_quant,
+        eager_a1_scales,
+        expert_num_tokens,
+    )
+    cutlass_moe._masked_swigluoai_quant(
+        mm1,
+        eager_a2_quant,
+        eager_a2_scales,
+        expert_num_tokens,
+        alpha=1.702,
+        beta=1.0,
+        clamp_limit=7.0,
+    )
+
+    for expert, count in enumerate(counts):
+        if not count:
+            continue
+        torch.testing.assert_close(
+            a1_quant[expert, :count].float(),
+            eager_a1_quant[expert, :count].float(),
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            a1_scales[expert, :count],
+            eager_a1_scales[expert, :count],
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            a2_quant[expert, :count].float(),
+            eager_a2_quant[expert, :count].float(),
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            a2_scales[expert, :count],
+            eager_a2_scales[expert, :count],
+            rtol=0,
+            atol=0,
+        )
 
 
 @pytest.mark.parametrize("missing", ["swiglu_alpha", "swiglu_beta", "swiglu_limit"])

--- a/tests/kernels/quantization/test_cutlass_w4a8_moe.py
+++ b/tests/kernels/quantization/test_cutlass_w4a8_moe.py
@@ -11,6 +11,13 @@ import pytest
 import torch
 
 from vllm import _custom_ops as ops
+from vllm.model_executor.layers.fused_moe.activation import (
+    MoEActivation,
+    apply_moe_activation,
+)
+from vllm.model_executor.layers.fused_moe.experts.cutlass_moe import (
+    run_cutlass_moe_w4a8_fp8,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     pack_rows,
     quantize_weights,
@@ -341,3 +348,221 @@ def test_cutlass_w4a8_moe_mm_cuda_graph():
     g.replay()
 
     torch.testing.assert_close(out_static, out_ref, rtol=1e-2, atol=1e-2)
+
+
+def make_batched_pipeline_weight(
+    num_experts: int,
+    out_features: int,
+    in_features: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    w_qs = []
+    w_ss = []
+    for _ in range(num_experts):
+        weight = to_fp8(torch.randn((in_features, out_features), device="cuda"))
+        _, w_q, w_s, _ = cutlass_quantize(
+            torch.float8_e4m3fn,
+            weight.to(torch.float16),
+            scalar_types.int4,
+            torch.float8_e4m3fn,
+            GROUP_SIZE,
+        )
+        w_qs.append(w_q)
+        w_ss.append(w_s)
+
+    weight_q, weight_scale, b_strides = cutlass_preprocess(w_qs, w_ss)
+    channel_scale = (
+        torch.rand(
+            (num_experts, out_features, 1),
+            dtype=torch.float32,
+            device="cuda",
+        )
+        .mul_(0.05)
+        .add_(0.001)
+    )
+    return weight_q, weight_scale, channel_scale, b_strides
+
+
+@pytest.mark.skipif(
+    not IS_SUPPORTED_BY_GPU,
+    reason="W4A8 Grouped GEMM is not supported on this GPU type.",
+)
+def test_cutlass_w4a8_batched_masked_pipeline_cuda_graph():
+    set_random_seed(42)
+    num_experts = 4
+    padded_m = 8
+    hidden = 512
+    intermediate = 256
+    counts = [0, 8, 1, 5]
+    device = torch.device("cuda")
+
+    w1, w1_scale, w1_chan_scale, b_strides1 = make_batched_pipeline_weight(
+        num_experts,
+        intermediate * 2,
+        hidden,
+    )
+    w2, w2_scale, w2_chan_scale, b_strides2 = make_batched_pipeline_weight(
+        num_experts,
+        hidden,
+        intermediate,
+    )
+    expert_num_tokens = torch.tensor(counts, dtype=torch.int32, device=device)
+    expert_offsets = (
+        torch.arange(num_experts, dtype=torch.int64, device=device) * padded_m
+    )
+    problem_sizes1 = torch.tensor(
+        [[intermediate * 2, count, hidden] for count in counts],
+        dtype=torch.int32,
+        device=device,
+    )
+    problem_sizes2 = torch.tensor(
+        [[hidden, count, intermediate] for count in counts],
+        dtype=torch.int32,
+        device=device,
+    )
+    a_strides1 = torch.full((num_experts,), hidden, dtype=torch.int64, device=device)
+    a_strides2 = torch.full(
+        (num_experts,), intermediate, dtype=torch.int64, device=device
+    )
+    c_strides1 = torch.full(
+        (num_experts,), intermediate * 2, dtype=torch.int64, device=device
+    )
+    c_strides2 = a_strides1
+    s_strides1 = torch.zeros((num_experts, 2), dtype=torch.int64, device=device)
+    s_strides1[:, 0] = intermediate * 2
+    s_strides2 = torch.zeros_like(s_strides1)
+    s_strides2[:, 0] = hidden
+    topk_ids = torch.zeros((1, 1), dtype=torch.int64, device=device)
+
+    common_workspace = torch.empty(
+        (num_experts, padded_m, hidden),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    workspace2 = torch.empty_like(common_workspace)
+    hidden_states = torch.randn_like(common_workspace)
+
+    def run_masked() -> torch.Tensor:
+        run_cutlass_moe_w4a8_fp8(
+            output=common_workspace,
+            hidden_states=hidden_states,
+            w1=w1,
+            w2=w2,
+            topk_ids=topk_ids,
+            activation=MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+            gemm1_alpha=1.702,
+            gemm1_beta=1.0,
+            gemm1_clamp_limit=7.0,
+            global_num_experts=num_experts,
+            expert_map=None,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+            a1q_scale=None,
+            a2_scale=None,
+            w1_chan_scale=w1_chan_scale,
+            w2_chan_scale=w2_chan_scale,
+            a_strides1=a_strides1,
+            a_strides2=a_strides2,
+            b_strides1=b_strides1,
+            b_strides2=b_strides2,
+            c_strides1=c_strides1,
+            c_strides2=c_strides2,
+            s_strides1=s_strides1,
+            s_strides2=s_strides2,
+            workspace13=common_workspace,
+            workspace2=workspace2,
+            expert_num_tokens=expert_num_tokens,
+            out_dtype=torch.bfloat16,
+            per_act_token=True,
+            per_out_ch=True,
+            use_batched_format=True,
+            topk_weights=None,
+            group_size=GROUP_SIZE,
+            permute_scratch=None,
+        )
+        return common_workspace
+
+    def run_full_flatten_reference() -> torch.Tensor:
+        a1q, a1q_scale = ops.scaled_fp8_quant(
+            hidden_states.view(-1, hidden),
+            use_per_token_if_dynamic=True,
+        )
+        mm1 = torch.zeros(
+            (num_experts * padded_m, intermediate * 2),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        ops.cutlass_w4a8_moe_mm(
+            mm1,
+            a1q,
+            w1,
+            a1q_scale,
+            w1_chan_scale,
+            w1_scale,
+            GROUP_SIZE,
+            expert_offsets,
+            problem_sizes1,
+            a_strides1,
+            b_strides1,
+            c_strides1,
+            s_strides1,
+        )
+        activation = torch.empty(
+            (num_experts * padded_m, intermediate),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        apply_moe_activation(
+            MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+            activation,
+            mm1,
+            clamp_limit=7.0,
+            alpha=1.702,
+            beta=1.0,
+        )
+        a2q, a2q_scale = ops.scaled_fp8_quant(
+            activation,
+            use_per_token_if_dynamic=True,
+        )
+        output = torch.empty_like(common_workspace)
+        ops.cutlass_w4a8_moe_mm(
+            output.view(-1, hidden),
+            a2q,
+            w2,
+            a2q_scale,
+            w2_chan_scale,
+            w2_scale,
+            GROUP_SIZE,
+            expert_offsets,
+            problem_sizes2,
+            a_strides2,
+            b_strides2,
+            c_strides2,
+            s_strides2,
+        )
+        return output
+
+    run_masked()
+    reference = run_full_flatten_reference()
+    for expert, count in enumerate(counts):
+        torch.testing.assert_close(
+            common_workspace[expert, :count],
+            reference[expert, :count],
+            rtol=1e-2,
+            atol=3e-2,
+        )
+
+    graph = torch.cuda.CUDAGraph()
+    stream = torch.cuda.Stream()
+    with torch.cuda.graph(graph, stream=stream):
+        captured_output = run_masked()
+
+    hidden_states.copy_(torch.randn_like(hidden_states))
+    graph.replay()
+    reference = run_full_flatten_reference()
+    for expert, count in enumerate(counts):
+        torch.testing.assert_close(
+            captured_output[expert, :count],
+            reference[expert, :count],
+            rtol=1e-2,
+            atol=3e-2,
+        )

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1986,6 +1986,8 @@ def test_kv_connector_hybrid_dense_hit_requires_remote_prefill():
 
     assert queried_local_hits == [0]
     assert scheduler_output.num_scheduled_tokens[local_req.request_id] == 1280
+
+
 @pytest.mark.parametrize("is_async", [False, True])
 def test_kv_connector_basic(is_async: bool):
     """
@@ -4789,6 +4791,33 @@ def test_abort_request_finished_recving():
     # verify request is deleted
     assert request.request_id not in scheduler.requests
     assert not scheduler.finished_recving_kv_req_ids
+
+
+@pytest.mark.parametrize("completion_kind", ["recv", "send"])
+def test_late_kv_completion_after_abort_is_ignored(completion_kind: str):
+    scheduler = create_scheduler(use_kv_connector=True)
+    request = create_requests(num_requests=1)[0]
+    scheduler.add_request(request)
+
+    scheduler.finish_requests(request.request_id, RequestStatus.FINISHED_ABORTED)
+    assert request.request_id not in scheduler.requests
+
+    completion = {request.request_id}
+    kv_connector_output = (
+        KVConnectorOutput(finished_recving=completion)
+        if completion_kind == "recv"
+        else KVConnectorOutput(finished_sending=completion)
+    )
+    scheduler_output = scheduler.schedule()
+    model_runner_output = ModelRunnerOutput(
+        req_ids=[],
+        req_id_to_index={},
+        kv_connector_output=kv_connector_output,
+    )
+
+    scheduler.update_from_output(scheduler_output, model_runner_output)
+
+    assert request.request_id not in scheduler.requests
 
 
 def test_delayed_kv_connector_free_keeps_scheduler_active():

--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -1668,6 +1668,39 @@ async def test_receive_kv_selects_remote_pp_workers(
     assert pull_metas["d-req-1"].pull_tasks_count == 0
 
 
+def test_receive_kv_rejects_consumer_pp_fanout():
+    """A producer PP stage cannot serve multiple consumer PP stages safely."""
+
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.shutdown = MagicMock()
+    worker.pp_size = 2
+    worker.pp_rank = 0
+    worker.pcp_size = 1
+    worker.pcp_rank = 0
+    worker.transfer_topo = SimpleNamespace(handshake_target_ranks=lambda _size: [0])
+    worker._remote_agents = {"p-engine": {0: {0: {0: "tcp://producer-pp0:1234"}}}}
+    worker._tp_size = {"p-engine": 1}
+    worker._pcp_size = {"p-engine": 1}
+    worker._invalid_block_ids_lock = threading.Lock()
+    worker._invalid_block_ids = set()
+    worker.finished_recving_reqs = set()
+    worker.receive_kv_from_single_worker = MagicMock()
+    pull_meta = PullReqMeta(
+        d_req_id="d-req-pp-fanout",
+        transfer_id="xfer-pp-fanout",
+        local_block_ids=[[100, 101]],
+        remote_engine_id="p-engine",
+        remote_bootstrap_addr="http://bootstrap:33333",
+    )
+
+    worker.receive_kv("p-engine", {pull_meta.d_req_id: pull_meta})
+
+    worker.receive_kv_from_single_worker.assert_not_called()
+    assert pull_meta.pull_failed is True
+    assert worker.finished_recving_reqs == {pull_meta.d_req_id}
+    assert worker.get_block_ids_with_load_errors() == {100, 101}
+
+
 @pytest.mark.asyncio
 async def test_receive_kv_waits_for_every_remote_pp_pcp_worker():
     """A PCP1 decoder must pull every PP/PCP shard from a PCP2 producer."""

--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -27,7 +27,9 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector im
     SendBlockMeta,
     TransferRegion,
     _align_transfer_regions,
+    _compute_sender_transfer_plan,
     _pair_pcp_block_ids,
+    _validate_asymmetric_region_lengths,
     get_mooncake_bootstrap_addr,
     should_launch_bootstrap_server,
 )
@@ -47,6 +49,272 @@ from vllm.v1.request import RequestStatus
 from .utils import create_request, create_scheduler, create_vllm_config
 
 pytestmark = pytest.mark.skip_global_cleanup
+
+
+@pytest.mark.parametrize(
+    ("local_tp_rank", "expected"),
+    [
+        (0, (True, 0, 0, 32768)),
+        (1, (False, 0, 0, 0)),
+        (2, (True, 0, 32768, 32768)),
+        (3, (False, 0, 0, 0)),
+        (4, (True, 0, 65536, 32768)),
+        (5, (False, 0, 0, 0)),
+        (6, (True, 0, 98304, 32768)),
+        (7, (False, 0, 0, 0)),
+    ],
+)
+def test_sender_plan_gqa_replicas_tp8_to_tp1(local_tp_rank, expected):
+    assert (
+        _compute_sender_transfer_plan(
+            local_tp_rank=local_tp_rank,
+            local_tp_size=8,
+            remote_tp_rank=0,
+            remote_tp_size=1,
+            local_kv_block_len=32768,
+            remote_kv_block_len=131072,
+            producer_cache_replicated=True,
+            transfer_unique_kv_heads=True,
+            total_num_kv_heads=4,
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("remote_tp_rank", "expected_src_offset"),
+    [
+        (0, 0),
+        (1, 0),
+        (2, 32768),
+        (3, 32768),
+        (4, 65536),
+        (5, 65536),
+        (6, 98304),
+        (7, 98304),
+    ],
+)
+def test_sender_plan_gqa_replicas_tp1_to_tp8(
+    remote_tp_rank,
+    expected_src_offset,
+):
+    assert _compute_sender_transfer_plan(
+        local_tp_rank=0,
+        local_tp_size=1,
+        remote_tp_rank=remote_tp_rank,
+        remote_tp_size=8,
+        local_kv_block_len=131072,
+        remote_kv_block_len=32768,
+        producer_cache_replicated=False,
+        transfer_unique_kv_heads=True,
+        total_num_kv_heads=4,
+    ) == (True, expected_src_offset, 0, 32768)
+
+
+def test_sender_plan_fully_replicated_region_is_unchanged():
+    assert _compute_sender_transfer_plan(
+        local_tp_rank=2,
+        local_tp_size=8,
+        remote_tp_rank=0,
+        remote_tp_size=1,
+        local_kv_block_len=4096,
+        remote_kv_block_len=4096,
+        producer_cache_replicated=True,
+    ) == (False, 0, 0, 4096)
+
+
+@pytest.mark.parametrize("remote_tp_rank", range(8))
+def test_sender_plan_fully_replicated_tp1_to_tp8(remote_tp_rank):
+    assert _compute_sender_transfer_plan(
+        local_tp_rank=0,
+        local_tp_size=1,
+        remote_tp_rank=remote_tp_rank,
+        remote_tp_size=8,
+        local_kv_block_len=4096,
+        remote_kv_block_len=4096,
+        producer_cache_replicated=True,
+    ) == (True, 0, 0, 4096)
+
+
+@pytest.mark.parametrize(
+    ("local_tp_rank", "remote_tp_rank", "should_transfer"),
+    [(0, 0, True), (1, 0, False), (2, 1, True), (3, 1, False)],
+)
+def test_sender_plan_fully_replicated_tp4_to_tp2(
+    local_tp_rank,
+    remote_tp_rank,
+    should_transfer,
+):
+    plan = _compute_sender_transfer_plan(
+        local_tp_rank=local_tp_rank,
+        local_tp_size=4,
+        remote_tp_rank=remote_tp_rank,
+        remote_tp_size=2,
+        local_kv_block_len=4096,
+        remote_kv_block_len=4096,
+        producer_cache_replicated=True,
+    )
+    assert plan == (
+        (True, 0, 0, 4096) if should_transfer else (False, 0, 0, 4096)
+    )
+
+
+def test_validate_asymmetric_regions_allows_fully_replicated_index_cache():
+    local_region = TransferRegion(
+        layer_name="model.layers.0.indexer",
+        layer_index=0,
+        base_addr=0x1000,
+        block_len=4096,
+        kv_block_len=4096,
+    )
+    remote_region = TransferRegion(
+        layer_name="model.layers.0.indexer",
+        layer_index=0,
+        base_addr=0x2000,
+        block_len=4096,
+        kv_block_len=4096,
+    )
+    assert (
+        _validate_asymmetric_region_lengths(
+            local_regions=[local_region],
+            remote_regions=[remote_region],
+            local_tp_size=1,
+            remote_tp_size=8,
+            producer_cache_replicated=False,
+            fully_replicated_layers={"model.layers.0.indexer"},
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("local_tp_rank", range(8))
+def test_sender_plan_infers_per_region_head_count(local_tp_rank):
+    assert _compute_sender_transfer_plan(
+        local_tp_rank=local_tp_rank,
+        local_tp_size=8,
+        remote_tp_rank=0,
+        remote_tp_size=1,
+        local_kv_block_len=32768,
+        remote_kv_block_len=8 * 32768,
+        producer_cache_replicated=True,
+        transfer_unique_kv_heads=True,
+        # Simulate a model-level 4-head hint for an 8-head SWA region.
+        total_num_kv_heads=4,
+    ) == (True, 0, local_tp_rank * 32768, 32768)
+
+
+def test_validate_asymmetric_regions_allows_replicated_consumer_heads():
+    local_region = TransferRegion(
+        layer_name="model.layers.0.self_attn",
+        layer_index=0,
+        base_addr=0x1000,
+        block_len=131072,
+        kv_block_len=131072,
+    )
+    remote_region = TransferRegion(
+        layer_name="model.layers.0.self_attn",
+        layer_index=0,
+        base_addr=0x2000,
+        block_len=32768,
+        kv_block_len=32768,
+    )
+    assert (
+        _validate_asymmetric_region_lengths(
+            local_regions=[local_region],
+            remote_regions=[remote_region],
+            local_tp_size=1,
+            remote_tp_size=8,
+            producer_cache_replicated=False,
+            unique_kv_head_layers={"model.layers.0.self_attn"},
+            total_num_kv_heads_hint=4,
+        )
+        is None
+    )
+
+
+def test_sender_plan_virtual_split_preserves_head_offsets():
+    assert _compute_sender_transfer_plan(
+        local_tp_rank=4,
+        local_tp_size=8,
+        remote_tp_rank=0,
+        remote_tp_size=1,
+        local_kv_block_len=16384,
+        remote_kv_block_len=65536,
+        producer_cache_replicated=True,
+        transfer_unique_kv_heads=True,
+        total_num_kv_heads=4,
+    ) == (True, 0, 32768, 16384)
+
+
+@pytest.mark.parametrize(
+    ("local_tp_rank", "remote_tp_rank", "should_transfer"),
+    [
+        (0, 0, True),
+        (1, 0, False),
+        (2, 1, True),
+        (3, 1, False),
+    ],
+)
+def test_sender_plan_replicated_heads_tp4_to_tp2(
+    local_tp_rank,
+    remote_tp_rank,
+    should_transfer,
+):
+    plan = _compute_sender_transfer_plan(
+        local_tp_rank=local_tp_rank,
+        local_tp_size=4,
+        remote_tp_rank=remote_tp_rank,
+        remote_tp_size=2,
+        local_kv_block_len=32768,
+        remote_kv_block_len=32768,
+        producer_cache_replicated=True,
+        transfer_unique_kv_heads=True,
+        total_num_kv_heads=1,
+    )
+    assert plan == (
+        (True, 0, 0, 32768) if should_transfer else (False, 0, 0, 0)
+    )
+
+
+@pytest.mark.parametrize(
+    ("local_tp_rank", "remote_tp_rank"),
+    [(0, 0), (0, 1), (1, 2), (1, 3)],
+)
+def test_sender_plan_replicated_heads_tp2_to_tp4(
+    local_tp_rank,
+    remote_tp_rank,
+):
+    assert _compute_sender_transfer_plan(
+        local_tp_rank=local_tp_rank,
+        local_tp_size=2,
+        remote_tp_rank=remote_tp_rank,
+        remote_tp_size=4,
+        local_kv_block_len=32768,
+        remote_kv_block_len=32768,
+        producer_cache_replicated=True,
+        transfer_unique_kv_heads=True,
+        total_num_kv_heads=1,
+    ) == (True, 0, 0, 32768)
+
+
+@pytest.mark.parametrize("local_tp_rank", range(16))
+def test_sender_plan_mimo_equal_region_tp16_to_tp8(local_tp_rank):
+    remote_tp_rank = local_tp_rank // 2
+    assert _compute_sender_transfer_plan(
+        local_tp_rank=local_tp_rank,
+        local_tp_size=16,
+        remote_tp_rank=remote_tp_rank,
+        remote_tp_size=8,
+        local_kv_block_len=32768,
+        remote_kv_block_len=32768,
+        producer_cache_replicated=True,
+        transfer_unique_kv_heads=True,
+        total_num_kv_heads=8,
+    ) == (
+        (True, 0, 0, 32768)
+        if local_tp_rank % 2 == 0
+        else (False, 0, 0, 0)
+    )
 
 
 def _make_test_kv_cache_config() -> KVCacheConfig:
@@ -2329,7 +2597,8 @@ async def test_kv_producer_heterogeneous_tp(monkeypatch, d_tp_size):
 
     P_TP_SIZE = 2
     P_TP_RANK = 0
-    LOCAL_BLOCK_LEN = 4096
+    # The fixture model has 12 KV heads, so TP2 owns 6 heads per rank.
+    LOCAL_BLOCK_LEN = 6 * 1024
 
     local_block_len = LOCAL_BLOCK_LEN
     remote_block_len = LOCAL_BLOCK_LEN * P_TP_SIZE // d_tp_size

--- a/tests/v1/kv_connector/unit/test_transfer_topology_sharded.py
+++ b/tests/v1/kv_connector/unit/test_transfer_topology_sharded.py
@@ -22,6 +22,17 @@ class _FakeAttentionBackend:
         return (num_blocks, num_kv_heads, block_size, 2 * head_size)
 
 
+class _FakeIndexerBackend:
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+    ) -> tuple[int, int, int]:
+        return (num_blocks, block_size, head_size)
+
+
 def _make_topology(
     *,
     tp_rank: int = 1,
@@ -38,6 +49,21 @@ def _make_topology(
         total_num_kv_heads=total_num_kv_heads,
         attn_backends=[_FakeAttentionBackend],
     )
+
+
+def test_standard_topology_skips_nonstandard_indexer_backend() -> None:
+    topology = TransferTopology(
+        tp_rank=0,
+        tp_size=4,
+        block_size=16,
+        engine_id="local-engine",
+        is_mla=False,
+        is_mamba=False,
+        total_num_kv_heads=8,
+        attn_backends=[_FakeIndexerBackend, _FakeAttentionBackend],
+    )
+
+    assert topology.local_physical_heads == 2
 
 
 def test_legacy_register_remote_engine_uses_pp_rank_zero() -> None:

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -940,6 +940,7 @@ def get_cutlass_batched_moe_mm_data(
     padded_m: int,
     n: int,
     k: int,
+    swap_ab: bool,
 ):
     """
     Prepare data necessary to perform CUTLASS grouped matrix multiplications
@@ -963,6 +964,7 @@ def get_cutlass_batched_moe_mm_data(
         padded_m,
         n,
         k,
+        swap_ab,
     )
 
 

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -1124,6 +1124,31 @@ class CompilationConfig:
     def set_splitting_ops_for_v1(
         self, all2all_backend: str, data_parallel_size: int = 1
     ):
+        uses_deepep_ht = (
+            all2all_backend == "deepep_high_throughput" and data_parallel_size > 1
+        )
+
+        def disable_unsupported_deepep_ht_cudagraphs():
+            if (
+                not uses_deepep_ht
+                or self.cudagraph_mode == CUDAGraphMode.NONE
+                or (
+                    envs.VLLM_DEEPEP_HIGH_THROUGHPUT_FORCE_INTRA_NODE
+                    and self.cudagraph_mode == CUDAGraphMode.PIECEWISE
+                )
+            ):
+                return
+            logger.info(
+                "DeepEP: Disabling CUDA Graphs because high-throughput kernels "
+                "only support PIECEWISE capture with forced intranode transport. "
+                "Set VLLM_DEEPEP_HIGH_THROUGHPUT_FORCE_INTRA_NODE=1 and "
+                "-cc.cudagraph_mode=PIECEWISE on a verified intranode topology "
+                "to opt in."
+            )
+            self.cudagraph_mode = CUDAGraphMode.NONE
+
+        disable_unsupported_deepep_ht_cudagraphs()
+
         # To compatible with OOT hardware plugin platform (for example vllm-ascend)
         # which currently only supports sequence parallelism in eager mode.
         if self.mode != CompilationMode.VLLM_COMPILE:
@@ -1220,23 +1245,9 @@ class CompilationConfig:
                 )
                 self.cudagraph_mode = CUDAGraphMode.FULL
 
-        # Disable CUDA graphs for DeepEP high-throughput since its not CG compatible
-        if (
-            all2all_backend == "deepep_high_throughput"
-            and data_parallel_size > 1
-            and self.cudagraph_mode != CUDAGraphMode.NONE
-        ):
-            # TODO: Piecewise Cuda graph might be enabled
-            # if torch compile cache key issue fixed
-            # See https://github.com/vllm-project/vllm/pull/25093
-            logger.info(
-                "DeepEP: Disabling CUDA Graphs since DeepEP high-throughput kernels "
-                "are optimized for prefill and are incompatible with CUDA Graphs. "
-                "In order to use CUDA Graphs for decode-optimized workloads, "
-                "use --all2all-backend with another option, such as "
-                "deepep_low_latency, nixl_ep, or allgather_reducescatter."
-            )
-            self.cudagraph_mode = CUDAGraphMode.NONE
+        # Fusion and sequence-parallel normalization above can promote
+        # PIECEWISE to FULL, which DeepEP HT does not support.
+        disable_unsupported_deepep_ht_cudagraphs()
 
     def set_splitting_ops_for_attn_fusion(self):
         assert self.pass_config.fuse_attn_quant

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -425,12 +425,30 @@ class TransferTopology:
         attn_backend = self.attn_backends[0]
         if not self.is_mamba:
             _MOCK_BLOCK_SIZE = 16
-            kv_cache_shape: tuple[int, ...] = attn_backend.get_kv_cache_shape(
-                num_blocks=1,
-                block_size=_MOCK_BLOCK_SIZE,
-                num_kv_heads=1,
-                head_size=1,
-            )
+            backend_shapes = [
+                (
+                    backend,
+                    backend.get_kv_cache_shape(
+                        num_blocks=1,
+                        block_size=_MOCK_BLOCK_SIZE,
+                        num_kv_heads=1,
+                        head_size=1,
+                    ),
+                )
+                for backend in self.attn_backends
+            ]
+            if self.is_mla:
+                kv_cache_shape = backend_shapes[0][1]
+            else:
+                standard_backends = [
+                    item for item in backend_shapes if len(item[1]) == 4
+                ]
+                assert standard_backends, (
+                    "Attention KV cache layout must be standardized as "
+                    "[num_blocks, num_kv_heads, block_size, content_size], "
+                    f"got shapes {[shape for _, shape in backend_shapes]}."
+                )
+                attn_backend, kv_cache_shape = standard_backends[0]
             logger.debug("Test kv_cache_shape: %s", kv_cache_shape)
             assert kv_cache_shape[0] == 1, (
                 "KV cache layout must be blocks-first; expected mocked "

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -246,6 +246,62 @@ def _get_region_metadata(metadata: list[list[_T]] | None, idx: int) -> tuple[_T,
     return ()
 
 
+def _spec_transfers_unique_kv_heads(spec: KVCacheSpec) -> bool:
+    return isinstance(spec, (FullAttentionSpec, SlidingWindowSpec)) and not isinstance(
+        spec,
+        (MLAAttentionSpec, SlidingWindowMLASpec),
+    )
+
+
+def _spec_transfers_fully_replicated(spec: KVCacheSpec) -> bool:
+    return isinstance(spec, (MLAAttentionSpec, SlidingWindowMLASpec))
+
+
+def _infer_total_num_kv_heads(
+    local_tp_size: int,
+    remote_tp_size: int,
+    local_kv_block_len: int,
+    remote_kv_block_len: int,
+    total_num_kv_heads_hint: int | None,
+) -> int | None:
+    max_candidate = max(
+        256,
+        local_tp_size * remote_tp_size,
+        total_num_kv_heads_hint or 0,
+    )
+    candidates: list[int] = []
+    for total_num_kv_heads in range(1, max_candidate + 1):
+        if total_num_kv_heads >= local_tp_size:
+            if total_num_kv_heads % local_tp_size != 0:
+                continue
+            local_head_count = total_num_kv_heads // local_tp_size
+        else:
+            if local_tp_size % total_num_kv_heads != 0:
+                continue
+            local_head_count = 1
+
+        if total_num_kv_heads >= remote_tp_size:
+            if total_num_kv_heads % remote_tp_size != 0:
+                continue
+            remote_head_count = total_num_kv_heads // remote_tp_size
+        else:
+            if remote_tp_size % total_num_kv_heads != 0:
+                continue
+            remote_head_count = 1
+
+        if (
+            local_kv_block_len % local_head_count == 0
+            and remote_kv_block_len % remote_head_count == 0
+            and local_kv_block_len // local_head_count
+            == remote_kv_block_len // remote_head_count
+        ):
+            candidates.append(total_num_kv_heads)
+
+    if total_num_kv_heads_hint in candidates:
+        return total_num_kv_heads_hint
+    return min(candidates) if candidates else None
+
+
 def _compute_sender_transfer_plan(
     local_tp_rank: int,
     local_tp_size: int,
@@ -254,12 +310,84 @@ def _compute_sender_transfer_plan(
     local_kv_block_len: int,
     remote_kv_block_len: int,
     producer_cache_replicated: bool,
+    transfer_unique_kv_heads: bool = False,
+    total_num_kv_heads: int | None = None,
 ) -> tuple[bool, int, int, int]:
     """Plan one producer-rank to one consumer-rank copy for heterogeneous TP."""
     tp_ratio = _get_tp_ratio(local_tp_size, remote_tp_size)
 
     if tp_ratio == 1:
         return True, 0, 0, local_kv_block_len
+
+    if transfer_unique_kv_heads:
+        inferred_num_kv_heads = _infer_total_num_kv_heads(
+            local_tp_size=local_tp_size,
+            remote_tp_size=remote_tp_size,
+            local_kv_block_len=local_kv_block_len,
+            remote_kv_block_len=remote_kv_block_len,
+            total_num_kv_heads_hint=total_num_kv_heads,
+        )
+        if inferred_num_kv_heads is None:
+            transfer_unique_kv_heads = False
+
+        def get_head_partition(
+            tp_rank: int,
+            tp_size: int,
+        ) -> tuple[int, int, int, int]:
+            assert inferred_num_kv_heads is not None
+            if tp_size >= inferred_num_kv_heads:
+                assert tp_size % inferred_num_kv_heads == 0
+                replicas = tp_size // inferred_num_kv_heads
+                return tp_rank // replicas, 1, tp_rank % replicas, replicas
+            assert inferred_num_kv_heads % tp_size == 0
+            num_heads = inferred_num_kv_heads // tp_size
+            return tp_rank * num_heads, num_heads, 0, 1
+
+        if transfer_unique_kv_heads:
+            (
+                local_head_start,
+                local_head_count,
+                local_replica_index,
+                local_replicas,
+            ) = get_head_partition(local_tp_rank, local_tp_size)
+            (
+                remote_head_start,
+                remote_head_count,
+                remote_replica_index,
+                remote_replicas,
+            ) = get_head_partition(remote_tp_rank, remote_tp_size)
+
+            is_canonical_producer = True
+            if local_replicas >= remote_replicas:
+                assert local_replicas % remote_replicas == 0
+                is_canonical_producer = local_replica_index == (
+                    remote_replica_index * (local_replicas // remote_replicas)
+                )
+            elif remote_replicas > 1:
+                assert remote_replicas % local_replicas == 0
+                is_canonical_producer = (
+                    remote_replica_index // (remote_replicas // local_replicas)
+                    == local_replica_index
+                )
+
+            overlap_start = max(local_head_start, remote_head_start)
+            overlap_end = min(
+                local_head_start + local_head_count,
+                remote_head_start + remote_head_count,
+            )
+            if not is_canonical_producer or overlap_start >= overlap_end:
+                return False, 0, 0, 0
+
+            local_head_len = local_kv_block_len // local_head_count
+            remote_head_len = remote_kv_block_len // remote_head_count
+            assert local_head_len == remote_head_len
+            overlap_count = overlap_end - overlap_start
+            return (
+                True,
+                (overlap_start - local_head_start) * local_head_len,
+                (overlap_start - remote_head_start) * remote_head_len,
+                overlap_count * local_head_len,
+            )
 
     if tp_ratio > 0:
         if producer_cache_replicated:
@@ -305,6 +433,10 @@ def _validate_asymmetric_region_lengths(
     local_tp_size: int,
     remote_tp_size: int,
     producer_cache_replicated: bool,
+    unique_kv_head_layers: set[str] | None = None,
+    fully_replicated_layers: set[str] | None = None,
+    total_num_kv_heads_hint: int | None = None,
+    total_num_kv_heads_by_layer: dict[str, int] | None = None,
 ) -> str | None:
     """Validate transfer-region metadata for a fixed producer/consumer pair.
 
@@ -318,13 +450,55 @@ def _validate_asymmetric_region_lengths(
             "producer and consumer."
         )
 
-    if producer_cache_replicated:
-        return None
-
     tp_ratio = _get_tp_ratio(local_tp_size, remote_tp_size)
     for idx, (local_region, remote_region) in enumerate(
         zip(local_regions, remote_regions)
     ):
+        if fully_replicated_layers and any(
+            layer_name in fully_replicated_layers
+            for layer_name in local_region.match_layer_names
+        ):
+            if local_region.kv_block_len != remote_region.kv_block_len:
+                return (
+                    "Mooncake fully replicated KV region length mismatch at "
+                    f"region {idx}: local={local_region.kv_block_len}, "
+                    f"remote={remote_region.kv_block_len}."
+                )
+            continue
+
+        if unique_kv_head_layers and any(
+            layer_name in unique_kv_head_layers
+            for layer_name in local_region.match_layer_names
+        ):
+            region_num_kv_heads = next(
+                (
+                    total_num_kv_heads_by_layer[layer_name]
+                    for layer_name in local_region.match_layer_names
+                    if total_num_kv_heads_by_layer
+                    and layer_name in total_num_kv_heads_by_layer
+                ),
+                total_num_kv_heads_hint,
+            )
+            inferred_num_kv_heads = _infer_total_num_kv_heads(
+                local_tp_size=local_tp_size,
+                remote_tp_size=remote_tp_size,
+                local_kv_block_len=local_region.kv_block_len,
+                remote_kv_block_len=remote_region.kv_block_len,
+                total_num_kv_heads_hint=region_num_kv_heads,
+            )
+            if inferred_num_kv_heads is None:
+                return (
+                    "Mooncake cannot infer a consistent heterogeneous TP KV-head "
+                    f"mapping at region {idx}: "
+                    f"local={local_region.kv_block_len}, "
+                    f"remote={remote_region.kv_block_len}, "
+                    f"local_tp={local_tp_size}, remote_tp={remote_tp_size}."
+                )
+            continue
+
+        if producer_cache_replicated:
+            continue
+
         if tp_ratio == 1:
             if local_region.kv_block_len != remote_region.kv_block_len:
                 return (
@@ -1879,6 +2053,21 @@ class MooncakeConnectorWorker:
             local_tp_size=self.tp_size,
             remote_tp_size=meta.remote_tp_size,
             producer_cache_replicated=self._producer_cache_is_replicated(),
+            unique_kv_head_layers={
+                layer_name
+                for layer_name, spec in self._layer_specs.items()
+                if _spec_transfers_unique_kv_heads(spec)
+            },
+            fully_replicated_layers={
+                layer_name
+                for layer_name, spec in self._layer_specs.items()
+                if _spec_transfers_fully_replicated(spec)
+            },
+            total_num_kv_heads_hint=self.transfer_topo.total_num_kv_heads,
+            total_num_kv_heads_by_layer={
+                layer_name: self._get_layer_total_num_kv_heads(layer_name)
+                for layer_name in self._layer_specs
+            },
         )
         if validation_err is not None:
             response = MooncakeXferResponse(
@@ -2235,6 +2424,10 @@ class MooncakeConnectorWorker:
                 local_block_ids,
                 remote_block_ids,
             ) in selected_region_blocks:
+                layer_spec = self._layer_specs[local_region.layer_name]
+                region_fully_replicated = _spec_transfers_fully_replicated(
+                    layer_spec
+                )
                 # Group by indices within this region's KV-cache group only.
                 group_local_block_ids, group_remote_block_ids = (
                     group_concurrent_contiguous(local_block_ids, remote_block_ids)
@@ -2249,6 +2442,15 @@ class MooncakeConnectorWorker:
                     remote_kv_block_len=remote_region.kv_block_len,
                     remote_tp_rank=agent_meta.remote_tp_rank,
                     remote_tp_size=agent_meta.remote_tp_size,
+                    transfer_unique_kv_heads=_spec_transfers_unique_kv_heads(
+                        layer_spec
+                    ),
+                    producer_cache_replicated=(
+                        True if region_fully_replicated else None
+                    ),
+                    total_num_kv_heads=self._get_layer_total_num_kv_heads(
+                        local_region.layer_name
+                    ),
                 )
                 if not should_transfer:
                     # Replicated KV cache: only one producer rank in the TP group
@@ -2999,6 +3201,9 @@ class MooncakeConnectorWorker:
         remote_kv_block_len: int,
         remote_tp_rank: int,
         remote_tp_size: int,
+        transfer_unique_kv_heads: bool = False,
+        producer_cache_replicated: bool | None = None,
+        total_num_kv_heads: int | None = None,
     ) -> tuple[bool, int, int, int]:
         return _compute_sender_transfer_plan(
             local_tp_rank=self.tp_rank,
@@ -3007,7 +3212,27 @@ class MooncakeConnectorWorker:
             remote_tp_size=remote_tp_size,
             local_kv_block_len=local_kv_block_len,
             remote_kv_block_len=remote_kv_block_len,
-            producer_cache_replicated=self._producer_cache_is_replicated(),
+            producer_cache_replicated=(
+                self._producer_cache_is_replicated()
+                if producer_cache_replicated is None
+                else producer_cache_replicated
+            ),
+            transfer_unique_kv_heads=transfer_unique_kv_heads,
+            total_num_kv_heads=(
+                total_num_kv_heads or self.transfer_topo.total_num_kv_heads
+            ),
+        )
+
+    def _get_layer_total_num_kv_heads(self, layer_name: str) -> int:
+        layer = self.vllm_config.compilation_config.static_forward_context.get(
+            layer_name
+        )
+        return int(
+            getattr(
+                layer,
+                "total_num_kv_heads",
+                self.transfer_topo.total_num_kv_heads,
+            )
         )
 
     def _log_debug_cache_registration(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -2990,6 +2990,25 @@ class MooncakeConnectorWorker:
         remote_tp_ranks = self.transfer_topo.handshake_target_ranks(
             self._tp_size[remote_engine_id]
         )
+        remote_pp_sizes = {
+            remote_tp_rank: len(self._remote_agents[remote_engine_id][remote_tp_rank])
+            for remote_tp_rank in remote_tp_ranks
+        }
+        unsupported_pp_fanout = any(
+            remote_pp_size < self.pp_size for remote_pp_size in remote_pp_sizes.values()
+        )
+        if unsupported_pp_fanout:
+            logger.error(
+                "Unsupported Mooncake PP topology for engine %s: "
+                "producer PP sizes=%s, consumer PP size=%d",
+                remote_engine_id,
+                remote_pp_sizes,
+                self.pp_size,
+            )
+            for pull_meta in pull_metas.values():
+                pull_meta.pull_failed = True
+                self._mark_pull_failed(pull_meta)
+            return
         worker_addrs: list[str] = []
         selected_remote_pp: dict[int, list[int]] = {}
         selected_remote_pcp: dict[tuple[int, int], list[int]] = {}

--- a/vllm/model_executor/layers/fused_moe/__init__.py
+++ b/vllm/model_executor/layers/fused_moe/__init__.py
@@ -94,6 +94,7 @@ if HAS_TRITON:
     )
     from vllm.model_executor.layers.fused_moe.experts.cutlass_moe import (
         CutlassBatchedExpertsFp8,
+        CutlassBatchedExpertsW4A8Fp8,
         CutlassExpertsFp8,
         CutlassExpertsW4A8Fp8,
     )
@@ -138,6 +139,7 @@ if HAS_TRITON:
         "CutlassExpertsFp8",
         "CutlassBatchedExpertsFp8",
         "CutlassExpertsW4A8Fp8",
+        "CutlassBatchedExpertsW4A8Fp8",
         "TritonExperts",
         "TritonWNA16Experts",
         "BatchedTritonExperts",

--- a/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
@@ -81,9 +81,7 @@ def _estimate_w4a8_batched_m(
     assert topk > 0
     assert global_num_experts > 0
 
-    return (
-        total_num_tokens * topk + global_num_experts - 1
-    ) // global_num_experts
+    return (total_num_tokens * topk + global_num_experts - 1) // global_num_experts
 
 
 def _select_w4a8_batched_schedule(
@@ -649,8 +647,13 @@ class CutlassExpertsFp8Base(mk.FusedMoEExpertsModular):
         if self._permute_scratch is None and moe_permute_unpermute_supported():
             max_num_tokens = self.moe_config.max_num_tokens
             if self.activation_format() == mk.FusedMoEActivationFormat.Standard:
-                # Standard DP/EP gathers every rank's tokens before the experts.
-                max_num_tokens *= self.moe_config.dp_size
+                parallel_config = self.moe_config.moe_parallel_config
+                num_dispatchers = (
+                    parallel_config.ep_size
+                    if parallel_config.use_ep
+                    else parallel_config.dp_size
+                )
+                max_num_tokens *= num_dispatchers
             self._permute_scratch = MoEPermuteScratch(
                 max_num_tokens=max_num_tokens,
                 topk=self.moe_config.experts_per_token,
@@ -1828,7 +1831,13 @@ class CutlassExpertsW4A8Fp8(mk.FusedMoEExpertsModular):
         if self._permute_scratch is None and moe_permute_unpermute_supported():
             max_num_tokens = self.moe_config.max_num_tokens
             if self.activation_format() == mk.FusedMoEActivationFormat.Standard:
-                max_num_tokens *= self.moe_config.dp_size
+                parallel_config = self.moe_config.moe_parallel_config
+                num_dispatchers = (
+                    parallel_config.ep_size
+                    if parallel_config.use_ep
+                    else parallel_config.dp_size
+                )
+                max_num_tokens *= num_dispatchers
             self._permute_scratch = MoEPermuteScratch(
                 max_num_tokens=max_num_tokens,
                 topk=self.moe_config.experts_per_token,
@@ -1876,11 +1885,11 @@ class CutlassExpertsW4A8Fp8(mk.FusedMoEExpertsModular):
         assert self.w1_zp is None, "w1_zp is not supported in CUTLASS MoE"
         assert self.w2_zp is None, "w2_zp is not supported in CUTLASS MoE"
 
+        expert_num_tokens = None
         use_batched_format = (
             self.activation_format() == mk.FusedMoEActivationFormat.BatchedExperts
         )
-        expert_num_tokens = None
-        if expert_tokens_meta is not None:
+        if use_batched_format and expert_tokens_meta is not None:
             expert_num_tokens = expert_tokens_meta.expert_num_tokens
 
         in_dtype = hidden_states.dtype

--- a/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
@@ -1776,8 +1776,10 @@ class CutlassExpertsW4A8Fp8(mk.FusedMoEExpertsModular):
         if moe_config.intermediate_size_per_partition % 256 != 0:
             return (
                 False,
-                "kernel requires intermediate_size_per_partition to be "
-                "divisible by 256",
+                (
+                    "kernel requires intermediate_size_per_partition to be "
+                    "divisible by 256"
+                ),
             )
 
         if moe_config.activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE:

--- a/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
@@ -46,8 +46,216 @@ from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
 )
 from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
+from vllm.triton_utils import tl, triton
 
 logger = init_logger(__name__)
+
+
+def _require_w4a8_swigluoai_params(
+    gemm1_alpha: float | None,
+    gemm1_beta: float | None,
+    gemm1_clamp_limit: float | None,
+) -> tuple[float, float, float]:
+    params = {
+        "gemm1_alpha": gemm1_alpha,
+        "gemm1_beta": gemm1_beta,
+        "gemm1_clamp_limit": gemm1_clamp_limit,
+    }
+    missing = [name for name, value in params.items() if value is None]
+    if missing:
+        raise ValueError("SWIGLUOAI_UNINTERLEAVE requires " + ", ".join(missing))
+
+    assert gemm1_alpha is not None
+    assert gemm1_beta is not None
+    assert gemm1_clamp_limit is not None
+    return gemm1_alpha, gemm1_beta, gemm1_clamp_limit
+
+
+@triton.jit
+def _masked_per_token_fp8_quant_kernel(
+    src,
+    dst,
+    scales,
+    expert_num_tokens,
+    hidden: tl.constexpr,
+    src_stride_e: tl.constexpr,
+    src_stride_m: tl.constexpr,
+    dst_stride_e: tl.constexpr,
+    dst_stride_m: tl.constexpr,
+    scale_stride_e: tl.constexpr,
+    scale_stride_m: tl.constexpr,
+    fp8_min: tl.constexpr,
+    fp8_max: tl.constexpr,
+    min_scale: tl.constexpr,
+    block_n: tl.constexpr,
+):
+    expert = tl.program_id(0)
+    token = tl.program_id(1)
+    valid_tokens = tl.load(expert_num_tokens + expert)
+    if token < valid_tokens:
+        offsets = tl.arange(0, block_n)
+        mask = offsets < hidden
+        src_ptr = src + expert * src_stride_e + token * src_stride_m + offsets
+        values = tl.load(src_ptr, mask=mask, other=0.0).to(tl.float32)
+        absmax = tl.max(tl.abs(values), axis=0)
+        scale = tl.maximum(absmax / fp8_max, min_scale)
+        quantized = tl.clamp(values / scale, fp8_min, fp8_max).to(tl.float8e4nv)
+        dst_ptr = dst + expert * dst_stride_e + token * dst_stride_m + offsets
+        tl.store(dst_ptr, quantized, mask=mask)
+        tl.store(
+            scales + expert * scale_stride_e + token * scale_stride_m,
+            scale,
+        )
+
+
+@triton.jit
+def _masked_swigluoai_quant_kernel(
+    src,
+    dst,
+    scales,
+    expert_num_tokens,
+    hidden: tl.constexpr,
+    src_stride_e: tl.constexpr,
+    src_stride_m: tl.constexpr,
+    dst_stride_e: tl.constexpr,
+    dst_stride_m: tl.constexpr,
+    scale_stride_e: tl.constexpr,
+    scale_stride_m: tl.constexpr,
+    alpha: tl.constexpr,
+    beta: tl.constexpr,
+    clamp_limit: tl.constexpr,
+    fp8_min: tl.constexpr,
+    fp8_max: tl.constexpr,
+    min_scale: tl.constexpr,
+    block_n: tl.constexpr,
+):
+    expert = tl.program_id(0)
+    token = tl.program_id(1)
+    valid_tokens = tl.load(expert_num_tokens + expert)
+    if token < valid_tokens:
+        offsets = tl.arange(0, block_n)
+        mask = offsets < hidden
+        src_ptr = src + expert * src_stride_e + token * src_stride_m
+        gate = tl.load(src_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+        up = tl.load(src_ptr + hidden + offsets, mask=mask, other=0.0).to(tl.float32)
+        gate = tl.minimum(gate, clamp_limit)
+        up = tl.minimum(tl.maximum(up, -clamp_limit), clamp_limit)
+        gate = (gate / (1.0 + tl.exp(-alpha * gate))).to(tl.bfloat16).to(tl.float32)
+        activated = gate * (up + beta)
+        activated = activated.to(tl.bfloat16).to(tl.float32)
+        absmax = tl.max(tl.abs(activated), axis=0)
+        scale = tl.maximum(absmax / fp8_max, min_scale)
+        quantized = tl.clamp(activated / scale, fp8_min, fp8_max).to(tl.float8e4nv)
+        dst_ptr = dst + expert * dst_stride_e + token * dst_stride_m + offsets
+        tl.store(dst_ptr, quantized, mask=mask)
+        tl.store(
+            scales + expert * scale_stride_e + token * scale_stride_m,
+            scale,
+        )
+
+
+def _masked_per_token_fp8_quant(
+    src: torch.Tensor,
+    dst: torch.Tensor,
+    scales: torch.Tensor,
+    expert_num_tokens: torch.Tensor,
+) -> None:
+    assert src.dim() == 3 and src.is_contiguous()
+    assert src.is_cuda and src.dtype == torch.bfloat16
+    assert dst.shape == src.shape and dst.is_contiguous()
+    assert dst.is_cuda and dst.dtype == torch.float8_e4m3fn
+    assert scales.shape == (*src.shape[:2], 1) and scales.is_contiguous()
+    assert scales.is_cuda and scales.dtype == torch.float32
+    assert expert_num_tokens.shape == (src.shape[0],)
+    assert expert_num_tokens.is_cuda and expert_num_tokens.dtype == torch.int32
+    assert expert_num_tokens.is_contiguous()
+    _, padded_m, hidden = src.shape
+    fp8_info = torch.finfo(torch.float8_e4m3fn)
+    min_scale = 1.0 / (fp8_info.max * 512.0)
+    _masked_per_token_fp8_quant_kernel[(src.shape[0], padded_m)](
+        src,
+        dst,
+        scales,
+        expert_num_tokens,
+        hidden,
+        src.stride(0),
+        src.stride(1),
+        dst.stride(0),
+        dst.stride(1),
+        scales.stride(0),
+        scales.stride(1),
+        fp8_info.min,
+        fp8_info.max,
+        min_scale,
+        triton.next_power_of_2(hidden),
+        num_warps=8,
+    )
+
+
+def _masked_swigluoai_quant(
+    src: torch.Tensor,
+    dst: torch.Tensor,
+    scales: torch.Tensor,
+    expert_num_tokens: torch.Tensor,
+    alpha: float,
+    beta: float,
+    clamp_limit: float,
+) -> None:
+    assert src.dim() == 3 and src.is_contiguous()
+    assert src.is_cuda and src.dtype == torch.bfloat16
+    assert src.shape[-1] == dst.shape[-1] * 2
+    assert dst.shape[:2] == src.shape[:2] and dst.is_contiguous()
+    assert dst.is_cuda and dst.dtype == torch.float8_e4m3fn
+    assert scales.shape == (*dst.shape[:2], 1) and scales.is_contiguous()
+    assert scales.is_cuda and scales.dtype == torch.float32
+    assert expert_num_tokens.shape == (src.shape[0],)
+    assert expert_num_tokens.is_cuda and expert_num_tokens.dtype == torch.int32
+    assert expert_num_tokens.is_contiguous()
+    _, padded_m, two_hidden = src.shape
+    hidden = two_hidden // 2
+    fp8_info = torch.finfo(torch.float8_e4m3fn)
+    min_scale = 1.0 / (fp8_info.max * 512.0)
+    _masked_swigluoai_quant_kernel[(src.shape[0], padded_m)](
+        src,
+        dst,
+        scales,
+        expert_num_tokens,
+        hidden,
+        src.stride(0),
+        src.stride(1),
+        dst.stride(0),
+        dst.stride(1),
+        scales.stride(0),
+        scales.stride(1),
+        alpha,
+        beta,
+        clamp_limit,
+        fp8_info.min,
+        fp8_info.max,
+        min_scale,
+        triton.next_power_of_2(hidden),
+        num_warps=8,
+    )
+
+
+def _w4a8_batched_quant_workspace(
+    workspace: torch.Tensor,
+    num_experts: int,
+    padded_m: int,
+    hidden: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    assert workspace.dtype == torch.bfloat16 and workspace.is_contiguous()
+    storage = workspace.view(torch.uint8).flatten()
+    quant_bytes = num_experts * padded_m * hidden
+    scale_offset = (quant_bytes + 3) // 4 * 4
+    scale_bytes = num_experts * padded_m * torch.float32.itemsize
+    assert storage.numel() >= scale_offset + scale_bytes
+    quant = storage[:quant_bytes].view(torch.float8_e4m3fn)
+    scales = storage[scale_offset : scale_offset + scale_bytes].view(torch.float32)
+    return (
+        quant.view(num_experts, padded_m, hidden),
+        scales.view(num_experts, padded_m, 1),
+    )
 
 
 def _apply_w4a8_moe_activation(
@@ -58,19 +266,12 @@ def _apply_w4a8_moe_activation(
     gemm1_beta: float | None,
     gemm1_clamp_limit: float | None,
 ) -> None:
-    if activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE and (
-        gemm1_alpha is None or gemm1_beta is None or gemm1_clamp_limit is None
-    ):
-        missing = [
-            name
-            for name, value in (
-                ("gemm1_alpha", gemm1_alpha),
-                ("gemm1_beta", gemm1_beta),
-                ("gemm1_clamp_limit", gemm1_clamp_limit),
-            )
-            if value is None
-        ]
-        raise ValueError("SWIGLUOAI_UNINTERLEAVE requires " + ", ".join(missing))
+    if activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE:
+        gemm1_alpha, gemm1_beta, gemm1_clamp_limit = _require_w4a8_swigluoai_params(
+            gemm1_alpha,
+            gemm1_beta,
+            gemm1_clamp_limit,
+        )
 
     apply_moe_activation(
         activation,
@@ -210,6 +411,7 @@ def run_cutlass_moe_fp8(
             padded_M,
             N,
             K,
+            local_E * padded_M <= 64,
         )
 
         w1_scale = w1_scale.reshape(w1_scale.size(0), -1)
@@ -364,8 +566,12 @@ class CutlassExpertsFp8Base(mk.FusedMoEExpertsModular):
 
     def _get_permute_scratch(self) -> MoEPermuteScratch | None:
         if self._permute_scratch is None and moe_permute_unpermute_supported():
+            max_num_tokens = self.moe_config.max_num_tokens
+            if self.activation_format() == mk.FusedMoEActivationFormat.Standard:
+                # Standard DP/EP gathers every rank's tokens before the experts.
+                max_num_tokens *= self.moe_config.dp_size
             self._permute_scratch = MoEPermuteScratch(
-                max_num_tokens=self.moe_config.max_num_tokens,
+                max_num_tokens=max_num_tokens,
                 topk=self.moe_config.experts_per_token,
                 num_experts=self.moe_config.num_experts,
                 num_local_experts=self.moe_config.num_local_experts,
@@ -1172,7 +1378,6 @@ def run_cutlass_moe_w4a8_fp8(
     permute_scratch: MoEPermuteScratch | None,
 ):
     a1q = hidden_states
-    M = a1q.size(0)
     local_E = w1.size(0)
     device = a1q.device
     _, K, N_packed = w2.shape
@@ -1189,12 +1394,8 @@ def run_cutlass_moe_w4a8_fp8(
     assert w1_chan_scale.dtype == torch.float32
     assert w2_chan_scale.dtype == torch.float32
     assert w1.size(0) == w2.size(0), "Weights expert number mismatch"
-    assert a1q_scale is not None
     assert a2_scale is None
     assert out_dtype in [torch.bfloat16], f"Invalid output dtype: {out_dtype}"
-    if expert_map is not None:
-        assert expert_num_tokens is None
-    assert not use_batched_format, "batched format not supported yet"
     assert group_size == 128, f"Only group size 128 supported but got {group_size=}"
 
     assert global_num_experts != -1
@@ -1203,35 +1404,98 @@ def run_cutlass_moe_w4a8_fp8(
     )
 
     topk = topk_ids.size(1)
-    a1q_perm = _resize_cache(workspace2.view(dtype=torch.float8_e4m3fn), (M * topk, K))
-    mm1_out = _resize_cache(workspace13, (M * topk, N * 2))
-    act_out = _resize_cache(workspace2, (M * topk, N))
-    # original workspace are based on input hidden_states dtype (bf16)
-    quant_out = _resize_cache(
-        workspace13.view(dtype=torch.float8_e4m3fn), (M * topk, N)
-    )
-    mm2_out = _resize_cache(workspace2, (M * topk, K))
-
     problem_sizes1 = torch.empty((local_E, 3), dtype=torch.int32, device=device)
     problem_sizes2 = torch.empty((local_E, 3), dtype=torch.int32, device=device)
 
-    num_expert = global_num_experts if expert_map is None else expert_map.size(0)
-    # permuted a1q reuses workspace2
-    a1q, a1q_scale, expert_first_token_offset, inv_perm, _ = moe_permute(
-        a1q,
-        a1q_scale,
-        topk_ids,
-        num_expert,
-        local_E,
-        expert_map,
-        permuted_hidden_states=a1q_perm,
-        scratch=permute_scratch,
-    )
-    # for RS gemm SwapAB is always enabled (swap logical M, N in the problem shape).
-    ops.get_cutlass_moe_mm_problem_sizes_from_expert_offsets(
-        expert_first_token_offset, problem_sizes1, problem_sizes2, N, K, True
-    )
-    expert_offsets = expert_first_token_offset[:-1]
+    if use_batched_format:
+        assert expert_num_tokens is not None
+        assert expert_num_tokens.dtype == torch.int32
+        assert expert_num_tokens.is_cuda
+        assert expert_num_tokens.shape == (local_E,)
+        assert a1q.dim() == 3
+        assert a1q.shape[0] == local_E
+        assert a1q.shape[2] == K
+        assert a1q.is_contiguous()
+
+        padded_M = a1q.size(1)
+        assert output.dim() == 3
+        assert output.shape[0] == local_E
+        assert output.shape[1] == padded_M
+        assert output.shape[2] == K
+        assert output.is_contiguous()
+        mm1_out = _resize_cache(workspace13, (local_E * padded_M, N * 2))
+
+        if a1q.dtype == torch.bfloat16:
+            assert a1q_scale is None
+            a1q, a1q_scale = _w4a8_batched_quant_workspace(
+                workspace2,
+                local_E,
+                padded_M,
+                K,
+            )
+            _masked_per_token_fp8_quant(
+                hidden_states,
+                a1q,
+                a1q_scale,
+                expert_num_tokens,
+            )
+        else:
+            assert a1q.dtype == torch.float8_e4m3fn
+            assert a1q_scale is not None
+            assert a1q_scale.dim() == 3
+            assert a1q_scale.shape == (local_E, padded_M, 1)
+            assert a1q_scale.is_contiguous()
+
+        expert_offsets = torch.empty((local_E,), dtype=torch.int32, device=device)
+        ops.get_cutlass_batched_moe_mm_data(
+            expert_offsets,
+            problem_sizes1,
+            problem_sizes2,
+            expert_num_tokens,
+            local_E,
+            padded_M,
+            N,
+            K,
+            True,
+        )
+        a1q = a1q.reshape(local_E * padded_M, K)
+        assert a1q_scale is not None
+        a1q_scale = a1q_scale.reshape(local_E * padded_M, 1)
+        # c3x get_group_gemm_starts expects int64 to avoid overflow during
+        # offset calculations. W4A8 offsets are physical padded slabs.
+        expert_offsets = expert_offsets.to(torch.int64)
+    else:
+        assert expert_num_tokens is None
+        assert a1q_scale is not None
+        M = a1q.size(0)
+        a1q_perm = _resize_cache(
+            workspace2.view(dtype=torch.float8_e4m3fn), (M * topk, K)
+        )
+        mm1_out = _resize_cache(workspace13, (M * topk, N * 2))
+        act_out = _resize_cache(workspace2, (M * topk, N))
+        # original workspace are based on input hidden_states dtype (bf16)
+        quant_out = _resize_cache(
+            workspace13.view(dtype=torch.float8_e4m3fn), (M * topk, N)
+        )
+        mm2_out = _resize_cache(workspace2, (M * topk, K))
+
+        num_expert = global_num_experts if expert_map is None else expert_map.size(0)
+        # permuted a1q reuses workspace2
+        a1q, a1q_scale, expert_first_token_offset, inv_perm, _ = moe_permute(
+            a1q,
+            a1q_scale,
+            topk_ids,
+            num_expert,
+            local_E,
+            expert_map,
+            permuted_hidden_states=a1q_perm,
+            scratch=permute_scratch,
+        )
+        # for RS gemm SwapAB is always enabled (swap logical M, N in the problem shape).
+        ops.get_cutlass_moe_mm_problem_sizes_from_expert_offsets(
+            expert_first_token_offset, problem_sizes1, problem_sizes2, N, K, True
+        )
+        expert_offsets = expert_first_token_offset[:-1]
 
     ops.cutlass_w4a8_moe_mm(
         mm1_out,
@@ -1249,18 +1513,56 @@ def run_cutlass_moe_w4a8_fp8(
         s_strides1,
     )
 
-    _apply_w4a8_moe_activation(
-        activation,
-        act_out,
-        mm1_out,
-        gemm1_alpha,
-        gemm1_beta,
-        gemm1_clamp_limit,
+    use_masked_swigluoai = (
+        use_batched_format and activation == MoEActivation.SWIGLUOAI_UNINTERLEAVE
     )
-
-    a2q, a2q_scale = ops.scaled_fp8_quant(
-        act_out, a2_scale, use_per_token_if_dynamic=per_act_token, output=quant_out
-    )
+    if use_masked_swigluoai:
+        assert expert_num_tokens is not None
+        alpha, beta, clamp_limit = _require_w4a8_swigluoai_params(
+            gemm1_alpha,
+            gemm1_beta,
+            gemm1_clamp_limit,
+        )
+        a2q, a2q_scale = _w4a8_batched_quant_workspace(
+            workspace2,
+            local_E,
+            padded_M,
+            N,
+        )
+        _masked_swigluoai_quant(
+            mm1_out.view(local_E, padded_M, N * 2),
+            a2q,
+            a2q_scale,
+            expert_num_tokens,
+            alpha,
+            beta,
+            clamp_limit,
+        )
+        a2q = a2q.reshape(local_E * padded_M, N)
+        a2q_scale = a2q_scale.reshape(local_E * padded_M, 1)
+        mm2_out = output[:, :padded_M, :].reshape(local_E * padded_M, K)
+    else:
+        if use_batched_format:
+            act_out = _resize_cache(workspace2, (local_E * padded_M, N))
+            quant_out = _resize_cache(
+                workspace13.view(dtype=torch.float8_e4m3fn),
+                (local_E * padded_M, N),
+            )
+            mm2_out = _resize_cache(workspace2, (local_E * padded_M, K))
+        _apply_w4a8_moe_activation(
+            activation,
+            act_out,
+            mm1_out,
+            gemm1_alpha,
+            gemm1_beta,
+            gemm1_clamp_limit,
+        )
+        a2q, a2q_scale = ops.scaled_fp8_quant(
+            act_out,
+            a2_scale,
+            use_per_token_if_dynamic=per_act_token,
+            output=quant_out,
+        )
 
     ops.cutlass_w4a8_moe_mm(
         mm2_out,
@@ -1278,15 +1580,20 @@ def run_cutlass_moe_w4a8_fp8(
         s_strides2,
     )
 
-    # for non-chunking mode the output is resized from workspace13
-    # so we need to make sure mm2_out uses workspace2.
-    moe_unpermute(
-        out=output,
-        permuted_hidden_states=mm2_out,
-        topk_weights=topk_weights,
-        inv_permuted_idx=inv_perm,
-        expert_first_token_offset=expert_first_token_offset,
-    )
+    if use_batched_format and not use_masked_swigluoai:
+        output[:, :padded_M, :].copy_(
+            mm2_out.reshape(local_E, padded_M, K), non_blocking=True
+        )
+    elif not use_batched_format:
+        # for non-chunking mode the output is resized from workspace13
+        # so we need to make sure mm2_out uses workspace2.
+        moe_unpermute(
+            out=output,
+            permuted_hidden_states=mm2_out,
+            topk_weights=topk_weights,
+            inv_permuted_idx=inv_perm,
+            expert_first_token_offset=expert_first_token_offset,
+        )
 
 
 class CutlassExpertsW4A8Fp8(mk.FusedMoEExpertsModular):
@@ -1297,8 +1604,15 @@ class CutlassExpertsW4A8Fp8(mk.FusedMoEExpertsModular):
         b_strides1: torch.Tensor,
         b_strides2: torch.Tensor,
         group_size: int,
+        max_num_tokens: int | None = None,
+        num_dispatchers: int | None = None,
     ):
-        super().__init__(moe_config=moe_config, quant_config=quant_config)
+        super().__init__(
+            moe_config=moe_config,
+            quant_config=quant_config,
+            max_num_tokens=max_num_tokens,
+            num_dispatchers=num_dispatchers,
+        )
 
         e = moe_config.num_local_experts
         n = moe_config.intermediate_size_per_partition
@@ -1411,8 +1725,11 @@ class CutlassExpertsW4A8Fp8(mk.FusedMoEExpertsModular):
 
     def _get_permute_scratch(self) -> MoEPermuteScratch | None:
         if self._permute_scratch is None and moe_permute_unpermute_supported():
+            max_num_tokens = self.moe_config.max_num_tokens
+            if self.activation_format() == mk.FusedMoEActivationFormat.Standard:
+                max_num_tokens *= self.moe_config.dp_size
             self._permute_scratch = MoEPermuteScratch(
-                max_num_tokens=self.moe_config.max_num_tokens,
+                max_num_tokens=max_num_tokens,
                 topk=self.moe_config.experts_per_token,
                 num_experts=self.moe_config.num_experts,
                 num_local_experts=self.moe_config.num_local_experts,
@@ -1458,12 +1775,12 @@ class CutlassExpertsW4A8Fp8(mk.FusedMoEExpertsModular):
         assert self.w1_zp is None, "w1_zp is not supported in CUTLASS MoE"
         assert self.w2_zp is None, "w2_zp is not supported in CUTLASS MoE"
 
-        expert_num_tokens = None
-
         use_batched_format = (
             self.activation_format() == mk.FusedMoEActivationFormat.BatchedExperts
         )
-        assert not use_batched_format, "batched format not supported"
+        expert_num_tokens = None
+        if expert_tokens_meta is not None:
+            expert_num_tokens = expert_tokens_meta.expert_num_tokens
 
         in_dtype = hidden_states.dtype
 
@@ -1504,3 +1821,52 @@ class CutlassExpertsW4A8Fp8(mk.FusedMoEExpertsModular):
             self.group_size,
             self._get_permute_scratch(),
         )
+
+
+class CutlassBatchedExpertsW4A8Fp8(CutlassExpertsW4A8Fp8):
+    """Batched CUTLASS W4A8 expert implementation for DeepEP low latency."""
+
+    @staticmethod
+    def activation_format() -> mk.FusedMoEActivationFormat:
+        return mk.FusedMoEActivationFormat.BatchedExperts
+
+    @property
+    def expects_unquantized_inputs(self) -> bool:
+        return True
+
+    @staticmethod
+    def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:
+        return moe_parallel_config.use_deepep_ll_kernels
+
+    def finalize_weight_and_reduce_impl(self) -> mk.TopKWeightAndReduce:
+        return TopKWeightAndReduceDelegate()
+
+    def workspace_shapes(
+        self,
+        M: int,
+        N: int,
+        K: int,
+        topk: int,
+        global_num_experts: int,
+        local_num_experts: int,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        activation: MoEActivation,
+    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+        num_dispatchers = self.num_dispatchers
+        assert num_dispatchers is not None
+        max_num_tokens = self.max_num_tokens
+        assert max_num_tokens is not None
+        experts_per_worker = self.moe_config.num_local_experts
+        activation_out_dim = self.adjust_N_for_activation(N, activation)
+        padded_m = max_num_tokens * num_dispatchers
+        workspace13 = (experts_per_worker, padded_m, max(N, K))
+        workspace2 = (
+            experts_per_worker,
+            padded_m,
+            max(activation_out_dim, K),
+        )
+        output = (experts_per_worker, padded_m, K)
+        return (workspace13, workspace2, output)
+
+    def _get_permute_scratch(self) -> MoEPermuteScratch | None:
+        return None

--- a/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
@@ -6,6 +6,7 @@ import torch
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm import _custom_ops as ops
+from vllm.forward_context import get_forward_context, is_forward_context_available
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.activation import (
     MoEActivation,
@@ -71,6 +72,80 @@ def _require_w4a8_swigluoai_params(
     return gemm1_alpha, gemm1_beta, gemm1_clamp_limit
 
 
+def _estimate_w4a8_batched_m(
+    total_num_tokens: int,
+    topk: int,
+    global_num_experts: int,
+) -> int:
+    assert total_num_tokens >= 0
+    assert topk > 0
+    assert global_num_experts > 0
+
+    return (
+        total_num_tokens * topk + global_num_experts - 1
+    ) // global_num_experts
+
+
+def _select_w4a8_batched_schedule(
+    total_num_tokens: int,
+    topk: int,
+    global_num_experts: int,
+) -> str:
+    """Select a grouped-GEMM schedule from useful, rather than padded, M."""
+    m_expert = _estimate_w4a8_batched_m(
+        total_num_tokens,
+        topk,
+        global_num_experts,
+    )
+
+    if m_expert <= 1:
+        return "Kernel_128x16_1x1x1_Coop"
+    if m_expert <= 16:
+        return "Kernel_256x16_1x1x1_Coop"
+    if m_expert <= 32:
+        return "Kernel_256x32_1x1x1_Coop"
+    if m_expert <= 64:
+        return "Kernel_256x64_1x1x1_Coop"
+    if m_expert <= 128:
+        return "Kernel_256x128_2x1x1_Coop"
+    return "Kernel_128x256_2x1x1_Coop"
+
+
+def _select_w4a8_compact_programs(
+    total_num_tokens: int,
+    topk: int,
+    global_num_experts: int,
+) -> int:
+    m_expert = _estimate_w4a8_batched_m(
+        total_num_tokens,
+        topk,
+        global_num_experts,
+    )
+    if m_expert <= 16:
+        return 16
+    if m_expert <= 32:
+        return 64
+    if m_expert <= 64:
+        return 128
+    return 256
+
+
+def _w4a8_batched_total_num_tokens(
+    local_num_tokens: int,
+    global_num_experts: int,
+    num_local_experts: int,
+) -> int:
+    dp_metadata = (
+        get_forward_context().dp_metadata if is_forward_context_available() else None
+    )
+    if dp_metadata is not None:
+        return int(dp_metadata.num_tokens_across_dp_cpu.sum().item())
+
+    assert global_num_experts % num_local_experts == 0
+    num_dispatchers = global_num_experts // num_local_experts
+    return local_num_tokens * num_dispatchers
+
+
 @triton.jit
 def _masked_per_token_fp8_quant_kernel(
     src,
@@ -88,13 +163,14 @@ def _masked_per_token_fp8_quant_kernel(
     fp8_max: tl.constexpr,
     min_scale: tl.constexpr,
     block_n: tl.constexpr,
+    programs_per_expert: tl.constexpr,
 ):
     expert = tl.program_id(0)
-    token = tl.program_id(1)
+    lane = tl.program_id(1)
     valid_tokens = tl.load(expert_num_tokens + expert)
-    if token < valid_tokens:
-        offsets = tl.arange(0, block_n)
-        mask = offsets < hidden
+    offsets = tl.arange(0, block_n)
+    mask = offsets < hidden
+    for token in tl.range(lane, valid_tokens, programs_per_expert):
         src_ptr = src + expert * src_stride_e + token * src_stride_m + offsets
         values = tl.load(src_ptr, mask=mask, other=0.0).to(tl.float32)
         absmax = tl.max(tl.abs(values), axis=0)
@@ -128,13 +204,14 @@ def _masked_swigluoai_quant_kernel(
     fp8_max: tl.constexpr,
     min_scale: tl.constexpr,
     block_n: tl.constexpr,
+    programs_per_expert: tl.constexpr,
 ):
     expert = tl.program_id(0)
-    token = tl.program_id(1)
+    lane = tl.program_id(1)
     valid_tokens = tl.load(expert_num_tokens + expert)
-    if token < valid_tokens:
-        offsets = tl.arange(0, block_n)
-        mask = offsets < hidden
+    offsets = tl.arange(0, block_n)
+    mask = offsets < hidden
+    for token in tl.range(lane, valid_tokens, programs_per_expert):
         src_ptr = src + expert * src_stride_e + token * src_stride_m
         gate = tl.load(src_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
         up = tl.load(src_ptr + hidden + offsets, mask=mask, other=0.0).to(tl.float32)
@@ -159,6 +236,7 @@ def _masked_per_token_fp8_quant(
     dst: torch.Tensor,
     scales: torch.Tensor,
     expert_num_tokens: torch.Tensor,
+    programs_per_expert: int = 16,
 ) -> None:
     assert src.dim() == 3 and src.is_contiguous()
     assert src.is_cuda and src.dtype == torch.bfloat16
@@ -169,10 +247,10 @@ def _masked_per_token_fp8_quant(
     assert expert_num_tokens.shape == (src.shape[0],)
     assert expert_num_tokens.is_cuda and expert_num_tokens.dtype == torch.int32
     assert expert_num_tokens.is_contiguous()
-    _, padded_m, hidden = src.shape
+    _, _, hidden = src.shape
     fp8_info = torch.finfo(torch.float8_e4m3fn)
     min_scale = 1.0 / (fp8_info.max * 512.0)
-    _masked_per_token_fp8_quant_kernel[(src.shape[0], padded_m)](
+    _masked_per_token_fp8_quant_kernel[(src.shape[0], programs_per_expert)](
         src,
         dst,
         scales,
@@ -188,6 +266,7 @@ def _masked_per_token_fp8_quant(
         fp8_info.max,
         min_scale,
         triton.next_power_of_2(hidden),
+        programs_per_expert,
         num_warps=8,
     )
 
@@ -200,6 +279,7 @@ def _masked_swigluoai_quant(
     alpha: float,
     beta: float,
     clamp_limit: float,
+    programs_per_expert: int = 16,
 ) -> None:
     assert src.dim() == 3 and src.is_contiguous()
     assert src.is_cuda and src.dtype == torch.bfloat16
@@ -211,11 +291,11 @@ def _masked_swigluoai_quant(
     assert expert_num_tokens.shape == (src.shape[0],)
     assert expert_num_tokens.is_cuda and expert_num_tokens.dtype == torch.int32
     assert expert_num_tokens.is_contiguous()
-    _, padded_m, two_hidden = src.shape
+    _, _, two_hidden = src.shape
     hidden = two_hidden // 2
     fp8_info = torch.finfo(torch.float8_e4m3fn)
     min_scale = 1.0 / (fp8_info.max * 512.0)
-    _masked_swigluoai_quant_kernel[(src.shape[0], padded_m)](
+    _masked_swigluoai_quant_kernel[(src.shape[0], programs_per_expert)](
         src,
         dst,
         scales,
@@ -234,6 +314,7 @@ def _masked_swigluoai_quant(
         fp8_info.max,
         min_scale,
         triton.next_power_of_2(hidden),
+        programs_per_expert,
         num_warps=8,
     )
 
@@ -1406,6 +1487,7 @@ def run_cutlass_moe_w4a8_fp8(
     topk = topk_ids.size(1)
     problem_sizes1 = torch.empty((local_E, 3), dtype=torch.int32, device=device)
     problem_sizes2 = torch.empty((local_E, 3), dtype=torch.int32, device=device)
+    schedule = None
 
     if use_batched_format:
         assert expert_num_tokens is not None
@@ -1424,6 +1506,16 @@ def run_cutlass_moe_w4a8_fp8(
         assert output.shape[2] == K
         assert output.is_contiguous()
         mm1_out = _resize_cache(workspace13, (local_E * padded_M, N * 2))
+        total_num_tokens = _w4a8_batched_total_num_tokens(
+            local_num_tokens=topk_ids.size(0),
+            global_num_experts=global_num_experts,
+            num_local_experts=local_E,
+        )
+        compact_programs = _select_w4a8_compact_programs(
+            total_num_tokens=total_num_tokens,
+            topk=topk,
+            global_num_experts=global_num_experts,
+        )
 
         if a1q.dtype == torch.bfloat16:
             assert a1q_scale is None
@@ -1438,6 +1530,7 @@ def run_cutlass_moe_w4a8_fp8(
                 a1q,
                 a1q_scale,
                 expert_num_tokens,
+                compact_programs,
             )
         else:
             assert a1q.dtype == torch.float8_e4m3fn
@@ -1464,6 +1557,11 @@ def run_cutlass_moe_w4a8_fp8(
         # c3x get_group_gemm_starts expects int64 to avoid overflow during
         # offset calculations. W4A8 offsets are physical padded slabs.
         expert_offsets = expert_offsets.to(torch.int64)
+        schedule = _select_w4a8_batched_schedule(
+            total_num_tokens=total_num_tokens,
+            topk=topk,
+            global_num_experts=global_num_experts,
+        )
     else:
         assert expert_num_tokens is None
         assert a1q_scale is not None
@@ -1511,6 +1609,7 @@ def run_cutlass_moe_w4a8_fp8(
         b_strides1,
         c_strides1,
         s_strides1,
+        schedule,
     )
 
     use_masked_swigluoai = (
@@ -1537,6 +1636,7 @@ def run_cutlass_moe_w4a8_fp8(
             alpha,
             beta,
             clamp_limit,
+            compact_programs,
         )
         a2q = a2q.reshape(local_E * padded_M, N)
         a2q_scale = a2q_scale.reshape(local_E * padded_M, 1)
@@ -1578,6 +1678,7 @@ def run_cutlass_moe_w4a8_fp8(
         b_strides2,
         c_strides2,
         s_strides2,
+        schedule,
     )
 
     if use_batched_format and not use_masked_swigluoai:

--- a/vllm/model_executor/layers/fused_moe/oracle/w4a8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/w4a8.py
@@ -23,6 +23,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 
 if TYPE_CHECKING:
     from vllm.model_executor.layers.fused_moe.experts.cutlass_moe import (
+        CutlassBatchedExpertsW4A8Fp8,
         CutlassExpertsW4A8Fp8,
     )
 
@@ -35,13 +36,14 @@ class W4A8MoeBackend(Enum):
 
 def backend_to_kernel_cls(
     backend: W4A8MoeBackend,
-) -> list[type["CutlassExpertsW4A8Fp8"]]:
+) -> list[type["CutlassExpertsW4A8Fp8"] | type["CutlassBatchedExpertsW4A8Fp8"]]:
     if backend == W4A8MoeBackend.CUTLASS:
         from vllm.model_executor.layers.fused_moe.experts.cutlass_moe import (
+            CutlassBatchedExpertsW4A8Fp8,
             CutlassExpertsW4A8Fp8,
         )
 
-        return [CutlassExpertsW4A8Fp8]
+        return [CutlassExpertsW4A8Fp8, CutlassBatchedExpertsW4A8Fp8]
     else:
         raise ValueError(f"Unknown W4A8 MoE backend: {backend.value}")
 
@@ -187,12 +189,20 @@ def make_w4a8_moe_kernel(
 
     logger.info_once("Using %s", prepare_finalize.__class__.__name__)
 
+    expert_kwargs = {}
+    if prepare_finalize.activation_format == mk.FusedMoEActivationFormat.BatchedExperts:
+        expert_kwargs = {
+            "max_num_tokens": prepare_finalize.max_num_tokens_per_rank(),
+            "num_dispatchers": prepare_finalize.num_dispatchers(),
+        }
+
     experts = experts_cls(
         moe_config=moe_config,
         quant_config=moe_quant_config,
         b_strides1=b_strides1,
         b_strides2=b_strides2,
         group_size=group_size,
+        **expert_kwargs,
     )
 
     return mk.FusedMoEKernel(

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_ht.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_ht.py
@@ -61,6 +61,7 @@ class DeepEPHTPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         self.rank_expert_offset = rank_expert_offset
         self.async_prepare = True
         self.sync_dbo_comm = current_platform.is_rocm()
+        self.num_rdma_ranks = buffer.runtime.get_num_rdma_ranks()
 
         # The dispatch function returns a handle that the combine function
         # requires. Under DBO microbatching we must track one handle per
@@ -115,6 +116,12 @@ class DeepEPHTPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         defer_input_quant: bool,
     ) -> Callable:
         has_scales = token_scales is not None
+        is_capturing = torch.cuda.is_current_stream_capturing()
+        if is_capturing and self.num_rdma_ranks > 1:
+            raise RuntimeError(
+                "DeepEP high-throughput CUDA graph capture only supports "
+                "intranode transport"
+            )
 
         # Capture a DeepEP event on the compute stream before yielding.
         # This must happen before the yield so the event only covers this
@@ -145,6 +152,12 @@ class DeepEPHTPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         if has_scales:
             token_data = (tokens, token_scales)
 
+        num_worst_tokens = 0
+        if is_capturing:
+            # Avoid the CPU receive-count sync during CUDA graph capture.
+            # Every dispatcher can route all of its tokens to this EP rank.
+            num_worst_tokens = tokens.shape[0] * self.num_dispatchers_
+
         (
             token_data,
             expert_topk_ids,
@@ -164,6 +177,7 @@ class DeepEPHTPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
             # expert_alignment rounds the number of tokens per expert
             # to this value.
             expert_alignment=1,
+            num_worst_tokens=num_worst_tokens,
             config=self._get_dispatch_config(),
             previous_event=previous_event,
             async_finish=self.async_prepare and not dbo_enabled(),
@@ -233,8 +247,12 @@ class DeepEPHTPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         # Makes a GPU-CPU copy.
         # TODO (varun): Maybe it is better to re-compute the expert_num_tokens
         # on GPU.
-        expert_tokens_meta = mk.ExpertTokensMetadata.make_from_list(
-            expert_num_tokens_per_expert_list, device=expert_x.device
+        expert_tokens_meta = (
+            mk.ExpertTokensMetadata.make_from_list(
+                expert_num_tokens_per_expert_list, device=expert_x.device
+            )
+            if expert_num_tokens_per_expert_list
+            else None
         )
 
         # * For non-block quant, dispatch in b16 and quantize now as
@@ -245,12 +263,11 @@ class DeepEPHTPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
             # Quantize after dispatch.
             expert_x_scale = None
             if expert_x.numel() != 0:
-                # TODO: support per_act_token_quant,
                 expert_x, expert_x_scale = moe_kernel_quantize_input(
                     expert_x,
                     a1_scale,
                     quant_dtype=quant_config.quant_dtype,
-                    per_act_token_quant=False,
+                    per_act_token_quant=quant_config.per_act_token_quant,
                     block_shape=quant_config.block_shape,
                     is_scale_swizzled=quant_config.is_scale_swizzled,
                 )

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_ll.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_ll.py
@@ -237,12 +237,6 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         quant_config: FusedMoEQuantConfig,
         defer_input_quant: bool = False,
     ) -> tuple[Callable, mk.ReceiverType]:
-        if defer_input_quant:
-            raise NotImplementedError(
-                f"{self.__class__.__name__} does not support defer_input_quant=True. "
-                "Please select an MoE kernel that accepts quantized inputs."
-            )
-
         hidden_size = a1.size(1)
         assert hidden_size in self.SUPPORTED_HIDDEN_SIZES, (
             f"Hidden Size {hidden_size} not in supported list of hidden sizes"
@@ -322,6 +316,7 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
                 quant_config.a1_scale,
                 a1.dtype,
                 quant_config,
+                defer_input_quant,
             ),
         )
 
@@ -332,8 +327,21 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         a1_scale: torch.Tensor | None,
         a1_dtype: torch.dtype,
         quant_config: FusedMoEQuantConfig,
+        defer_input_quant: bool = False,
     ) -> mk.PrepareResultType:
-        expert_x, expert_x_scale = self._do_quant(expert_x, a1_dtype, quant_config)
+        if defer_input_quant:
+            if self.use_fp8_dispatch:
+                assert isinstance(expert_x, tuple)
+                expert_x_fp8, expert_x_scales = expert_x
+                expert_x = dequant_fp8(expert_x_fp8, expert_x_scales).to(dtype=a1_dtype)
+            assert isinstance(expert_x, torch.Tensor)
+            expert_x_scale = None
+        else:
+            expert_x, expert_x_scale = self._do_quant(
+                expert_x,
+                a1_dtype,
+                quant_config,
+            )
 
         expert_tokens_meta = mk.ExpertTokensMetadata(
             expert_num_tokens=expert_num_tokens, expert_num_tokens_cpu=None
@@ -352,11 +360,6 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         quant_config: FusedMoEQuantConfig,
         defer_input_quant: bool = False,
     ) -> mk.PrepareResultType:
-        if defer_input_quant:
-            raise NotImplementedError(
-                f"{self.__class__.__name__} does not support defer_input_quant=True. "
-                "Please select an MoE kernel that accepts quantized inputs."
-            )
         hook, receiver = self.prepare_async(
             a1,
             topk_weights,
@@ -365,6 +368,7 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
             expert_map,
             apply_router_weight_on_input,
             quant_config,
+            defer_input_quant,
         )
         hook()
         return receiver()

--- a/vllm/model_executor/models/mimo_v2.py
+++ b/vllm/model_executor/models/mimo_v2.py
@@ -337,6 +337,7 @@ class MiMoV2Attention(nn.Module):
             attn_backend=attn_backend,
             head_size_v=self.v_head_dim,
         )
+        self.attn.total_num_kv_heads = self.total_num_kv_heads
 
     def forward(
         self,

--- a/vllm/models/minimax_m3/nvidia/model.py
+++ b/vllm/models/minimax_m3/nvidia/model.py
@@ -358,6 +358,7 @@ class MiniMaxM3Attention(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.attn",
         )
+        self.attn.total_num_kv_heads = self.total_num_kv_heads
 
     def forward(
         self,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2883,17 +2883,22 @@ class Scheduler(SchedulerInterface):
         # KV Connector:: update recv and send status from last step.
         for req_id in kv_connector_output.finished_recving or ():
             logger.debug("Finished recving KV transfer for request %s", req_id)
-            assert req_id in self.requests
-            req = self.requests[req_id]
+            req = self.requests.get(req_id)
+            if req is None:
+                logger.debug("Ignoring stale KV recv completion for request %s", req_id)
+                continue
             if req.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
                 self.finished_recving_kv_req_ids.add(req_id)
             else:
                 assert RequestStatus.is_finished(req.status)
-                self._free_blocks(self.requests[req_id])
+                self._free_blocks(req)
         for req_id in kv_connector_output.finished_sending or ():
             logger.debug("Finished sending KV transfer for request %s", req_id)
-            assert req_id in self.requests
-            self._free_blocks(self.requests[req_id])
+            req = self.requests.get(req_id)
+            if req is None:
+                logger.debug("Ignoring stale KV send completion for request %s", req_id)
+                continue
+            self._free_blocks(req)
 
     def _update_requests_with_invalid_blocks(
         self,


### PR DESCRIPTION
## Purpose
- Support DeepEP LL/HT with w4a8 cutlass kerenl. Specifically, we optimized DeepEP LL and achieve over 30% output throughput improvement.
- Fix Mooncake heterogeneous TP KV transfer for replicated KV-head layouts when TP size exceeds num_kv_heads, such as GQA models with TP8 prefill and TP1/TP2 decode. 
- Support prefill PP with cutlass kernel.

## Test Plan & Result
<img width="1597" height="718" alt="Screenshot 2026-08-17 at 15-09-43" src="https://github.com/user-attachments/assets/6263d79f-f7ed-444a-8782-b514605d3690" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

