### PR TITLE
[Feature] Support step-level token bucket schedule

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -580,6 +580,14 @@ def test_human_readable_other_args():
     args = parser.parse_args(["--max-num-scheduled-tokens", "10.5k"])
     assert args.max_num_scheduled_tokens == 10500
 
+    args = parser.parse_args(["--enable-prefill-token-bucket-schedule"])
+    assert args.enable_prefill_token_bucket_schedule
+
+    args = parser.parse_args(
+        ["--prefill-token-bucket-schedule", "4095:8192,16383:4096,-1:8192"]
+    )
+    assert args.prefill_token_bucket_schedule == "4095:8192,16383:4096,-1:8192"
+
     # Test kv_cache_memory_bytes (existing human-readable arg)
     args = parser.parse_args(["--kv-cache-memory-bytes", "100000"])
     assert args.kv_cache_memory_bytes == 100000

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -228,6 +228,43 @@ def test_schedule_multimodal_requests():
         assert len(encoder_input) == 1
 
 
+@pytest.mark.parametrize(
+    ("num_prompt_tokens", "expected_first_chunk"),
+    [
+        (3500, 3500),
+        (8000, 4096),
+        (16383, 4096),
+        (16384, 8192),
+        (32000, 8192),
+    ],
+)
+def test_prefill_token_bucket_schedule(num_prompt_tokens, expected_first_chunk):
+    scheduler = create_scheduler(
+        max_num_batched_tokens=8192,
+        max_model_len=65536,
+        enable_prefill_token_bucket_schedule=True,
+    )
+    (request,) = create_requests(num_requests=1, num_tokens=num_prompt_tokens)
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+
+    assert output.num_scheduled_tokens[request.request_id] == expected_first_chunk
+    assert output.prefill_chunk_stats is not None
+    assert output.prefill_chunk_stats.num_chunks == 1
+    assert output.prefill_chunk_stats.chunk_tokens == [expected_first_chunk]
+
+
+def test_prefill_token_bucket_schedule_disabled_by_default():
+    scheduler = create_scheduler(max_num_batched_tokens=8192, max_model_len=65536)
+    (request,) = create_requests(num_requests=1, num_tokens=8000)
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+
+    assert output.num_scheduled_tokens[request.request_id] == 8000
+
+
 def test_async_scheduling_pp_allows_rescheduling_with_output_placeholders():
     """Async scheduling + PP: allow multi-step in-flight scheduling per request"""
     scheduler = create_scheduler(async_scheduling=True, pipeline_parallel_size=2)

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -265,6 +265,85 @@ def test_prefill_token_bucket_schedule_disabled_by_default():
     assert output.num_scheduled_tokens[request.request_id] == 8000
 
 
+def test_prefill_token_bucket_schedule_limits_step_budget():
+    scheduler = create_scheduler(
+        max_num_batched_tokens=8192,
+        max_model_len=65536,
+        enable_prefill_token_bucket_schedule=True,
+    )
+    req_a, req_b = create_requests(
+        num_requests=2, num_tokens=8000, req_ids=["a", "b"]
+    )
+    scheduler.add_request(req_a)
+    scheduler.add_request(req_b)
+
+    output = scheduler.schedule()
+
+    assert output.num_scheduled_tokens == {"a": 4096}
+    assert sum(output.num_scheduled_tokens.values()) <= 4096
+    assert len(scheduler.waiting) == 1
+
+
+def test_prefill_token_bucket_schedule_keeps_prefill_buckets_homogeneous():
+    scheduler = create_scheduler(
+        max_num_batched_tokens=8192,
+        max_model_len=65536,
+        enable_prefill_token_bucket_schedule=True,
+    )
+    (short_req,) = create_requests(
+        num_requests=1, num_tokens=3500, req_ids=["short"]
+    )
+    (medium_req,) = create_requests(
+        num_requests=1, num_tokens=8000, req_ids=["medium"]
+    )
+    scheduler.add_request(short_req)
+    scheduler.add_request(medium_req)
+
+    output = scheduler.schedule()
+
+    assert output.num_scheduled_tokens == {"short": 3500}
+    assert "medium" not in output.num_scheduled_tokens
+
+    scheduler.finish_requests(short_req.request_id, RequestStatus.FINISHED_ABORTED)
+    output = scheduler.schedule()
+
+    assert output.num_scheduled_tokens == {"medium": 4096}
+
+
+def test_prefill_token_bucket_schedule_allows_decode_in_prefill_step():
+    scheduler = create_scheduler(
+        max_num_batched_tokens=8192,
+        max_model_len=65536,
+        enable_prefill_token_bucket_schedule=True,
+    )
+    (decode_req,) = create_requests(num_requests=1, num_tokens=4, req_ids=["decode"])
+    scheduler.add_request(decode_req)
+    output = scheduler.schedule()
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=["decode"],
+            req_id_to_index={"decode": 0},
+            sampled_token_ids=[[0]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+    assert decode_req in scheduler.running and not decode_req.is_prefill_chunk
+
+    (prefill_req,) = create_requests(
+        num_requests=1, num_tokens=8000, req_ids=["prefill"]
+    )
+    scheduler.add_request(prefill_req)
+
+    output = scheduler.schedule()
+
+    assert output.num_scheduled_tokens["decode"] == 1
+    assert output.num_scheduled_tokens["prefill"] == 4095
+    assert sum(output.num_scheduled_tokens.values()) == 4096
+
+
 def test_async_scheduling_pp_allows_rescheduling_with_output_placeholders():
     """Async scheduling + PP: allow multi-step in-flight scheduling per request"""
     scheduler = create_scheduler(async_scheduling=True, pipeline_parallel_size=2)

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -46,6 +46,8 @@ def create_scheduler(
     model: str = "facebook/opt-125m",
     max_num_seqs: int = 16,
     max_num_batched_tokens: int = 8192,
+    enable_prefill_token_bucket_schedule: bool = False,
+    prefill_token_bucket_schedule: str = "",
     enable_chunked_prefill: bool = True,
     enable_prefix_caching: bool = False,
     long_prefill_token_threshold: int = 0,
@@ -93,6 +95,8 @@ def create_scheduler(
     scheduler_config = SchedulerConfig(
         max_num_seqs=max_num_seqs,
         max_num_batched_tokens=max_num_batched_tokens,
+        enable_prefill_token_bucket_schedule=enable_prefill_token_bucket_schedule,
+        prefill_token_bucket_schedule=prefill_token_bucket_schedule,
         max_model_len=max_model_len,
         long_prefill_token_threshold=long_prefill_token_threshold,
         disable_chunked_mm_input=disable_chunked_mm_input,

--- a/tests/v1/metrics/test_stats.py
+++ b/tests/v1/metrics/test_stats.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from vllm.v1.core.sched.output import ScheduledEncoderInputStats, SchedulerOutput
+from vllm.v1.core.sched.output import (
+    PrefillChunkStats,
+    ScheduledEncoderInputStats,
+    SchedulerOutput,
+)
 from vllm.v1.engine import EngineCoreOutputs, FinishReason
 from vllm.v1.metrics.stats import (
     IterationStats,
@@ -29,6 +33,12 @@ def test_scheduler_iteration_details_serialization():
         elapsed_ms=6.7,
         num_encoder_inputs=2,
         num_encoder_output_tokens=392,
+        prefill_chunks=3,
+        prefill_chunk_tokens=12288,
+        max_prefill_chunk_tokens=4096,
+        prefill_chunk_token_counts=[4096, 4096, 4096],
+        pp_queue_len=2,
+        pp_queue_capacity=2,
     )
     outputs = EngineCoreOutputs(
         scheduler_stats=SchedulerStats(
@@ -56,6 +66,23 @@ def test_compute_iteration_details_includes_encoder_stats():
 
     assert iteration_details.num_encoder_inputs == 2
     assert iteration_details.num_encoder_output_tokens == 392
+
+
+def test_compute_iteration_details_includes_prefill_chunk_stats():
+    scheduler_output = SchedulerOutput.make_empty()
+    scheduler_output.prefill_chunk_stats = PrefillChunkStats(
+        num_chunks=2,
+        total_tokens=8192,
+        max_tokens=4096,
+        chunk_tokens=[4096, 4096],
+    )
+
+    iteration_details = compute_iteration_details(scheduler_output)
+
+    assert iteration_details.prefill_chunks == 2
+    assert iteration_details.prefill_chunk_tokens == 8192
+    assert iteration_details.max_prefill_chunk_tokens == 4096
+    assert iteration_details.prefill_chunk_token_counts == [4096, 4096]
 
 
 def test_prefill_kv_computed_with_cache():

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -62,6 +62,18 @@ class SchedulerConfig:
     max_num_scheduled_tokens_auto_derived: bool = False
     """Whether max_num_scheduled_tokens was derived by vLLM rather than user-set."""
 
+    enable_prefill_token_bucket_schedule: bool = False
+    """If True, apply an experimental prompt-length bucket policy to prefill
+    chunks. Prompts shorter than 4096 tokens are not additionally capped, prompts
+    below 16384 tokens are capped at 4096 scheduled tokens per chunk, and longer
+    prompts are capped at 8192 scheduled tokens per chunk."""
+
+    prefill_token_bucket_schedule: str = ""
+    """Comma-separated prompt length to prefill chunk token budget buckets.
+    Each bucket is formatted as ``max_prompt_tokens:max_chunk_tokens``. Use -1
+    as the last max prompt token for a catch-all bucket. Example:
+    ``4095:8192,16383:4096,-1:8192``."""
+
     max_num_seqs: int = Field(default=DEFAULT_MAX_NUM_SEQS, ge=1)
     """Maximum number of sequences to be processed in a single iteration.
 

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -64,13 +64,13 @@ class SchedulerConfig:
 
     enable_prefill_token_bucket_schedule: bool = False
     """If True, apply an experimental prompt-length bucket policy to prefill
-    chunks. Prompts shorter than 4096 tokens are not additionally capped, prompts
-    below 16384 tokens are capped at 4096 scheduled tokens per chunk, and longer
-    prompts are capped at 8192 scheduled tokens per chunk."""
+    scheduler steps. A step that schedules local prefill work uses the first
+    eligible prefill request as its bucket anchor and only admits prefills from
+    that bucket. Decode requests may still be scheduled in the same step."""
 
     prefill_token_bucket_schedule: str = ""
-    """Comma-separated prompt length to prefill chunk token budget buckets.
-    Each bucket is formatted as ``max_prompt_tokens:max_chunk_tokens``. Use -1
+    """Comma-separated prompt length to prefill step token budget buckets.
+    Each bucket is formatted as ``max_prompt_tokens:max_step_tokens``. Use -1
     as the last max prompt token for a catch-all bucket. Example:
     ``4095:8192,16383:4096,-1:8192``."""
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -527,6 +527,12 @@ class EngineArgs:
     kv_cache_memory_bytes: int | None = CacheConfig.kv_cache_memory_bytes
     max_num_batched_tokens: int | None = None
     max_num_scheduled_tokens: int | None = None
+    enable_prefill_token_bucket_schedule: bool = (
+        SchedulerConfig.enable_prefill_token_bucket_schedule
+    )
+    prefill_token_bucket_schedule: str = (
+        SchedulerConfig.prefill_token_bucket_schedule
+    )
     max_num_partial_prefills: int = SchedulerConfig.max_num_partial_prefills
     max_long_partial_prefills: int = SchedulerConfig.max_long_partial_prefills
     long_prefill_token_threshold: int = SchedulerConfig.long_prefill_token_threshold
@@ -1434,6 +1440,14 @@ class EngineArgs:
             },
         )
         scheduler_group.add_argument(
+            "--enable-prefill-token-bucket-schedule",
+            **scheduler_kwargs["enable_prefill_token_bucket_schedule"],
+        )
+        scheduler_group.add_argument(
+            "--prefill-token-bucket-schedule",
+            **scheduler_kwargs["prefill_token_bucket_schedule"],
+        )
+        scheduler_group.add_argument(
             "--max-num-seqs",
             **{
                 **scheduler_kwargs["max_num_seqs"],
@@ -2182,6 +2196,10 @@ class EngineArgs:
             runner_type=model_config.runner_type,
             max_num_batched_tokens=self.max_num_batched_tokens,
             max_num_scheduled_tokens=self.max_num_scheduled_tokens,
+            enable_prefill_token_bucket_schedule=(
+                self.enable_prefill_token_bucket_schedule
+            ),
+            prefill_token_bucket_schedule=self.prefill_token_bucket_schedule,
             max_num_seqs=self.max_num_seqs,
             max_model_len=model_config.max_model_len,
             enable_chunked_prefill=self.enable_chunked_prefill,

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property
 from typing import TYPE_CHECKING
 
@@ -188,6 +188,16 @@ class ScheduledEncoderInputStats:
 
 
 @dataclass
+class PrefillChunkStats:
+    """Stats for prefill chunks scheduled in one iteration."""
+
+    num_chunks: int = 0
+    total_tokens: int = 0
+    max_tokens: int = 0
+    chunk_tokens: list[int] = field(default_factory=list)
+
+
+@dataclass
 class SchedulerOutput:
     # list of the requests that are scheduled for the first time.
     # We cache the request's data in each worker process, so that we don't
@@ -225,6 +235,7 @@ class SchedulerOutput:
     free_encoder_mm_hashes: list[str]
 
     scheduled_encoder_input_stats: ScheduledEncoderInputStats | None = None
+    prefill_chunk_stats: PrefillChunkStats | None = None
 
     # Request IDs that are preempted in this step.
     # Only used for v2 model runner.
@@ -258,6 +269,10 @@ class SchedulerOutput:
     # Dynamic speculative decoding: optimal K chosen by scheduler.
     # Number of spec tokens to schedule for the next step.
     num_spec_tokens_to_schedule: int = 0
+
+    # Engine-side PP batch queue occupancy sampled when this batch is enqueued.
+    pp_queue_len: int = 0
+    pp_queue_capacity: int = 0
 
     @classmethod
     def make_empty(cls) -> "SchedulerOutput":

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -44,6 +44,7 @@ from vllm.v1.core.sched.output import (
     CachedRequestData,
     GrammarOutput,
     NewRequestData,
+    PrefillChunkStats,
     ScheduledEncoderInputStats,
     SchedulerOutput,
 )
@@ -164,6 +165,14 @@ class Scheduler(SchedulerInterface):
             self.scheduler_config.max_num_scheduled_tokens
             if self.scheduler_config.max_num_scheduled_tokens is not None
             else self.scheduler_config.max_num_batched_tokens
+        )
+        self.enable_prefill_token_bucket_schedule = (
+            self.scheduler_config.enable_prefill_token_bucket_schedule
+        )
+        self.prefill_token_bucket_schedule = (
+            self._parse_prefill_token_bucket_schedule(
+                self.scheduler_config.prefill_token_bucket_schedule
+            )
         )
         self.max_model_len = vllm_config.model_config.max_model_len
         self.enable_kv_cache_events = (
@@ -589,6 +598,58 @@ class Scheduler(SchedulerInterface):
             default_budget=self.max_num_scheduled_tokens,
         )
 
+    def _get_prefill_token_bucket_budget(self, request: Request) -> int | None:
+        if not self.enable_prefill_token_bucket_schedule:
+            return None
+
+        for max_prompt_tokens, chunk_tokens in self.prefill_token_bucket_schedule:
+            if max_prompt_tokens < 0 or request.num_prompt_tokens <= max_prompt_tokens:
+                return min(chunk_tokens, self.scheduler_config.max_num_batched_tokens)
+        return None
+
+    @staticmethod
+    def _parse_prefill_token_bucket_schedule(
+        value: str,
+    ) -> tuple[tuple[int, int], ...]:
+        if not value:
+            return ((4095, 8192), (16383, 4096), (-1, 8192))
+
+        buckets: list[tuple[int, int]] = []
+        for item in value.split(","):
+            item = item.strip()
+            if not item:
+                continue
+            try:
+                max_prompt_tokens_str, chunk_tokens_str = item.split(":", 1)
+                max_prompt_tokens = int(max_prompt_tokens_str)
+                chunk_tokens = int(chunk_tokens_str)
+            except ValueError as exc:
+                raise ValueError(
+                    "prefill_token_bucket_schedule entries must use "
+                    "'max_prompt_tokens:chunk_tokens' format"
+                ) from exc
+            if chunk_tokens <= 0:
+                raise ValueError("prefill token bucket chunk size must be positive")
+            if max_prompt_tokens < -1:
+                raise ValueError(
+                    "prefill token bucket max prompt tokens must be -1 or positive"
+                )
+            buckets.append((max_prompt_tokens, chunk_tokens))
+
+        if not buckets:
+            raise ValueError("prefill_token_bucket_schedule cannot be empty")
+        return tuple(buckets)
+
+    def _apply_prefill_token_bucket_budget(
+        self,
+        request: Request,
+        num_new_tokens: int,
+    ) -> int:
+        bucket_budget = self._get_prefill_token_bucket_budget(request)
+        if bucket_budget is None:
+            return num_new_tokens
+        return min(num_new_tokens, bucket_budget)
+
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
         self.current_step += 1
         # NOTE(woosuk) on the scheduling algorithm:
@@ -685,6 +746,11 @@ class Scheduler(SchedulerInterface):
                     < num_new_tokens
                 ):
                     num_new_tokens = self.scheduler_config.long_prefill_token_threshold
+
+                if request.is_prefill_chunk:
+                    num_new_tokens = self._apply_prefill_token_bucket_budget(
+                        request, num_new_tokens
+                    )
 
                 num_new_tokens = min(num_new_tokens, token_budget)
 
@@ -1069,6 +1135,11 @@ class Scheduler(SchedulerInterface):
                     if 0 < threshold < num_new_tokens:
                         num_new_tokens = threshold
 
+                    if num_computed_tokens < request.num_tokens - 1:
+                        num_new_tokens = self._apply_prefill_token_bucket_budget(
+                            request, num_new_tokens
+                        )
+
                     # chunked prefill has to be enabled explicitly to allow
                     # pooling requests to be chunked
                     if (
@@ -1360,6 +1431,13 @@ class Scheduler(SchedulerInterface):
                 scheduled_encoder_inputs
             )
 
+        prefill_chunk_stats = self._make_prefill_chunk_stats(
+            scheduled_new_reqs,
+            scheduled_running_reqs,
+            scheduled_resumed_reqs,
+            num_scheduled_tokens,
+        )
+
         scheduler_output = SchedulerOutput(
             scheduled_new_reqs=new_reqs_data,
             scheduled_cached_reqs=cached_reqs_data,
@@ -1368,6 +1446,7 @@ class Scheduler(SchedulerInterface):
             scheduled_spec_decode_tokens=scheduled_spec_decode_tokens,
             scheduled_encoder_inputs=scheduled_encoder_inputs,
             scheduled_encoder_input_stats=scheduled_encoder_input_stats,
+            prefill_chunk_stats=prefill_chunk_stats,
             num_common_prefix_blocks=num_common_prefix_blocks,
             preempted_req_ids=self.reset_preempted_req_ids,
             # finished_req_ids is an existing state in the scheduler,
@@ -1776,6 +1855,34 @@ class Scheduler(SchedulerInterface):
                 stats.output_tokens += mm_feature.mm_position.get_num_embeds()
 
         return stats if stats.num_inputs else None
+
+    def _make_prefill_chunk_stats(
+        self,
+        scheduled_new_reqs: list[Request],
+        scheduled_running_reqs: list[Request],
+        scheduled_resumed_reqs: list[Request],
+        num_scheduled_tokens: dict[str, int],
+    ) -> PrefillChunkStats | None:
+        stats = PrefillChunkStats()
+        chunk_tokens: list[int] = []
+        reqs = itertools.chain(
+            scheduled_new_reqs,
+            scheduled_running_reqs,
+            scheduled_resumed_reqs,
+        )
+        for request in reqs:
+            num_tokens = num_scheduled_tokens.get(request.request_id, 0)
+            if num_tokens <= 0:
+                continue
+            if request.num_computed_tokens >= request.num_tokens:
+                continue
+            stats.num_chunks += 1
+            stats.total_tokens += num_tokens
+            stats.max_tokens = max(stats.max_tokens, num_tokens)
+            chunk_tokens.append(num_tokens)
+
+        stats.chunk_tokens = chunk_tokens
+        return stats if stats.num_chunks else None
 
     def get_grammar_bitmask(
         self, scheduler_output: SchedulerOutput

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -598,14 +598,23 @@ class Scheduler(SchedulerInterface):
             default_budget=self.max_num_scheduled_tokens,
         )
 
-    def _get_prefill_token_bucket_budget(self, request: Request) -> int | None:
+    def _get_prefill_token_bucket(self, request: Request) -> tuple[int, int] | None:
         if not self.enable_prefill_token_bucket_schedule:
             return None
 
-        for max_prompt_tokens, chunk_tokens in self.prefill_token_bucket_schedule:
+        for index, (max_prompt_tokens, chunk_tokens) in enumerate(
+            self.prefill_token_bucket_schedule
+        ):
             if max_prompt_tokens < 0 or request.num_prompt_tokens <= max_prompt_tokens:
-                return min(chunk_tokens, self.scheduler_config.max_num_batched_tokens)
+                return (
+                    index,
+                    min(chunk_tokens, self.scheduler_config.max_num_batched_tokens),
+                )
         return None
+
+    def _get_prefill_token_bucket_budget(self, request: Request) -> int | None:
+        bucket = self._get_prefill_token_bucket(request)
+        return None if bucket is None else bucket[1]
 
     @staticmethod
     def _parse_prefill_token_bucket_schedule(
@@ -650,6 +659,33 @@ class Scheduler(SchedulerInterface):
             return num_new_tokens
         return min(num_new_tokens, bucket_budget)
 
+    def _apply_prefill_token_bucket_step_budget(
+        self,
+        request: Request,
+        token_budget: int,
+        base_token_budget: int,
+        prefill_token_bucket_step: tuple[int, int] | None,
+    ) -> tuple[int, tuple[int, int] | None, bool]:
+        bucket = self._get_prefill_token_bucket(request)
+        if bucket is None:
+            return token_budget, prefill_token_bucket_step, True
+
+        bucket_index, bucket_budget = bucket
+        if prefill_token_bucket_step is not None:
+            return (
+                token_budget,
+                prefill_token_bucket_step,
+                bucket_index == prefill_token_bucket_step[0],
+            )
+
+        step_budget = min(bucket_budget, base_token_budget)
+        used_budget = base_token_budget - token_budget
+        remaining_budget = step_budget - used_budget
+        if remaining_budget <= 0:
+            return 0, prefill_token_bucket_step, False
+        token_budget = min(token_budget, remaining_budget)
+        return token_budget, (bucket_index, step_budget), True
+
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
         self.current_step += 1
         # NOTE(woosuk) on the scheduling algorithm:
@@ -672,9 +708,12 @@ class Scheduler(SchedulerInterface):
         num_scheduled_tokens: dict[str, int] = {}
         dynamic_sd_early_k = self._get_dynamic_sd_early_k()
         token_budget = self._get_effective_max_num_scheduled_tokens(dynamic_sd_early_k)
+        base_token_budget = token_budget
+        prefill_token_bucket_step: tuple[int, int] | None = None
         if self._pause_state == PauseState.PAUSED_ALL:
             # Do not schedule any requests when paused.
             token_budget = 0
+            base_token_budget = 0
 
         # Encoder-related.
         scheduled_encoder_inputs: dict[str, list[int]] = {}
@@ -728,6 +767,23 @@ class Scheduler(SchedulerInterface):
                 req_index += 1
                 continue
 
+            request_token_budget = token_budget
+            request_prefill_token_bucket_step = prefill_token_bucket_step
+            if request.is_prefill_chunk:
+                (
+                    request_token_budget,
+                    request_prefill_token_bucket_step,
+                    bucket_matches_step,
+                ) = self._apply_prefill_token_bucket_step_budget(
+                    request,
+                    request_token_budget,
+                    base_token_budget,
+                    request_prefill_token_bucket_step,
+                )
+                if not bucket_matches_step or request_token_budget <= 0:
+                    req_index += 1
+                    continue
+
             is_async_spec_decode = (
                 self.scheduler_config.async_scheduling
                 and self.num_sampled_tokens_per_step > 0
@@ -752,7 +808,7 @@ class Scheduler(SchedulerInterface):
                         request, num_new_tokens
                     )
 
-                num_new_tokens = min(num_new_tokens, token_budget)
+                num_new_tokens = min(num_new_tokens, request_token_budget)
 
                 # Make sure the input position does not exceed the max model len.
                 # This is necessary when using spec decoding.
@@ -875,6 +931,8 @@ class Scheduler(SchedulerInterface):
                 break
 
             # Schedule the request.
+            token_budget = request_token_budget
+            prefill_token_bucket_step = request_prefill_token_bucket_step
             scheduled_running_reqs.append(request)
             prefill_scheduled |= request.is_prefill_chunk
             request_id = request.request_id
@@ -949,6 +1007,8 @@ class Scheduler(SchedulerInterface):
 
                 request = request_queue.peek_request()
                 request_id = request.request_id
+                request_token_budget = token_budget
+                request_prefill_token_bucket_step = prefill_token_bucket_step
 
                 # try to promote blocked statuses while traversing skipped queue.
                 if self._is_blocked_waiting_status(
@@ -1073,6 +1133,27 @@ class Scheduler(SchedulerInterface):
                         step_skipped_waiting.prepend_request(request)
                         continue
 
+                    is_local_prefill = num_computed_tokens < request.num_tokens - 1
+                    if (
+                        not load_kv_async
+                        and not defer_prefills
+                        and is_local_prefill
+                    ):
+                        (
+                            request_token_budget,
+                            request_prefill_token_bucket_step,
+                            bucket_matches_step,
+                        ) = self._apply_prefill_token_bucket_step_budget(
+                            request,
+                            request_token_budget,
+                            base_token_budget,
+                            request_prefill_token_bucket_step,
+                        )
+                        if not bucket_matches_step or request_token_budget <= 0:
+                            request_queue.pop_request()
+                            step_skipped_waiting.prepend_request(request)
+                            continue
+
                     # Track first scheduled prefill, not post-preemption repeat prefills
                     if (
                         request.prefill_stats is not None
@@ -1125,7 +1206,7 @@ class Scheduler(SchedulerInterface):
                     if pad_spec_decode:
                         padded_num_new_tokens = num_new_tokens
                         if (
-                            num_new_tokens > token_budget
+                            num_new_tokens > request_token_budget
                             or num_computed_tokens + num_new_tokens > self.max_model_len
                         ):
                             # Prefer to not schedule than schedule un-padded here.
@@ -1144,13 +1225,13 @@ class Scheduler(SchedulerInterface):
                     # pooling requests to be chunked
                     if (
                         not self.scheduler_config.enable_chunked_prefill
-                        and num_new_tokens > token_budget
+                        and num_new_tokens > request_token_budget
                     ):
                         # If chunked_prefill is disabled,
                         # we can stop the scheduling here.
                         break
 
-                    num_new_tokens = min(num_new_tokens, token_budget)
+                    num_new_tokens = min(num_new_tokens, request_token_budget)
                     assert num_new_tokens > 0
 
                     # Schedule encoder inputs.
@@ -1290,6 +1371,8 @@ class Scheduler(SchedulerInterface):
                         )
                     continue
 
+                token_budget = request_token_budget
+                prefill_token_bucket_step = request_prefill_token_bucket_step
                 self.running.append(request)
                 if self.log_stats:
                     request.record_event(
@@ -1343,10 +1426,12 @@ class Scheduler(SchedulerInterface):
 
         # Check if the scheduling constraints are satisfied.
         total_num_scheduled_tokens = sum(num_scheduled_tokens.values())
-        assert (
-            total_num_scheduled_tokens
-            <= self._get_effective_max_num_scheduled_tokens(dynamic_sd_early_k)
+        max_scheduled_tokens = self._get_effective_max_num_scheduled_tokens(
+            dynamic_sd_early_k
         )
+        if prefill_token_bucket_step is not None:
+            max_scheduled_tokens = min(max_scheduled_tokens, prefill_token_bucket_step[1])
+        assert total_num_scheduled_tokens <= max_scheduled_tokens
 
         assert token_budget >= 0
         assert len(self.running) <= self.max_num_running_reqs

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -518,6 +518,7 @@ class EngineCore:
             return
 
         iteration_index = getattr(self, "_iteration_index", 0)
+        pp_queue_capacity = getattr(self, "batch_queue_size", 0)
         # scheduler_output=None marks a DP dummy iteration.
         if scheduler_output is None:
             iteration_details = SchedulerIterationDetails(
@@ -527,6 +528,7 @@ class EngineCore:
                 num_generation_requests=0,
                 num_generation_tokens=0,
                 elapsed_ms=0.0,
+                pp_queue_capacity=pp_queue_capacity,
                 is_dummy=True,
             )
         else:
@@ -540,6 +542,12 @@ class EngineCore:
                 elapsed_ms=0.0,
                 num_encoder_inputs=details.num_encoder_inputs,
                 num_encoder_output_tokens=details.num_encoder_output_tokens,
+                prefill_chunks=details.prefill_chunks,
+                prefill_chunk_tokens=details.prefill_chunk_tokens,
+                max_prefill_chunk_tokens=details.max_prefill_chunk_tokens,
+                prefill_chunk_token_counts=details.prefill_chunk_token_counts or [],
+                pp_queue_len=scheduler_output.pp_queue_len,
+                pp_queue_capacity=pp_queue_capacity,
             )
 
         start_time = time.monotonic()
@@ -672,6 +680,8 @@ class EngineCore:
             if not deferred_scheduler_output:
                 # Add this step's future to the queue.
                 batch_queue.appendleft((future, scheduler_output, exec_future))
+                scheduler_output.pp_queue_len = len(batch_queue)
+                scheduler_output.pp_queue_capacity = self.batch_queue_size
                 if len(batch_queue) < self.batch_queue_size and (
                     model_executed or self.scheduler.has_requests()
                 ):
@@ -728,6 +738,8 @@ class EngineCore:
             )
             future = self.model_executor.sample_tokens(grammar_output, non_block=True)
             batch_queue.appendleft((future, deferred_scheduler_output, exec_future))
+            deferred_scheduler_output.pp_queue_len = len(batch_queue)
+            deferred_scheduler_output.pp_queue_capacity = self.batch_queue_size
 
         return engine_core_outputs, model_executed
 

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -178,12 +178,25 @@ class LoggingStatLogger(StatLoggerBase):
                 f", encoder inputs: {details.num_encoder_inputs}, "
                 f"encoder output embeddings: {details.num_encoder_output_tokens}"
             )
+        prefill_chunk_msg = ""
+        if details.prefill_chunks:
+            prefill_chunk_msg = (
+                f", prefill chunks: {details.prefill_chunks}, "
+                f"prefill chunk tokens: {details.prefill_chunk_tokens}, "
+                f"max prefill chunk tokens: {details.max_prefill_chunk_tokens}"
+            )
+        pp_queue_msg = ""
+        if details.pp_queue_capacity:
+            pp_queue_msg = (
+                f", PP queue occupancy: {details.pp_queue_len}/"
+                f"{details.pp_queue_capacity}"
+            )
 
         logger.info(
             "%sIteration(%d): %d context requests, %d context tokens, "
             "%d generation requests, %d generation tokens, "
             "iteration elapsed time: %.2f ms%s, "
-            "GPU KV cache usage: %.1f%%%s",
+            "GPU KV cache usage: %.1f%%%s%s%s",
             self._log_prefix_for_engine(engine_idx),
             details.iteration_index,
             details.num_ctx_requests,
@@ -194,6 +207,8 @@ class LoggingStatLogger(StatLoggerBase):
             " (dummy)" if details.is_dummy else "",
             scheduler_stats.kv_cache_usage * 100,
             encoder_msg,
+            prefill_chunk_msg,
+            pp_queue_msg,
         )
 
     def record(
@@ -568,6 +583,28 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             gauge_kv_cache_usage, per_engine_labelvalues
         )
 
+        gauge_pp_batch_queue_occupancy = self._gauge_cls(
+            name="vllm:pp_batch_queue_occupancy",
+            documentation=(
+                "Number of in-flight batches in the pipeline-parallel batch queue."
+            ),
+            multiprocess_mode="mostrecent",
+            labelnames=labelnames,
+        )
+        self.gauge_pp_batch_queue_occupancy = create_metric_per_engine(
+            gauge_pp_batch_queue_occupancy, per_engine_labelvalues
+        )
+
+        gauge_pp_batch_queue_capacity = self._gauge_cls(
+            name="vllm:pp_batch_queue_capacity",
+            documentation="Capacity of the pipeline-parallel batch queue.",
+            multiprocess_mode="mostrecent",
+            labelnames=labelnames,
+        )
+        self.gauge_pp_batch_queue_capacity = create_metric_per_engine(
+            gauge_pp_batch_queue_capacity, per_engine_labelvalues
+        )
+
         if envs.VLLM_COMPUTE_NANS_IN_LOGITS:
             counter_corrupted_requests = self._counter_cls(
                 name="vllm:corrupted_requests",
@@ -710,6 +747,27 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             counter_generation_tokens, per_engine_labelvalues
         )
 
+        gauge_prefill_chunks = self._gauge_cls(
+            name="vllm:prefill_chunks",
+            documentation=(
+                "Number of prefill chunks scheduled in the latest iteration."
+            ),
+            multiprocess_mode="mostrecent",
+            labelnames=labelnames,
+        )
+        self.gauge_prefill_chunks = create_metric_per_engine(
+            gauge_prefill_chunks, per_engine_labelvalues
+        )
+
+        counter_prefill_chunks = self._counter_cls(
+            name="vllm:prefill_chunks_total",
+            documentation="Cumulative number of scheduled prefill chunks.",
+            labelnames=labelnames,
+        )
+        self.counter_prefill_chunks = create_metric_per_engine(
+            counter_prefill_chunks, per_engine_labelvalues
+        )
+
         self.counter_request_success: dict[FinishReason, dict[int, Counter]] = {}
         counter_request_success_base = self._counter_cls(
             name="vllm:request_success",
@@ -758,6 +816,41 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         )
         self.histogram_iteration_tokens = create_metric_per_engine(
             histogram_iteration_tokens, per_engine_labelvalues
+        )
+
+        histogram_prefill_chunk_tokens = self._histogram_cls(
+            name="vllm:prefill_chunk_tokens",
+            documentation="Histogram of tokens per scheduled prefill chunk.",
+            buckets=[1, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384],
+            labelnames=labelnames,
+        )
+        self.histogram_prefill_chunk_tokens = create_metric_per_engine(
+            histogram_prefill_chunk_tokens, per_engine_labelvalues
+        )
+
+        histogram_engine_step_latency = self._histogram_cls(
+            name="vllm:engine_step_latency_seconds",
+            documentation="Histogram of scheduler-visible engine step latency.",
+            buckets=[
+                0.001,
+                0.005,
+                0.01,
+                0.025,
+                0.05,
+                0.1,
+                0.25,
+                0.5,
+                1.0,
+                2.5,
+                5.0,
+                10.0,
+                30.0,
+                60.0,
+            ],
+            labelnames=labelnames,
+        )
+        self.histogram_engine_step_latency = create_metric_per_engine(
+            histogram_engine_step_latency, per_engine_labelvalues
         )
 
         histogram_max_num_generation_tokens_request = self._histogram_cls(
@@ -1121,6 +1214,24 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                 scheduler_stats.num_skipped_waiting_reqs
             )
             self.gauge_kv_cache_usage[engine_idx].set(scheduler_stats.kv_cache_usage)
+            if scheduler_stats.iteration_details is not None:
+                details = scheduler_stats.iteration_details
+                self.gauge_pp_batch_queue_occupancy[engine_idx].set(
+                    details.pp_queue_len
+                )
+                self.gauge_pp_batch_queue_capacity[engine_idx].set(
+                    details.pp_queue_capacity
+                )
+                self.gauge_prefill_chunks[engine_idx].set(details.prefill_chunks)
+                self.counter_prefill_chunks[engine_idx].inc(details.prefill_chunks)
+                for chunk_tokens in details.prefill_chunk_token_counts:
+                    self.histogram_prefill_chunk_tokens[engine_idx].observe(
+                        chunk_tokens
+                    )
+                if details.elapsed_ms:
+                    self.histogram_engine_step_latency[engine_idx].observe(
+                        details.elapsed_ms / 1000.0
+                    )
 
             self.counter_prefix_cache_queries[engine_idx].inc(
                 scheduler_stats.prefix_cache_stats.queries

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -748,7 +748,7 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         )
 
         gauge_prefill_chunks = self._gauge_cls(
-            name="vllm:prefill_chunks",
+            name="vllm:prefill_chunks_per_iteration",
             documentation=(
                 "Number of prefill chunks scheduled in the latest iteration."
             ),

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -179,6 +179,12 @@ class SchedulerIterationDetails:
     elapsed_ms: float
     num_encoder_inputs: int = 0
     num_encoder_output_tokens: int = 0
+    prefill_chunks: int = 0
+    prefill_chunk_tokens: int = 0
+    max_prefill_chunk_tokens: int = 0
+    prefill_chunk_token_counts: list[int] = field(default_factory=list)
+    pp_queue_len: int = 0
+    pp_queue_capacity: int = 0
     is_dummy: bool = False
 
 

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -784,6 +784,10 @@ class IterationDetails:
     num_generation_tokens: int
     num_encoder_inputs: int = 0
     num_encoder_output_tokens: int = 0
+    prefill_chunks: int = 0
+    prefill_chunk_tokens: int = 0
+    max_prefill_chunk_tokens: int = 0
+    prefill_chunk_token_counts: list[int] | None = None
 
     def __repr__(self) -> str:
         return f"IterationDetails(num_ctx_requests={self.num_ctx_requests},\
@@ -791,7 +795,11 @@ class IterationDetails:
                  num_generation_requests={self.num_generation_requests}, \
                  num_generation_tokens={self.num_generation_tokens}, \
                  num_encoder_inputs={self.num_encoder_inputs}, \
-                 num_encoder_output_tokens={self.num_encoder_output_tokens})"
+                 num_encoder_output_tokens={self.num_encoder_output_tokens}, \
+                 prefill_chunks={self.prefill_chunks}, \
+                 prefill_chunk_tokens={self.prefill_chunk_tokens}, \
+                 max_prefill_chunk_tokens={self.max_prefill_chunk_tokens}, \
+                 prefill_chunk_token_counts={self.prefill_chunk_token_counts})"
 
 
 def compute_iteration_details(scheduler_output: SchedulerOutput) -> IterationDetails:
@@ -828,6 +836,16 @@ def compute_iteration_details(scheduler_output: SchedulerOutput) -> IterationDet
     if scheduled_encoder_input_stats is not None:
         num_encoder_inputs = scheduled_encoder_input_stats.num_inputs
         num_encoder_output_tokens = scheduled_encoder_input_stats.output_tokens
+    prefill_chunk_stats = scheduler_output.prefill_chunk_stats
+    prefill_chunks = 0
+    prefill_chunk_tokens = 0
+    max_prefill_chunk_tokens = 0
+    prefill_chunk_token_counts = None
+    if prefill_chunk_stats is not None:
+        prefill_chunks = prefill_chunk_stats.num_chunks
+        prefill_chunk_tokens = prefill_chunk_stats.total_tokens
+        max_prefill_chunk_tokens = prefill_chunk_stats.max_tokens
+        prefill_chunk_token_counts = prefill_chunk_stats.chunk_tokens
 
     return IterationDetails(
         num_context_requests,
@@ -836,4 +854,8 @@ def compute_iteration_details(scheduler_output: SchedulerOutput) -> IterationDet
         num_generation_tokens,
         num_encoder_inputs,
         num_encoder_output_tokens,
+        prefill_chunks,
+        prefill_chunk_tokens,
+        max_prefill_chunk_tokens,
+        prefill_chunk_token_counts,
     )

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -1034,6 +1034,11 @@ class Worker(WorkerBase):
             annotation = "".join(
                 [
                     "execute_",
+                    "pp",
+                    str(get_pp_group().rank_in_group),
+                    "_tp",
+                    str(get_tp_group().rank_in_group),
+                    "_",
                     str(total_scheduled_tokens),
                     "_context_",
                     str(iteration_details.num_ctx_requests),
@@ -1062,6 +1067,11 @@ class Worker(WorkerBase):
             annotation = "".join(
                 [
                     "execute_context_",
+                    "pp",
+                    str(get_pp_group().rank_in_group),
+                    "_tp",
+                    str(get_tp_group().rank_in_group),
+                    "_",
                     str(iteration_details.num_ctx_requests),
                     "(",
                     str(iteration_details.num_ctx_tokens),


### PR DESCRIPTION
## Purpose

Enable prompt-length-aware Prefill chunk scheduling. For MiniMax-M3-W4AFP8 with PP2+TP4, prompts between 4k and 12k tokens can use a 4096-token chunk size to reduce pipeline bubbles, while other prompt lengths continue using the default 8192-token chunk size to avoid regressions.

Example schedule:

```bash
vllm serve /models/MiniMax-M3-W4AFP8 \
  --tensor-parallel-size 4 \
  --pipeline-parallel-size 2 \
  --max-num-batched-tokens 8192 \
  --max-num-scheduled-tokens 8192 \
  --enable-prefill-token-bucket-schedule \
  --prefill-token-bucket-schedule '4095:8192,12287:4096,-1:8192'
```

Meaning：

| Prompt Length | Step token budget |
|---:|---:|
| <= 4095 | 8192 |
| 4096-12287 | 4096 |
| >= 12288 | 8192 |


The feature is disabled by default and does not change existing scheduling behavior unless explicitly enabled.

## Test

Delivers clear performance gains for 6k-12k prompts without regressions at other context lengths：

<img width="1294" height="570" alt="Screenshot 2026-08-28 at 11-18-26" src="https://github.com/user-attachments/assets/ee75dd77-1a40-4a4a-af33-0c3d26f34612" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

