### PR TITLE
Support MiniMax-M3 DCP2 with EAGLE3 in PD

### DIFF
--- a/tests/config/test_dspark_dflash_validation.py
+++ b/tests/config/test_dspark_dflash_validation.py
@@ -11,7 +11,10 @@ from vllm.config import ParallelConfig, SpeculativeConfig, VllmConfig
 pytestmark = pytest.mark.cpu_test
 
 
-def _make_block_size_config(method: str):
+def _make_block_size_config(
+    method: str,
+    draft_model_type: str | None = None,
+):
     return SimpleNamespace(
         cache_config=SimpleNamespace(block_size=16, mamba_cache_mode="none"),
         parallel_config=SimpleNamespace(
@@ -19,7 +22,12 @@ def _make_block_size_config(method: str):
             dcp_kv_cache_interleave_size=1,
             cp_kv_cache_interleave_size=1,
         ),
-        speculative_config=SimpleNamespace(method=method),
+        speculative_config=SimpleNamespace(
+            method=method,
+            draft_model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(model_type=draft_model_type)
+            ),
+        ),
         scheduler_config=SimpleNamespace(),
     )
 
@@ -31,6 +39,26 @@ def test_dcp_rejects_parallel_drafters(method):
     with pytest.raises(
         NotImplementedError,
         match="does not support decode context parallelism",
+    ):
+        VllmConfig.validate_block_size(config)
+
+
+def test_dcp_rejects_draft_model():
+    config = _make_block_size_config("draft_model")
+
+    with pytest.raises(
+        NotImplementedError,
+        match="Draft-model speculative decoding does not support",
+    ):
+        VllmConfig.validate_block_size(config)
+
+
+def test_dcp_rejects_step3_mtp():
+    config = _make_block_size_config("mtp", draft_model_type="step3p5_mtp")
+
+    with pytest.raises(
+        NotImplementedError,
+        match="Step3 MTP speculative decoding does not support",
     ):
         VllmConfig.validate_block_size(config)
 
@@ -51,6 +79,65 @@ def test_explicit_v1_runner_rejected_for_dspark(monkeypatch):
         VllmConfig.use_v2_model_runner.fget(config)
 
 
+def test_v2_runner_rejects_replicated_eagle3_draft_kv():
+    config = SimpleNamespace(
+        model_config=None,
+        speculative_config=SimpleNamespace(
+            method="eagle3",
+            parallel_drafting=False,
+            enable_eagle3_replicated_draft_kv=True,
+        ),
+        parallel_config=SimpleNamespace(
+            prefill_context_parallel_size=1,
+            tensor_parallel_size=8,
+            distributed_executor_backend=None,
+            pipeline_parallel_size=1,
+            enable_dbo=False,
+            enable_elastic_ep=False,
+        ),
+        compilation_config=SimpleNamespace(
+            mode=None,
+            pass_config=SimpleNamespace(enable_sp=False),
+        ),
+        cache_config=SimpleNamespace(kv_sharing_fast_prefill=False),
+        ec_transfer_config=None,
+    )
+
+    unsupported = VllmConfig._get_v2_model_runner_unsupported_features(config)
+
+    assert "EAGLE3 replicated draft KV" in unsupported
+
+
+def test_v2_runner_rejects_eagle3_target_dense_full_temporal_kv():
+    config = SimpleNamespace(
+        model_config=None,
+        speculative_config=SimpleNamespace(
+            method="eagle3",
+            parallel_drafting=False,
+            enable_eagle3_replicated_draft_kv=False,
+            enable_eagle3_target_dense_full_temporal_kv=True,
+        ),
+        parallel_config=SimpleNamespace(
+            prefill_context_parallel_size=1,
+            tensor_parallel_size=8,
+            distributed_executor_backend=None,
+            pipeline_parallel_size=1,
+            enable_dbo=False,
+            enable_elastic_ep=False,
+        ),
+        compilation_config=SimpleNamespace(
+            mode=None,
+            pass_config=SimpleNamespace(enable_sp=False),
+        ),
+        cache_config=SimpleNamespace(kv_sharing_fast_prefill=False),
+        ec_transfer_config=None,
+    )
+
+    unsupported = VllmConfig._get_v2_model_runner_unsupported_features(config)
+
+    assert "EAGLE3 target dense full-temporal KV" in unsupported
+
+
 def test_dspark_allows_static_k_below_checkpoint_block_size(monkeypatch):
     def _fake_draft_model_config(*args, **kwargs):
         hf_config = SimpleNamespace(
@@ -66,9 +153,7 @@ def test_dspark_allows_static_k_below_checkpoint_block_size(monkeypatch):
             max_model_len=kwargs["spec_target_max_model_len"],
         )
 
-    monkeypatch.setattr(
-        "vllm.config.speculative.ModelConfig", _fake_draft_model_config
-    )
+    monkeypatch.setattr("vllm.config.speculative.ModelConfig", _fake_draft_model_config)
 
     target_model_config = SimpleNamespace(
         model="deepseek-ai/DeepSeek-V4",

--- a/tests/config/test_model_arch_config.py
+++ b/tests/config/test_model_arch_config.py
@@ -4,11 +4,14 @@
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
-from transformers import PretrainedConfig
+from transformers import LlamaConfig, PretrainedConfig
 
+import vllm.config.speculative as speculative_config_module
 from vllm.config import ModelConfig, ParallelConfig, SpeculativeConfig
+from vllm.transformers_utils.configs.minimax_m3 import MiniMaxM3TextConfig
 from vllm.transformers_utils.model_arch_config_convertor import (
     ModelArchConfigConvertorBase,
 )
@@ -189,3 +192,265 @@ def test_draft_model_arch_config(
     _assert_model_config_methods(
         model_config, expected, check_head_size=check_head_size
     )
+
+
+def _make_local_llama_model_config(tmp_path: Path) -> ModelConfig:
+    LlamaConfig(
+        architectures=["LlamaForCausalLM"],
+        hidden_size=128,
+        intermediate_size=256,
+        num_attention_heads=8,
+        num_hidden_layers=2,
+        num_key_value_heads=8,
+        vocab_size=32000,
+    ).save_pretrained(tmp_path)
+    return ModelConfig(model=str(tmp_path), runner="generate", max_model_len=100)
+
+
+def test_extract_hidden_states_allows_supported_pipeline_parallel_target(
+    tmp_path,
+    monkeypatch,
+):
+    model_config = _make_local_llama_model_config(tmp_path)
+    model_config.hf_text_config.supports_pp_aux_hidden_state_transport = True
+    monkeypatch.setattr(
+        speculative_config_module.current_platform,
+        "is_cuda",
+        lambda: True,
+    )
+    parallel_config = ParallelConfig(pipeline_parallel_size=2)
+
+    speculative_config = SpeculativeConfig(
+        target_model_config=model_config,
+        target_parallel_config=parallel_config,
+        method="extract_hidden_states",
+        num_speculative_tokens=1,
+        draft_model_config={
+            "hf_config": {
+                "eagle_aux_hidden_state_layer_ids": [1, 2, 3],
+            }
+        },
+    )
+
+    assert MiniMaxM3TextConfig.supports_pp_aux_hidden_state_transport
+    assert speculative_config.draft_parallel_config is parallel_config
+
+
+def test_extract_hidden_states_rejects_unsupported_pipeline_parallel_target(
+    tmp_path,
+    monkeypatch,
+):
+    model_config = _make_local_llama_model_config(tmp_path)
+    monkeypatch.setattr(
+        speculative_config_module.current_platform,
+        "is_cuda",
+        lambda: True,
+    )
+
+    with pytest.raises(
+        NotImplementedError,
+        match="does not support pipeline-parallel auxiliary hidden-state transport",
+    ):
+        SpeculativeConfig(
+            target_model_config=model_config,
+            target_parallel_config=ParallelConfig(pipeline_parallel_size=2),
+            method="extract_hidden_states",
+            num_speculative_tokens=1,
+            draft_model_config={
+                "hf_config": {
+                    "eagle_aux_hidden_state_layer_ids": [1, 2, 3],
+                }
+            },
+        )
+
+
+def test_extract_hidden_states_rejects_non_cuda_pipeline_parallel_target(
+    tmp_path,
+    monkeypatch,
+):
+    model_config = _make_local_llama_model_config(tmp_path)
+    model_config.hf_text_config.supports_pp_aux_hidden_state_transport = True
+    monkeypatch.setattr(
+        speculative_config_module.current_platform,
+        "is_cuda",
+        lambda: False,
+    )
+
+    with pytest.raises(
+        NotImplementedError,
+        match="does not support pipeline-parallel auxiliary hidden-state transport",
+    ):
+        SpeculativeConfig(
+            target_model_config=model_config,
+            target_parallel_config=ParallelConfig(pipeline_parallel_size=2),
+            method="extract_hidden_states",
+            num_speculative_tokens=1,
+            draft_model_config={
+                "hf_config": {
+                    "eagle_aux_hidden_state_layer_ids": [1, 2, 3],
+                }
+            },
+        )
+
+
+def _prefill_draft_kv_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        method="eagle3",
+        num_speculative_tokens=1,
+        target_model_config=SimpleNamespace(
+            architectures=["MiniMaxM3SparseForConditionalGeneration"],
+            get_total_num_hidden_layers=lambda: 60,
+        ),
+        target_parallel_config=SimpleNamespace(
+            pipeline_parallel_size=2,
+            tensor_parallel_size=4,
+            decode_context_parallel_size=1,
+        ),
+        parallel_drafting=False,
+        uses_dynamic_speculative_decoding=lambda: False,
+        draft_model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(
+                num_hidden_layers=1,
+                num_attention_heads=64,
+                num_key_value_heads=64,
+                head_dim=128,
+            )
+        ),
+        draft_parallel_config=SimpleNamespace(tensor_parallel_size=4),
+    )
+
+
+def test_minimax_eagle3_prefill_draft_kv_accepts_supported_config(
+    monkeypatch,
+) -> None:
+    config = _prefill_draft_kv_config()
+    monkeypatch.setattr(
+        speculative_config_module.current_platform,
+        "is_cuda",
+        lambda: True,
+    )
+
+    SpeculativeConfig._verify_eagle3_prefill_draft_kv(config)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected"),
+    [
+        ("method", "eagle", "method must be eagle3"),
+        ("num_speculative_tokens", 3, "num_speculative_tokens must be 1"),
+    ],
+)
+def test_minimax_eagle3_prefill_draft_kv_rejects_unsupported_config(
+    monkeypatch,
+    field: str,
+    value,
+    expected: str,
+) -> None:
+    config = _prefill_draft_kv_config()
+    setattr(config, field, value)
+    monkeypatch.setattr(
+        speculative_config_module.current_platform,
+        "is_cuda",
+        lambda: True,
+    )
+
+    with pytest.raises(ValueError, match=expected):
+        SpeculativeConfig._verify_eagle3_prefill_draft_kv(config)
+
+
+def _replicated_draft_kv_config(dcp_size: int = 2) -> SimpleNamespace:
+    return SimpleNamespace(
+        method="eagle3",
+        num_speculative_tokens=3,
+        target_model_config=SimpleNamespace(
+            architectures=["MiniMaxM3SparseForConditionalGeneration"],
+            get_total_num_hidden_layers=lambda: 60,
+        ),
+        target_parallel_config=SimpleNamespace(
+            pipeline_parallel_size=1,
+            tensor_parallel_size=8,
+            decode_context_parallel_size=dcp_size,
+            prefill_context_parallel_size=1,
+            data_parallel_size=1,
+            use_ubatching=False,
+        ),
+        parallel_drafting=False,
+        uses_dynamic_speculative_decoding=lambda: False,
+        draft_model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(
+                num_hidden_layers=1,
+                num_attention_heads=64,
+                num_key_value_heads=64,
+                head_dim=128,
+            )
+        ),
+        draft_parallel_config=SimpleNamespace(tensor_parallel_size=8),
+    )
+
+
+@pytest.mark.parametrize("dcp_size", [1, 2])
+def test_minimax_eagle3_replicated_draft_kv_accepts_supported_config(
+    monkeypatch,
+    dcp_size: int,
+) -> None:
+    config = _replicated_draft_kv_config(dcp_size)
+    monkeypatch.setattr(
+        speculative_config_module.current_platform,
+        "is_cuda",
+        lambda: True,
+    )
+
+    SpeculativeConfig._verify_eagle3_replicated_draft_kv(config)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected"),
+    [
+        ("num_speculative_tokens", 1, "num_speculative_tokens must be 3"),
+        (
+            "target_parallel_config.decode_context_parallel_size",
+            3,
+            "decode_context_parallel_size must be 1 or 2",
+        ),
+    ],
+)
+def test_minimax_eagle3_replicated_draft_kv_rejects_unsupported_config(
+    monkeypatch,
+    field: str,
+    value,
+    expected: str,
+) -> None:
+    config = _replicated_draft_kv_config()
+    target = config
+    parts = field.split(".")
+    for part in parts[:-1]:
+        target = getattr(target, part)
+    setattr(target, parts[-1], value)
+    monkeypatch.setattr(
+        speculative_config_module.current_platform,
+        "is_cuda",
+        lambda: True,
+    )
+
+    with pytest.raises(ValueError, match=expected):
+        SpeculativeConfig._verify_eagle3_replicated_draft_kv(config)
+
+
+def test_minimax_eagle3_target_dense_full_temporal_kv_defers_execution_mode() -> None:
+    eager_config = SimpleNamespace(
+        enable_eagle3_replicated_draft_kv=True,
+        target_model_config=SimpleNamespace(enforce_eager=True),
+    )
+    SpeculativeConfig._verify_eagle3_target_dense_full_temporal_kv(eager_config)
+
+    graph_config = SimpleNamespace(
+        enable_eagle3_replicated_draft_kv=True,
+        target_model_config=SimpleNamespace(enforce_eager=False),
+    )
+    SpeculativeConfig._verify_eagle3_target_dense_full_temporal_kv(graph_config)
+
+    prefill_graph_config = SimpleNamespace(
+        enable_eagle3_replicated_draft_kv=False,
+        target_model_config=SimpleNamespace(enforce_eager=False),
+    )
+    SpeculativeConfig._verify_eagle3_target_dense_full_temporal_kv(prefill_graph_config)

--- a/tests/distributed/test_cp_mapping.py
+++ b/tests/distributed/test_cp_mapping.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.distributed.cp_mapping import (
+    get_cp_global_position,
+    get_cp_local_position,
+    get_cp_local_seq_len,
+    get_cp_local_seq_lens,
+    get_cp_token_owner,
+    get_suffix_global_page_range,
+    global_page_to_local_page,
+    iter_owned_suffix_pages,
+    local_page_to_global_page,
+    map_cp_positions,
+)
+
+BOUNDARY_LENGTHS = (0, 1, 127, 128, 129, 255, 256, 257, 3563, 3564)
+
+
+@pytest.mark.parametrize("cp_world_size", (1, 2, 4))
+@pytest.mark.parametrize("interleave_size", (1, 128))
+@pytest.mark.parametrize("seq_len", BOUNDARY_LENGTHS)
+def test_token_mapping_is_bijective_and_complete(
+    cp_world_size: int,
+    interleave_size: int,
+    seq_len: int,
+) -> None:
+    local_positions = [[] for _ in range(cp_world_size)]
+
+    for global_position in range(seq_len):
+        owner = get_cp_token_owner(
+            global_position,
+            cp_world_size,
+            interleave_size,
+        )
+        local_position = get_cp_local_position(
+            global_position,
+            cp_world_size,
+            interleave_size,
+        )
+        assert (
+            get_cp_global_position(
+                owner,
+                local_position,
+                cp_world_size,
+                interleave_size,
+            )
+            == global_position
+        )
+        local_positions[owner].append(local_position)
+
+    for cp_rank, positions in enumerate(local_positions):
+        assert positions == list(range(len(positions)))
+        assert len(positions) == get_cp_local_seq_len(
+            seq_len,
+            cp_world_size,
+            cp_rank,
+            interleave_size,
+        )
+    assert sum(map(len, local_positions)) == seq_len
+
+
+@pytest.mark.parametrize("cp_world_size", (1, 2, 4))
+@pytest.mark.parametrize("interleave_size", (1, 128))
+def test_tensor_mapping_matches_scalar_oracle(
+    cp_world_size: int,
+    interleave_size: int,
+) -> None:
+    positions = torch.tensor(BOUNDARY_LENGTHS[1:], dtype=torch.int64) - 1
+
+    owners, local_positions = map_cp_positions(
+        positions,
+        cp_world_size,
+        interleave_size,
+    )
+
+    assert owners.tolist() == [
+        get_cp_token_owner(int(position), cp_world_size, interleave_size)
+        for position in positions
+    ]
+    assert local_positions.tolist() == [
+        get_cp_local_position(int(position), cp_world_size, interleave_size)
+        for position in positions
+    ]
+
+
+@pytest.mark.parametrize("cp_world_size", (1, 2, 4))
+@pytest.mark.parametrize("interleave_size", (1, 128))
+def test_tensor_local_lengths_match_scalar_oracle(
+    cp_world_size: int,
+    interleave_size: int,
+) -> None:
+    seq_lens = torch.tensor(BOUNDARY_LENGTHS, dtype=torch.int64)
+
+    all_ranks = get_cp_local_seq_lens(
+        seq_lens,
+        cp_world_size=cp_world_size,
+        interleave_size=interleave_size,
+    )
+    assert all_ranks.shape == (len(BOUNDARY_LENGTHS), cp_world_size)
+    assert torch.equal(
+        all_ranks.sum(dim=-1),
+        seq_lens.to(torch.int32),
+    )
+
+    for cp_rank in range(cp_world_size):
+        expected = [
+            get_cp_local_seq_len(
+                seq_len,
+                cp_world_size,
+                cp_rank,
+                interleave_size,
+            )
+            for seq_len in BOUNDARY_LENGTHS
+        ]
+        assert all_ranks[:, cp_rank].tolist() == expected
+        assert (
+            get_cp_local_seq_lens(
+                seq_lens,
+                cp_world_size=cp_world_size,
+                cp_rank=cp_rank,
+                interleave_size=interleave_size,
+            ).tolist()
+            == expected
+        )
+
+
+@pytest.mark.parametrize("cp_world_size", (1, 2, 4))
+def test_page_mapping_is_bijective(cp_world_size: int) -> None:
+    for global_page in range(32):
+        owner, local_page = global_page_to_local_page(
+            global_page,
+            cp_world_size,
+            page_size=128,
+            interleave_size=128,
+        )
+        assert (
+            local_page_to_global_page(
+                owner,
+                local_page,
+                cp_world_size,
+                page_size=128,
+                interleave_size=128,
+            )
+            == global_page
+        )
+
+
+@pytest.mark.parametrize(
+    ("total_tokens", "external_start_token", "expected"),
+    [
+        (0, 0, []),
+        (1, 0, [0]),
+        (128, 0, [0]),
+        (129, 128, [1]),
+        (257, 127, [0, 1, 2]),
+        (3563, 256, list(range(2, 28))),
+        (3564, 3563, [27]),
+    ],
+)
+def test_suffix_global_page_range(
+    total_tokens: int,
+    external_start_token: int,
+    expected: list[int],
+) -> None:
+    assert (
+        list(
+            get_suffix_global_page_range(
+                total_tokens,
+                external_start_token,
+                page_size=128,
+            )
+        )
+        == expected
+    )
+
+
+def test_owned_suffix_pages_partition_global_pages() -> None:
+    expected = list(get_suffix_global_page_range(3564, 127, page_size=128))
+    owned = [
+        pair
+        for rank in range(2)
+        for pair in iter_owned_suffix_pages(
+            total_tokens=3564,
+            external_start_token=127,
+            cp_world_size=2,
+            cp_rank=rank,
+            page_size=128,
+            interleave_size=128,
+        )
+    ]
+
+    assert sorted(global_page for global_page, _ in owned) == expected
+    assert len({global_page for global_page, _ in owned}) == len(expected)
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda: get_cp_token_owner(0, 0, 128),
+        lambda: get_cp_local_position(-1, 2, 128),
+        lambda: get_cp_global_position(2, 0, 2, 128),
+        lambda: global_page_to_local_page(0, 2, 64, 128),
+        lambda: get_suffix_global_page_range(1, 2, 128),
+    ],
+)
+def test_invalid_mapping_contract_fails_closed(call) -> None:
+    with pytest.raises(ValueError):
+        call()

--- a/tests/models/minimax_m3/test_dcp_contract.py
+++ b/tests/models/minimax_m3/test_dcp_contract.py
@@ -196,10 +196,10 @@ class _FakeDCPGroup:
 
 
 @pytest.mark.parametrize(
-    ("rank", "score", "expected", "aligned"),
+    ("rank", "score", "expected"),
     [
-        (0, [1.0, 9.0, 3.0], [1, -1, -1], [1, -1, -1]),
-        (1, [8.0, 2.0, 7.0], [-1, 0, 2], [-1, 0, 2]),
+        (0, [1.0, 9.0, 3.0], [1, -1, -1]),
+        (1, [8.0, 2.0, 7.0], [-1, 0, 2]),
     ],
 )
 def test_dcp_global_topk_localizes_selected_owners(
@@ -207,7 +207,6 @@ def test_dcp_global_topk_localizes_selected_owners(
     rank: int,
     score: list[float],
     expected: list[int],
-    aligned: list[int],
 ) -> None:
     # Rank 0 owns global blocks 0/2/4; rank 1 owns 1/3/5.
     # The global top-3 is {2, 1, 5}.
@@ -247,8 +246,6 @@ def test_dcp_global_topk_localizes_selected_owners(
     )
 
     assert result.tolist() == [[expected]]
-    assert impl._dcp_canonical_global_topk.tolist() == [[[2, 1, 5]]]
-    assert impl._dcp_aligned_local_topk.tolist() == [[aligned]]
 
 
 def test_dcp_topk_uses_strict_lexicographic_order() -> None:

--- a/tests/models/minimax_m3/test_dcp_contract.py
+++ b/tests/models/minimax_m3/test_dcp_contract.py
@@ -1,0 +1,475 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import MethodType, SimpleNamespace
+
+import pytest
+import torch
+
+import vllm.models.minimax_m3.common.indexer as indexer
+import vllm.models.minimax_m3.common.sparse_attention as sparse_attention
+import vllm.models.minimax_m3.nvidia.model as minimax_model
+from vllm.sequence import IntermediateTensors
+
+
+class _SM100Platform:
+    @staticmethod
+    def is_cuda() -> bool:
+        return True
+
+    @staticmethod
+    def is_device_capability_family(family: int) -> bool:
+        return family == 100
+
+
+def test_sm100_dcp_forces_triton_backends(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = SimpleNamespace(
+        parallel_config=SimpleNamespace(decode_context_parallel_size=2)
+    )
+    monkeypatch.setattr(indexer, "get_current_vllm_config", lambda: config)
+    monkeypatch.setattr(sparse_attention, "get_current_vllm_config", lambda: config)
+    monkeypatch.setattr(indexer, "current_platform", _SM100Platform())
+    monkeypatch.setattr(sparse_attention, "current_platform", _SM100Platform())
+
+    indexer_impl_cls = indexer.select_indexer_impl_cls(
+        topk_blocks=16,
+        indexer_kv_dtype="bf16",
+    )
+    main_impl_cls = sparse_attention.select_main_impl_cls(
+        topk_blocks=16,
+        kv_cache_dtype="bfloat16",
+        num_kv_heads=1,
+    )
+
+    assert indexer_impl_cls is indexer.MiniMaxM3IndexerTritonImpl
+    assert main_impl_cls is sparse_attention.MiniMaxM3SparseTritonImpl
+    with pytest.raises(NotImplementedError, match="requires the BF16 Triton indexer"):
+        indexer.select_indexer_impl_cls(
+            topk_blocks=16,
+            indexer_kv_dtype="fp8",
+        )
+
+
+@pytest.mark.parametrize(
+    ("target_parity_enabled", "expected"),
+    [(False, False), (True, True)],
+)
+def test_target_parity_flag_enables_sparse_bf16_partials(
+    monkeypatch: pytest.MonkeyPatch,
+    target_parity_enabled: bool,
+    expected: bool,
+) -> None:
+    monkeypatch.setattr(
+        "vllm.distributed.parallel_state.get_dcp_group",
+        lambda: SimpleNamespace(world_size=2, rank_in_group=0),
+    )
+    monkeypatch.setattr(
+        sparse_attention,
+        "get_current_vllm_config",
+        lambda: SimpleNamespace(
+            parallel_config=SimpleNamespace(
+                cp_kv_cache_interleave_size=128,
+                dcp_comm_backend="a2a",
+            ),
+            speculative_config=SimpleNamespace(
+                enable_eagle3_target_dense_full_temporal_kv=(target_parity_enabled)
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        sparse_attention.current_platform,
+        "is_device_capability",
+        lambda capability: capability == 90,
+    )
+
+    impl = sparse_attention.MiniMaxM3SparseTritonImpl(
+        num_heads=8,
+        head_size=128,
+        scale=1.0,
+        num_kv_heads=1,
+        kv_cache_dtype="fp8",
+        topk_blocks=16,
+        sparse_block_size=128,
+    )
+
+    assert impl.dcp_bf16_partials is expected
+
+
+class _FakeDCPGroup:
+    def __init__(self, gathered: torch.Tensor) -> None:
+        self.gathered = gathered
+
+    def all_gather(self, input_: torch.Tensor, dim: int) -> torch.Tensor:
+        assert input_.shape == (1, 1, 3, 3)
+        assert dim == 2
+        return self.gathered.clone()
+
+
+@pytest.mark.parametrize(
+    ("rank", "score", "expected", "aligned"),
+    [
+        (0, [1.0, 9.0, 3.0], [1, -1, -1], [1, -1, -1]),
+        (1, [8.0, 2.0, 7.0], [-1, 0, 2], [-1, 0, 2]),
+    ],
+)
+def test_dcp_global_topk_localizes_selected_owners(
+    monkeypatch: pytest.MonkeyPatch,
+    rank: int,
+    score: list[float],
+    expected: list[int],
+    aligned: list[int],
+) -> None:
+    # Rank 0 owns global blocks 0/2/4; rank 1 owns 1/3/5.
+    # The global top-3 is {2, 1, 5}.
+    gathered = torch.tensor(
+        [
+            [
+                [
+                    [9.0, 2.0, 0.0],
+                    [3.0, 4.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                    [8.0, 1.0, 0.0],
+                    [7.0, 5.0, 0.0],
+                    [2.0, 3.0, 0.0],
+                ]
+            ]
+        ],
+        dtype=torch.float32,
+    )
+    monkeypatch.setattr(indexer, "get_dcp_group", lambda: _FakeDCPGroup(gathered))
+
+    impl = SimpleNamespace(
+        dcp_world_size=2,
+        dcp_rank=rank,
+        block_size=128,
+        init_blocks=0,
+        local_blocks=0,
+        topk_blocks=3,
+    )
+    out = torch.empty((1, 1, 3), dtype=torch.int32)
+
+    result = indexer.MiniMaxM3IndexerTritonImpl._select_dcp_global_topk(
+        impl,
+        torch.tensor(score, dtype=torch.float32).view(1, 1, 3),
+        torch.tensor([6 * 128], dtype=torch.int32),
+        out,
+        max_local_blocks=3,
+    )
+
+    assert result.tolist() == [[expected]]
+    assert impl._dcp_canonical_global_topk.tolist() == [[[2, 1, 5]]]
+    assert impl._dcp_aligned_local_topk.tolist() == [[aligned]]
+
+
+def test_dcp_topk_uses_strict_lexicographic_order() -> None:
+    scores = torch.tensor([[[5.0, 5.0, 999.0, 5.0]]])
+    global_ids = torch.tensor([[[3, 1, 2, 0]]], dtype=torch.int32)
+    tiers = torch.tensor([[[0, 0, 2, 1]]], dtype=torch.int32)
+
+    _, selected_ids, selected_tiers = indexer._stable_lexicographic_topk(
+        scores,
+        global_ids,
+        tiers,
+        4,
+    )
+
+    assert selected_ids.tolist() == [[[2, 0, 1, 3]]]
+    assert selected_tiers.tolist() == [[[2, 1, 0, 0]]]
+
+
+def test_decoder_layer_toggles_dense_and_moe_ffn_reduction() -> None:
+    dense = SimpleNamespace(
+        is_moe_layer=False,
+        mlp=SimpleNamespace(down_proj=SimpleNamespace(reduce_results=False)),
+    )
+    moe = SimpleNamespace(
+        is_moe_layer=True,
+        block_sparse_moe=SimpleNamespace(
+            experts=SimpleNamespace(
+                moe_config=SimpleNamespace(skip_final_all_reduce=True)
+            )
+        ),
+    )
+
+    minimax_model.MiniMaxM3DecoderLayer.set_ffn_all_reduce_deferred(dense, False)
+    minimax_model.MiniMaxM3DecoderLayer.set_ffn_all_reduce_deferred(moe, False)
+    assert dense.mlp.down_proj.reduce_results
+    assert not moe.block_sparse_moe.experts.moe_config.skip_final_all_reduce
+
+    minimax_model.MiniMaxM3DecoderLayer.set_ffn_all_reduce_deferred(dense, True)
+    minimax_model.MiniMaxM3DecoderLayer.set_ffn_all_reduce_deferred(moe, True)
+    assert not dense.mlp.down_proj.reduce_results
+    assert moe.block_sparse_moe.experts.moe_config.skip_final_all_reduce
+
+
+class _FakeDecoderLayer:
+    def __init__(self, deferred: bool) -> None:
+        self.deferred = deferred
+        self.fuse_input_allreduce = False
+
+    @property
+    def ffn_all_reduce_deferred(self) -> bool:
+        return self.deferred
+
+    def set_ffn_all_reduce_deferred(self, defer: bool) -> None:
+        self.deferred = defer
+
+
+class _MutatingFirstLayer:
+    def __call__(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        assert residual is None
+        residual = hidden_states
+        residual.add_(10)
+        return hidden_states, residual
+
+
+class _IncrementLayer:
+    def __call__(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if residual is None:
+            residual = torch.zeros_like(hidden_states)
+        return hidden_states + 1, residual
+
+
+def test_eagle_input_boundary_survives_first_layer_aliasing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        minimax_model,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+    model = SimpleNamespace(
+        aux_hidden_state_layers=(0,),
+        start_layer=0,
+        end_layer=1,
+        layers=[_MutatingFirstLayer()],
+        fuse_final_norm_allreduce=False,
+        norm=lambda hidden_states, residual: (hidden_states, residual),
+    )
+    model._maybe_add_hidden_state = lambda states, idx, hidden, residual: (
+        minimax_model.EagleModelMixin._maybe_add_hidden_state(
+            model, states, idx, hidden, residual
+        )
+    )
+    inputs = torch.tensor([[1.0, 2.0]])
+
+    _, aux_hidden_states = minimax_model.MiniMaxM3Model.forward(
+        model,
+        input_ids=None,
+        positions=torch.zeros(1, dtype=torch.int64),
+        intermediate_tensors=None,
+        inputs_embeds=inputs,
+    )
+
+    assert inputs.tolist() == [[11.0, 12.0]]
+    assert aux_hidden_states[0].tolist() == [[1.0, 2.0]]
+    assert aux_hidden_states[0].data_ptr() != inputs.data_ptr()
+
+
+@pytest.mark.parametrize(
+    ("start_layer", "end_layer", "expected_local", "expected_input_keys"),
+    [
+        (0, 30, (2, 30), ("hidden_states", "residual")),
+        (
+            30,
+            60,
+            (27,),
+            (
+                "hidden_states",
+                "residual",
+                "aux_hidden_state_2",
+                "aux_hidden_state_30",
+            ),
+        ),
+    ],
+)
+def test_eagle_aux_boundaries_map_global_to_pp_local(
+    start_layer: int,
+    end_layer: int,
+    expected_local: tuple[int, ...],
+    expected_input_keys: tuple[str, ...],
+) -> None:
+    model = SimpleNamespace(
+        start_layer=start_layer,
+        end_layer=end_layer,
+        layers=[None] * 60,
+        config=SimpleNamespace(hidden_size=2),
+    )
+    model._configure_deferred_allreduce = lambda boundaries: setattr(
+        model, "configured_boundaries", boundaries
+    )
+    make_empty_intermediate_tensors = MethodType(
+        minimax_model.MiniMaxM3Model.make_empty_intermediate_tensors,
+        model,
+    )
+
+    minimax_model.MiniMaxM3Model._set_aux_hidden_state_layers(model, (2, 30, 57))
+
+    assert model.aux_hidden_state_layers == (2, 30, 57)
+    assert model.configured_boundaries == expected_local
+    empty = make_empty_intermediate_tensors(
+        batch_size=1,
+        dtype=torch.bfloat16,
+        device=torch.device("cpu"),
+    )
+    assert tuple(empty.tensors) == expected_input_keys
+
+
+def test_eagle_aux_states_cross_pp_boundary_in_config_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pp_group = SimpleNamespace(is_first_rank=True, is_last_rank=False)
+    monkeypatch.setattr(minimax_model, "get_pp_group", lambda: pp_group)
+
+    layers = [_IncrementLayer() for _ in range(60)]
+
+    def make_partition(start_layer: int, end_layer: int) -> SimpleNamespace:
+        model = SimpleNamespace(
+            start_layer=start_layer,
+            end_layer=end_layer,
+            layers=layers,
+            aux_hidden_state_layers=(2, 30, 57),
+            fuse_final_norm_allreduce=False,
+            norm=lambda hidden, residual: (hidden + residual, None),
+        )
+        model._maybe_add_hidden_state = lambda states, idx, hidden, residual: (
+            minimax_model.EagleModelMixin._maybe_add_hidden_state(
+                model, states, idx, hidden, residual
+            )
+        )
+        return model
+
+    positions = torch.zeros(1, dtype=torch.int64)
+    inputs = torch.zeros((1, 1))
+    stage0 = make_partition(0, 30)
+    stage0_output = minimax_model.MiniMaxM3Model.forward(
+        stage0,
+        input_ids=None,
+        positions=positions,
+        intermediate_tensors=None,
+        inputs_embeds=inputs,
+    )
+
+    assert isinstance(stage0_output, IntermediateTensors)
+    assert tuple(stage0_output.tensors) == (
+        "hidden_states",
+        "residual",
+        "aux_hidden_state_2",
+        "aux_hidden_state_30",
+    )
+
+    pp_group.is_first_rank = False
+    pp_group.is_last_rank = True
+    stage1 = make_partition(30, 60)
+    _, pp_aux = minimax_model.MiniMaxM3Model.forward(
+        stage1,
+        input_ids=None,
+        positions=positions,
+        intermediate_tensors=stage0_output,
+    )
+
+    pp_group.is_first_rank = True
+    reference = make_partition(0, 60)
+    _, reference_aux = minimax_model.MiniMaxM3Model.forward(
+        reference,
+        input_ids=None,
+        positions=positions,
+        intermediate_tensors=None,
+        inputs_embeds=inputs,
+    )
+
+    assert len(pp_aux) == len(reference_aux) == 3
+    for actual, expected in zip(pp_aux, reference_aux):
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_minimax_pp_output_without_aux_states_is_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        minimax_model,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=False),
+    )
+    model = SimpleNamespace(
+        start_layer=0,
+        end_layer=1,
+        layers=[_IncrementLayer()],
+        aux_hidden_state_layers=(),
+    )
+    model._maybe_add_hidden_state = lambda states, idx, hidden, residual: (
+        minimax_model.EagleModelMixin._maybe_add_hidden_state(
+            model, states, idx, hidden, residual
+        )
+    )
+
+    output = minimax_model.MiniMaxM3Model.forward(
+        model,
+        input_ids=None,
+        positions=torch.zeros(1, dtype=torch.int64),
+        intermediate_tensors=None,
+        inputs_embeds=torch.zeros((1, 1)),
+    )
+
+    assert isinstance(output, IntermediateTensors)
+    assert tuple(output.tensors) == ("hidden_states", "residual")
+
+
+def test_eagle_aux_boundaries_reconfigure_deferred_allreduce() -> None:
+    layers = [
+        _FakeDecoderLayer(True),
+        _FakeDecoderLayer(False),
+        _FakeDecoderLayer(True),
+        _FakeDecoderLayer(True),
+    ]
+    model = SimpleNamespace(
+        layers=layers,
+        start_layer=0,
+        end_layer=len(layers),
+        config=SimpleNamespace(hidden_size=2),
+        _original_ffn_all_reduce_deferred=(True, False, True, True),
+    )
+    model._configure_deferred_allreduce = lambda boundaries: (
+        minimax_model.MiniMaxM3Model._configure_deferred_allreduce(model, boundaries)
+    )
+
+    minimax_model.MiniMaxM3Model._set_aux_hidden_state_layers(model, (0, 2, 4))
+    assert model.aux_hidden_state_layers == (0, 2, 4)
+    assert [layer.deferred for layer in layers] == [True, False, True, False]
+    assert [layer.fuse_input_allreduce for layer in layers] == [
+        False,
+        True,
+        False,
+        True,
+    ]
+    assert not model.fuse_final_norm_allreduce
+
+    minimax_model.MiniMaxM3Model._set_aux_hidden_state_layers(model, (1,))
+    assert [layer.deferred for layer in layers] == [False, False, True, True]
+    assert [layer.fuse_input_allreduce for layer in layers] == [
+        False,
+        False,
+        False,
+        True,
+    ]
+    assert model.fuse_final_norm_allreduce
+
+    minimax_model.MiniMaxM3Model._set_aux_hidden_state_layers(model, ())
+    assert [layer.deferred for layer in layers] == [True, False, True, True]
+    assert [layer.fuse_input_allreduce for layer in layers] == [
+        False,
+        True,
+        False,
+        True,
+    ]
+    assert model.fuse_final_norm_allreduce

--- a/tests/models/minimax_m3/test_dcp_contract.py
+++ b/tests/models/minimax_m3/test_dcp_contract.py
@@ -95,6 +95,96 @@ def test_target_parity_flag_enables_sparse_bf16_partials(
     assert impl.dcp_bf16_partials is expected
 
 
+@pytest.mark.parametrize(
+    ("dcp_size", "is_mtp_block", "expected"),
+    [
+        (1, False, False),
+        (2, True, False),
+        (2, False, True),
+    ],
+)
+def test_dcp_q_replication_follows_production_topology(
+    monkeypatch: pytest.MonkeyPatch,
+    dcp_size: int,
+    is_mtp_block: bool,
+    expected: bool,
+) -> None:
+    config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=8,
+            decode_context_parallel_size=dcp_size,
+            prefill_context_parallel_size=1,
+            dcp_comm_backend="a2a",
+        )
+    )
+    monkeypatch.setattr(minimax_model, "current_platform", _SM100Platform())
+
+    assert (
+        minimax_model._use_dcp_replicated_q_proj(
+            config,
+            is_mtp_block=is_mtp_block,
+        )
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("tensor_parallel_size", 4),
+        ("decode_context_parallel_size", 4),
+        ("prefill_context_parallel_size", 2),
+        ("dcp_comm_backend", "ag_rs"),
+    ],
+)
+def test_dcp_q_replication_rejects_unvalidated_topologies(
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: object,
+) -> None:
+    topology = {
+        "tensor_parallel_size": 8,
+        "decode_context_parallel_size": 2,
+        "prefill_context_parallel_size": 1,
+        "dcp_comm_backend": "a2a",
+    }
+    topology[field] = value
+    config = SimpleNamespace(parallel_config=SimpleNamespace(**topology))
+    monkeypatch.setattr(minimax_model, "current_platform", _SM100Platform())
+
+    with pytest.raises(NotImplementedError, match="TP8/DCP2/PCP1"):
+        minimax_model._use_dcp_replicated_q_proj(
+            config,
+            is_mtp_block=False,
+        )
+
+
+def test_dcp_q_replication_passes_q_shard_rank_to_v2_loader() -> None:
+    linear = object.__new__(minimax_model.MinimaxM3QKVParallelLinearWithIndexer)
+    linear.head_size = 4
+    linear.num_heads = 8
+    linear.num_kv_heads = 1
+    linear.num_index_heads = 1
+    linear.index_head_size = 4
+    linear.tp_size = 8
+    linear.num_kv_head_replicas = 2
+    linear.q_shard_rank = 3
+    calls: dict[str, object] = {}
+    param = SimpleNamespace(
+        load_qkv_weight=lambda **kwargs: calls.update(kwargs),
+    )
+
+    linear.weight_loader_v2(
+        param,
+        torch.empty((256, 4)),
+        loaded_shard_id="q",
+    )
+
+    assert calls["shard_rank"] == 3
+    assert calls["shard_size"] == 32
+    assert calls["shard_offset"] == 0
+
+
 class _FakeDCPGroup:
     def __init__(self, gathered: torch.Tensor) -> None:
         self.gathered = gathered

--- a/tests/models/test_llama_eagle3.py
+++ b/tests/models/test_llama_eagle3.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.model_executor.models.llama_eagle3 import (
+    _get_eagle3_target_layer_count,
+)
+
+
+def _config(*, prefill_draft_kv: bool, total_layers: int, local_layers: int):
+    return SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            enable_eagle3_prefill_draft_kv=prefill_draft_kv
+        ),
+        model_config=SimpleNamespace(
+            get_total_num_hidden_layers=lambda: total_layers,
+            get_num_layers=lambda _: local_layers,
+        ),
+        parallel_config=SimpleNamespace(),
+    )
+
+
+def test_eagle3_prefill_draft_uses_global_target_layer_count() -> None:
+    config = _config(
+        prefill_draft_kv=True,
+        total_layers=60,
+        local_layers=30,
+    )
+
+    assert _get_eagle3_target_layer_count(config) == 60
+
+
+def test_eagle3_default_path_keeps_local_target_layer_count() -> None:
+    config = _config(
+        prefill_draft_kv=False,
+        total_layers=60,
+        local_layers=30,
+    )
+
+    assert _get_eagle3_target_layer_count(config) == 30
+
+
+def test_eagle3_prefill_draft_rejects_non_minimax_layer_count() -> None:
+    config = _config(
+        prefill_draft_kv=True,
+        total_layers=30,
+        local_layers=15,
+    )
+
+    with pytest.raises(ValueError, match="60 global target layers"):
+        _get_eagle3_target_layer_count(config)

--- a/tests/v1/attention/test_flash_attn_dcp_fp8.py
+++ b/tests/v1/attention/test_flash_attn_dcp_fp8.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import vllm.v1.attention.backends.flash_attn as flash_attn
+from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheTemporalLayout,
+)
+
+
+def test_full_temporal_builder_uses_global_dcp1_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "vllm.distributed.parallel_state.get_dcp_group",
+        lambda: SimpleNamespace(world_size=2, rank_in_group=1),
+    )
+    monkeypatch.setattr(flash_attn, "get_flash_attn_version", lambda: 2)
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            get_num_attention_heads=lambda _parallel_config: 8,
+            get_num_kv_heads=lambda _parallel_config: 1,
+            get_head_size=lambda: 128,
+            rswa_window=None,
+        ),
+        parallel_config=SimpleNamespace(cp_kv_cache_interleave_size=128),
+        cache_config=SimpleNamespace(cache_dtype="fp8"),
+        compilation_config=SimpleNamespace(
+            cudagraph_mode=SimpleNamespace(
+                has_full_cudagraphs=lambda: False,
+            ),
+            max_cudagraph_capture_size=None,
+        ),
+        attention_config=SimpleNamespace(),
+    )
+    spec = FullAttentionSpec(
+        block_size=128,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.float8_e4m3fn,
+        temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL,
+    )
+    builder = flash_attn.FlashAttentionMetadataBuilder(
+        spec,
+        ["language_model.model.layers.0.self_attn.attn"],
+        config,
+        torch.device("cpu"),
+    )
+    common = CommonAttentionMetadata(
+        query_start_loc=torch.tensor([0, 4], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 4], dtype=torch.int32),
+        seq_lens=torch.tensor([260], dtype=torch.int32),
+        _seq_lens_cpu=torch.tensor([260], dtype=torch.int32),
+        seq_lens_cpu_upper_bound=torch.tensor([260], dtype=torch.int32),
+        num_reqs=1,
+        num_actual_tokens=4,
+        max_query_len=4,
+        max_seq_len=260,
+        block_table_tensor=torch.tensor([[6, 7, 10]], dtype=torch.int32),
+        slot_mapping=torch.tensor([895, 896, 1023, 1280]),
+    )
+
+    metadata = builder.build(0, common)
+
+    assert builder.dcp_world_size == 1
+    assert builder.dcp_rank == 0
+    assert metadata.dcp_context_kv_lens is None
+    assert metadata.max_dcp_context_kv_len == 0
+    assert torch.equal(metadata.block_table, common.block_table_tensor)
+    assert torch.equal(metadata.slot_mapping, common.slot_mapping)
+
+
+@pytest.mark.parametrize(
+    ("scale", "expected_group_shape"),
+    [
+        (torch.tensor(0.5), None),
+        (torch.tensor([0.5, 1.5]), (-1, 4)),
+    ],
+)
+def test_quantize_dcp_live_kv_uses_static_scale(
+    monkeypatch: pytest.MonkeyPatch,
+    scale: torch.Tensor,
+    expected_group_shape: tuple[int, int] | None,
+) -> None:
+    calls = []
+    fp8_dtype = flash_attn.current_platform.fp8_dtype()
+
+    def fake_scaled_fp8_quant(
+        tensor: torch.Tensor,
+        actual_scale: torch.Tensor,
+        *,
+        group_shape: tuple[int, int] | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        calls.append(
+            (
+                tensor.shape,
+                tensor.stride(),
+                tensor.is_contiguous(),
+                actual_scale,
+                group_shape,
+            )
+        )
+        return torch.empty_like(tensor, dtype=fp8_dtype), actual_scale
+
+    monkeypatch.setattr(
+        flash_attn.ops,
+        "scaled_fp8_quant",
+        fake_scaled_fp8_quant,
+    )
+    impl = object.__new__(flash_attn.FlashAttentionImpl)
+    qkv = torch.randn(3, 16, dtype=torch.bfloat16)
+    tensor = qkv[:, 4:12].view(3, 2, 4)
+    assert not tensor.is_contiguous()
+
+    result = impl._quantize_dcp_live_kv(tensor, scale)
+
+    assert result.shape == tensor.shape
+    assert result.dtype == fp8_dtype
+    assert calls == [
+        (
+            torch.Size([3, 8]),
+            (16, 1),
+            False,
+            scale,
+            expected_group_shape,
+        )
+    ]
+
+
+def test_quantize_dcp_live_kv_does_not_requantize_fp8(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("already-FP8 live K/V must not be requantized")
+
+    monkeypatch.setattr(
+        flash_attn.ops,
+        "scaled_fp8_quant",
+        fail_if_called,
+    )
+    impl = object.__new__(flash_attn.FlashAttentionImpl)
+    tensor = torch.empty(
+        3,
+        2,
+        4,
+        dtype=flash_attn.current_platform.fp8_dtype(),
+    )
+
+    result = impl._quantize_dcp_live_kv(tensor, torch.tensor([0.5, 1.5]))
+
+    assert result is tensor

--- a/tests/v1/attention/test_indexer_dcp_localize.py
+++ b/tests/v1/attention/test_indexer_dcp_localize.py
@@ -829,6 +829,40 @@ def test_correct_attn_out_zeroes_empty_nan_partial(is_lse_base_on_e: bool):
 
 
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
+def test_correct_attn_out_writes_fp32_workspace():
+    out = torch.tensor([[[1.0, -2.0, 3.0, -4.0]]], dtype=torch.bfloat16, device="cuda")
+    inplace_out = out.clone()
+    corrected_out = torch.empty_like(out, dtype=torch.float32)
+    lses = torch.tensor(
+        [[[0.0]], [[float("-inf")]]],
+        dtype=torch.float32,
+        device="cuda",
+    )
+    ctx = CPTritonContext()
+
+    inplace, _ = correct_attn_out(
+        inplace_out,
+        lses,
+        cp_rank=0,
+        ctx=ctx,
+    )
+    corrected, final_lse = correct_attn_out(
+        out,
+        lses,
+        cp_rank=0,
+        ctx=ctx,
+        corrected_out=corrected_out,
+    )
+    torch.accelerator.synchronize()
+
+    assert inplace is inplace_out
+    torch.testing.assert_close(inplace, out)
+    assert corrected is corrected_out
+    torch.testing.assert_close(corrected, out.float())
+    torch.testing.assert_close(final_lse, torch.zeros_like(final_lse))
+
+
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="This test requires CUDA")
 def test_decode_topk_pads_surplus_with_negative_one():
     """When a row's valid length < topk the top-k kernel must pad the surplus
     slots with -1: the DCP merge (`topk_indices >= 0`) and

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -4,6 +4,7 @@ import copy
 import hashlib
 import importlib
 from collections.abc import Callable
+from dataclasses import replace
 from types import SimpleNamespace
 from typing import Any
 
@@ -32,6 +33,7 @@ from vllm.v1.core.kv_cache_utils import (
     generate_scheduler_kv_cache_config,
     get_kv_cache_capacity,
     get_kv_cache_configs,
+    get_kv_cache_groups,
     get_max_concurrency_for_kv_cache_config,
     get_request_block_hasher,
     group_and_unify_kv_cache_specs,
@@ -48,6 +50,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     KVCacheSpec,
     KVCacheSpecKind,
+    KVCacheTemporalLayout,
     KVCacheTensor,
     KVQuantMode,
     MambaSpec,
@@ -1653,6 +1656,390 @@ def test_get_max_concurrency_packed_kv_cache_config():
     assert get_max_concurrency_for_kv_cache_config(
         vllm_config, kv_cache_config_packed
     ) == num_blocks / (1024 + 73)
+
+
+@pytest.mark.parametrize("dcp_size", [1, 2])
+def test_replicated_eagle_draft_kv_accounting(dcp_size: int):
+    target_spec = new_kv_cache_spec(
+        block_size=128,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.float8_e4m3fn,
+    )
+    draft_spec = replace(
+        new_kv_cache_spec(
+            block_size=128,
+            num_kv_heads=8,
+            head_size=128,
+            dtype=torch.float8_e4m3fn,
+        ),
+        temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL,
+    )
+    specs = {
+        "model.layers.0.self_attn.attn": target_spec,
+        "model.layers.60.self_attn.attn": draft_spec,
+    }
+    uniform_spec = UniformTypeKVCacheSpecs(
+        block_size=128,
+        kv_cache_specs=specs,
+    )
+    groups = [KVCacheGroupSpec(list(specs), uniform_spec)]
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            method="eagle3",
+            enable_eagle3_replicated_draft_kv=True,
+        ),
+        model_config=SimpleNamespace(
+            max_model_len=512,
+            get_total_num_hidden_layers=lambda: 60,
+        ),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=dcp_size),
+        cache_config=SimpleNamespace(num_gpu_blocks_override=None),
+    )
+
+    bytes_per_parent = (
+        target_spec.page_size_bytes + dcp_size * draft_spec.page_size_bytes
+    )
+    assert kv_cache_utils._pool_bytes_per_block(vllm_config, groups) == bytes_per_parent
+    assert (
+        kv_cache_utils._max_memory_usage_bytes_from_groups(vllm_config, groups)
+        == (4 // dcp_size) * bytes_per_parent
+    )
+
+    config = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config,
+        groups,
+        available_memory=10 * bytes_per_parent,
+    )
+    assert config.num_blocks == 10
+    tensor_sizes = {
+        tensor.shared_by[0]: tensor.size for tensor in config.kv_cache_tensors
+    }
+    assert tensor_sizes["model.layers.0.self_attn.attn"] == (
+        10 * target_spec.page_size_bytes
+    )
+    assert tensor_sizes["model.layers.60.self_attn.attn"] == (
+        10 * dcp_size * draft_spec.page_size_bytes
+    )
+
+
+def test_prefill_eagle_draft_kv_keeps_identity_page_allocation():
+    target_spec = new_kv_cache_spec(block_size=128)
+    draft_spec = replace(
+        new_kv_cache_spec(
+            block_size=128,
+            num_kv_heads=16,
+            head_size=128,
+        ),
+        temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL,
+    )
+    specs = {
+        "model.layers.30.self_attn.attn": target_spec,
+        "model.layers.60.self_attn.attn": draft_spec,
+    }
+    groups = [
+        KVCacheGroupSpec(
+            list(specs),
+            UniformTypeKVCacheSpecs(
+                block_size=128,
+                kv_cache_specs=specs,
+            ),
+        )
+    ]
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            method="eagle3",
+            enable_eagle3_prefill_draft_kv=True,
+            enable_eagle3_replicated_draft_kv=False,
+        ),
+        model_config=SimpleNamespace(
+            get_total_num_hidden_layers=lambda: 60,
+        ),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=1),
+        cache_config=SimpleNamespace(num_gpu_blocks_override=None),
+    )
+    bytes_per_parent = target_spec.page_size_bytes + draft_spec.page_size_bytes
+
+    config = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config,
+        groups,
+        available_memory=10 * bytes_per_parent,
+    )
+    tensor_sizes = {
+        tensor.shared_by[0]: tensor.size for tensor in config.kv_cache_tensors
+    }
+
+    assert config.num_blocks == 10
+    assert tensor_sizes["model.layers.30.self_attn.attn"] == (
+        10 * target_spec.page_size_bytes
+    )
+    assert tensor_sizes["model.layers.60.self_attn.attn"] == (
+        10 * draft_spec.page_size_bytes
+    )
+
+
+@pytest.mark.parametrize("layer_prefix", ["language_model.model", "model"])
+@pytest.mark.parametrize("dcp_size", [1, 2])
+def test_target_dense_and_draft_full_temporal_accounting(
+    layer_prefix: str,
+    dcp_size: int,
+):
+    target_specs = {
+        f"{layer_prefix}.layers.{layer}.self_attn.attn": replace(
+            new_kv_cache_spec(block_size=128),
+            temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL,
+        )
+        for layer in range(3)
+    }
+    sparse_spec = new_kv_cache_spec(block_size=128)
+    draft_spec = replace(
+        new_kv_cache_spec(
+            block_size=128,
+            num_kv_heads=8,
+            head_size=128,
+        ),
+        temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL,
+    )
+    specs = {
+        **target_specs,
+        f"{layer_prefix}.layers.3.self_attn.attn": sparse_spec,
+        "model.layers.60.self_attn.attn": draft_spec,
+    }
+    groups = [
+        KVCacheGroupSpec(
+            list(specs),
+            UniformTypeKVCacheSpecs(
+                block_size=128,
+                kv_cache_specs=specs,
+            ),
+        )
+    ]
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            method="eagle3",
+            enable_eagle3_prefill_draft_kv=False,
+            enable_eagle3_replicated_draft_kv=True,
+            enable_eagle3_target_dense_full_temporal_kv=True,
+        ),
+        model_config=SimpleNamespace(
+            get_total_num_hidden_layers=lambda: 60,
+        ),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=dcp_size),
+        cache_config=SimpleNamespace(num_gpu_blocks_override=None),
+    )
+    bytes_per_parent = sum(spec.page_size_bytes for spec in specs.values()) + (
+        dcp_size - 1
+    ) * sum(spec.page_size_bytes for spec in (*target_specs.values(), draft_spec))
+
+    config = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config,
+        groups,
+        available_memory=10 * bytes_per_parent,
+    )
+    tensor_sizes = {
+        tensor.shared_by[0]: tensor.size for tensor in config.kv_cache_tensors
+    }
+
+    assert config.num_blocks == 10
+    for layer_name, spec in target_specs.items():
+        assert tensor_sizes[layer_name] == (10 * dcp_size * spec.page_size_bytes)
+    assert tensor_sizes[f"{layer_prefix}.layers.3.self_attn.attn"] == (
+        10 * sparse_spec.page_size_bytes
+    )
+    assert tensor_sizes["model.layers.60.self_attn.attn"] == (
+        10 * dcp_size * draft_spec.page_size_bytes
+    )
+
+
+def test_prefill_eagle_draft_kv_allows_non_draft_pp_stage():
+    target_spec = new_kv_cache_spec(block_size=128)
+    groups = [
+        KVCacheGroupSpec(
+            ["model.layers.0.self_attn.attn"],
+            target_spec,
+        )
+    ]
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            enable_eagle3_prefill_draft_kv=True,
+            enable_eagle3_replicated_draft_kv=False,
+        ),
+        model_config=SimpleNamespace(
+            get_total_num_hidden_layers=lambda: 60,
+        ),
+    )
+
+    assert (
+        kv_cache_utils._get_eagle_full_temporal_layers(
+            vllm_config,
+            groups,
+        )
+        == []
+    )
+
+
+def test_full_temporal_draft_keeps_shared_parent_allocator_group():
+    target_spec = new_kv_cache_spec(block_size=128)
+    draft_spec = replace(
+        new_kv_cache_spec(
+            block_size=128,
+            num_kv_heads=8,
+            head_size=128,
+        ),
+        temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL,
+    )
+    specs = {
+        "model.layers.0.self_attn.attn": target_spec,
+        "model.layers.60.self_attn.attn": draft_spec,
+    }
+    groups = get_kv_cache_groups(
+        SimpleNamespace(
+            scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False)
+        ),
+        specs,
+    )
+
+    assert len(groups) == 1
+    assert isinstance(groups[0].kv_cache_spec, UniformTypeKVCacheSpecs)
+    assert groups[0].layer_names == list(specs)
+    assert groups[0].kv_cache_spec.kv_cache_specs == specs
+
+
+def test_replicated_eagle_draft_kv_requires_explicit_full_temporal_spec():
+    target_spec = new_kv_cache_spec(block_size=128)
+    draft_spec = new_kv_cache_spec(
+        block_size=128,
+        num_kv_heads=8,
+        head_size=128,
+    )
+    specs = {
+        "model.layers.0.self_attn.attn": target_spec,
+        "model.layers.60.self_attn.attn": draft_spec,
+    }
+    groups = [
+        KVCacheGroupSpec(
+            list(specs),
+            UniformTypeKVCacheSpecs(
+                block_size=128,
+                kv_cache_specs=specs,
+            ),
+        )
+    ]
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            method="eagle3",
+            enable_eagle3_replicated_draft_kv=True,
+        ),
+        model_config=SimpleNamespace(
+            get_total_num_hidden_layers=lambda: 60,
+        ),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=2),
+    )
+
+    with pytest.raises(ValueError, match="Unexpected FULL_TEMPORAL"):
+        kv_cache_utils._get_eagle_full_temporal_layers(
+            vllm_config,
+            groups,
+        )
+
+
+def test_replicated_eagle_draft_kv_override_counts_parent_blocks():
+    target_spec = new_kv_cache_spec(block_size=128)
+    draft_spec = replace(
+        new_kv_cache_spec(
+            block_size=128,
+            num_kv_heads=8,
+            head_size=128,
+        ),
+        temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL,
+    )
+    specs = {
+        "model.layers.0.self_attn.attn": target_spec,
+        "model.layers.60.self_attn.attn": draft_spec,
+    }
+    groups = [
+        KVCacheGroupSpec(
+            list(specs),
+            UniformTypeKVCacheSpecs(
+                block_size=128,
+                kv_cache_specs=specs,
+            ),
+        )
+    ]
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            method="eagle3",
+            enable_eagle3_replicated_draft_kv=True,
+        ),
+        model_config=SimpleNamespace(
+            get_total_num_hidden_layers=lambda: 60,
+        ),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=2),
+        cache_config=SimpleNamespace(num_gpu_blocks_override=7),
+    )
+
+    config = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config,
+        groups,
+        available_memory=1,
+    )
+    tensor_sizes = {
+        tensor.shared_by[0]: tensor.size for tensor in config.kv_cache_tensors
+    }
+    assert config.num_blocks == 7
+    assert tensor_sizes["model.layers.0.self_attn.attn"] == (
+        7 * target_spec.page_size_bytes
+    )
+    assert tensor_sizes["model.layers.60.self_attn.attn"] == (
+        14 * draft_spec.page_size_bytes
+    )
+
+
+def test_replicated_eagle_draft_kv_feature_off_preserves_allocation():
+    target_spec = new_kv_cache_spec(block_size=128)
+    draft_spec = new_kv_cache_spec(
+        block_size=128,
+        num_kv_heads=8,
+        head_size=128,
+    )
+    specs = {
+        "model.layers.0.self_attn.attn": target_spec,
+        "model.layers.60.self_attn.attn": draft_spec,
+    }
+    groups = [
+        KVCacheGroupSpec(
+            list(specs),
+            UniformTypeKVCacheSpecs(
+                block_size=128,
+                kv_cache_specs=specs,
+            ),
+        )
+    ]
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(
+            method="eagle3",
+            enable_eagle3_replicated_draft_kv=False,
+        ),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=2),
+        cache_config=SimpleNamespace(num_gpu_blocks_override=None),
+    )
+    bytes_per_parent = target_spec.page_size_bytes + draft_spec.page_size_bytes
+
+    config = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config,
+        groups,
+        available_memory=10 * bytes_per_parent,
+    )
+    tensor_sizes = {
+        tensor.shared_by[0]: tensor.size for tensor in config.kv_cache_tensors
+    }
+    assert config.num_blocks == 10
+    assert tensor_sizes["model.layers.0.self_attn.attn"] == (
+        10 * target_spec.page_size_bytes
+    )
+    assert tensor_sizes["model.layers.60.self_attn.attn"] == (
+        10 * draft_spec.page_size_bytes
+    )
 
 
 def test_allocate_with_lookahead():

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3648,6 +3648,44 @@ def test_can_fit_full_sequence_full_attention_still_gates_oversized():
     assert manager.allocate_slots(req, block_size, full_sequence_must_fit=True) is None
 
 
+def test_full_sequence_admission_includes_reserved_blocks():
+    block_size = 16
+    num_blocks = 10  # 9 usable after reserving the null block.
+    config = make_kv_cache_config(block_size, num_blocks)
+    manager = make_kv_cache_manager(
+        config,
+        max_model_len=16 * block_size,
+        enable_caching=False,
+        hash_block_size=block_size,
+    )
+    req = make_request("reserved", list(range(block_size)), block_size, sha256)
+
+    # The request needs six blocks through completion. Four blocks reserved for
+    # active requests leave only five available, so admission must wait.
+    assert (
+        manager.allocate_slots(
+            req,
+            block_size,
+            full_sequence_must_fit=True,
+            full_sequence_num_tokens=6 * block_size,
+            reserved_blocks=4,
+        )
+        is None
+    )
+
+    # Reducing the reservation by one makes the same full sequence fit exactly.
+    assert (
+        manager.allocate_slots(
+            req,
+            block_size,
+            full_sequence_must_fit=True,
+            full_sequence_num_tokens=6 * block_size,
+            reserved_blocks=3,
+        )
+        is not None
+    )
+
+
 def test_cache_hit_local_and_external():
     # Regression test for #33775: when a request hits the local prefix cache
     # in one KV cache group and needs external (connector) blocks in another,

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import dataclasses
 from concurrent.futures import Future
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
@@ -1082,6 +1083,246 @@ def test_preempt_during_execution():
     # sampled token id.
     assert len(requests[1].output_token_ids) == 1
     assert requests[1].output_token_ids[0] == 42
+
+
+def test_decode_only_dcp_running_allocation_failure_is_an_error():
+    scheduler = create_scheduler(
+        max_num_batched_tokens=100,
+        block_size=16,
+        num_blocks=11,
+        enable_prefix_caching=False,
+    )
+    requests = create_requests(num_requests=2, num_tokens=80, block_size=16)
+
+    scheduler.add_request(requests[0])
+    scheduler_output0 = scheduler.schedule()
+    scheduler.add_request(requests[1])
+    scheduler_output1 = scheduler.schedule()
+
+    scheduler.update_from_output(
+        scheduler_output0,
+        ModelRunnerOutput(
+            req_ids=[requests[0].request_id],
+            req_id_to_index={requests[0].request_id: 0},
+            sampled_token_ids=[[0]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+    scheduler._decode_only_dcp_no_preemption = True
+    scheduler._preempt_request = Mock(
+        side_effect=AssertionError("strict DCP must not preempt")
+    )
+    failed_output = scheduler.schedule()
+
+    error_outputs = scheduler.update_from_output(
+        scheduler_output1,
+        ModelRunnerOutput(
+            req_ids=[requests[1].request_id],
+            req_id_to_index={requests[1].request_id: 0},
+            sampled_token_ids=[[42]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+    scheduler.update_from_output(
+        failed_output,
+        ModelRunnerOutput(req_ids=[], req_id_to_index={}),
+    )
+
+    scheduler._preempt_request.assert_not_called()
+    assert requests[0].status == RequestStatus.FINISHED_ERROR
+    assert requests[1].status == RequestStatus.RUNNING
+    failed_request_output = next(
+        output
+        for output in error_outputs[0].outputs
+        if output.request_id == requests[0].request_id
+    )
+    assert failed_request_output.finish_reason == FinishReason.ERROR
+
+
+@pytest.mark.parametrize(
+    (
+        "enabled",
+        "prompt_tokens",
+        "max_tokens",
+        "lookahead_tokens",
+        "max_model_len",
+        "expected",
+    ),
+    [
+        (True, 7000, 1500, 3, 16384, 8505),
+        (True, 9000, 9000, 3, 16384, 16384),
+        (False, 7000, 1500, 3, 16384, None),
+    ],
+)
+def test_decode_only_dcp_reserves_full_generation_budget(
+    enabled: bool,
+    prompt_tokens: int,
+    max_tokens: int,
+    lookahead_tokens: int,
+    max_model_len: int,
+    expected: int | None,
+):
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler._decode_only_dcp_no_preemption = enabled
+    scheduler.num_lookahead_tokens = lookahead_tokens
+    scheduler.max_model_len = max_model_len
+    request = SimpleNamespace(
+        num_prompt_tokens=prompt_tokens,
+        max_tokens=max_tokens,
+    )
+
+    assert scheduler._get_full_sequence_admission_tokens(request) == expected
+
+
+def test_decode_only_dcp_reserves_running_and_inflight_growth():
+    scheduler = Scheduler.__new__(Scheduler)
+    running = Mock(request_id="a")
+    inflight = Mock(request_id="b")
+    scheduler.running = [running]
+    scheduler._inflight_prefills = {running, inflight}
+    scheduler._request_remaining_blocks = Mock(
+        side_effect=lambda req: 6 if req is running else 9
+    )
+
+    assert scheduler._active_full_sequence_reserved_blocks() == 15
+    assert scheduler._active_full_sequence_reserved_blocks(exclude=running) == 9
+    assert scheduler._active_full_sequence_reserved_blocks(exclude=inflight) == 6
+
+
+@pytest.mark.parametrize(
+    ("required_blocks", "expected"),
+    [
+        (63, False),
+        (64, True),
+        (65, True),
+    ],
+)
+def test_decode_only_dcp_rejects_request_exceeding_usable_parent_blocks(
+    required_blocks: int,
+    expected: bool,
+):
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler._decode_only_dcp_no_preemption = True
+    scheduler.max_model_len = 32768
+    scheduler.block_size = 256
+    scheduler.num_lookahead_tokens = 0
+    scheduler.kv_cache_manager = SimpleNamespace(
+        block_pool=SimpleNamespace(num_gpu_blocks=64)
+    )
+    request = Mock(
+        num_prompt_tokens=required_blocks * scheduler.block_size,
+        max_tokens=0,
+    )
+
+    assert scheduler._decode_only_dcp_request_exceeds_capacity(request) is expected
+
+
+def test_decode_only_dcp_reserves_rejected_draft_tail_across_block_boundary():
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler._decode_only_dcp_no_preemption = True
+    scheduler.max_model_len = 512
+    scheduler.block_size = 256
+    scheduler.num_lookahead_tokens = 3
+    scheduler.kv_cache_manager = SimpleNamespace(
+        block_pool=SimpleNamespace(num_gpu_blocks=2)
+    )
+    request = Mock(num_prompt_tokens=200, max_tokens=53)
+
+    assert scheduler._get_full_sequence_admission_tokens(request) == 258
+    assert scheduler._decode_only_dcp_request_exceeds_capacity(request)
+
+
+def test_decode_only_dcp_admission_accounts_for_shared_prefix():
+    block_size = 16
+    scheduler = create_scheduler(
+        max_num_batched_tokens=128,
+        max_model_len=128,
+        block_size=block_size,
+        num_blocks=10,  # 9 usable blocks.
+        enable_prefix_caching=True,
+    )
+    scheduler._decode_only_dcp_no_preemption = True
+    scheduler.scheduler_reserve_full_isl = False
+    requests = create_requests(
+        num_requests=2,
+        num_tokens=4 * block_size,
+        max_tokens=2 * block_size,
+        same_prompt=True,
+        block_size=block_size,
+    )
+
+    scheduler.add_request(requests[0])
+    first_output = scheduler.schedule()
+    scheduler.update_from_output(
+        first_output,
+        ModelRunnerOutput(
+            req_ids=[requests[0].request_id],
+            req_id_to_index={requests[0].request_id: 0},
+            sampled_token_ids=[[1000]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+    scheduler.add_request(requests[1])
+    shared_output = scheduler.schedule()
+
+    # Raw budgets need 12 blocks, but the four-block prompt is shared:
+    # 4 shared prompt blocks + 2 output blocks per request = 8 <= 9.
+    assert requests[1].request_id in {
+        request.req_id for request in shared_output.scheduled_new_reqs
+    }
+    assert len(scheduler.running) == 2
+    assert not scheduler.capacity_error_reqs
+
+
+def test_decode_only_dcp_oversized_request_fails_without_blocking_queue():
+    block_size = 16
+    scheduler = create_scheduler(
+        max_num_batched_tokens=256,
+        max_model_len=256,
+        block_size=block_size,
+        num_blocks=10,  # 9 usable blocks.
+        enable_prefix_caching=False,
+    )
+    scheduler._decode_only_dcp_no_preemption = True
+    [oversized] = create_requests(
+        num_requests=1,
+        num_tokens=9 * block_size,
+        max_tokens=block_size,
+        block_size=block_size,
+        req_ids=["oversized"],
+    )
+    [small] = create_requests(
+        num_requests=1,
+        num_tokens=block_size,
+        max_tokens=block_size,
+        block_size=block_size,
+        req_ids=["small"],
+    )
+
+    scheduler.add_request(oversized)
+    scheduler.add_request(small)
+
+    error_schedule = scheduler.schedule()
+    assert not error_schedule.num_scheduled_tokens
+    error_outputs = scheduler.update_from_output(
+        error_schedule,
+        ModelRunnerOutput(req_ids=[], req_id_to_index={}),
+    )
+    assert oversized.status == RequestStatus.FINISHED_ERROR
+    assert error_outputs[0].outputs[0].finish_reason == FinishReason.ERROR
+
+    next_output = scheduler.schedule()
+    assert small.request_id in {
+        request.req_id for request in next_output.scheduled_new_reqs
+    }
 
 
 def test_scheduler_reset_prefix_cache():

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -43,6 +43,7 @@ from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.core.single_type_kv_cache_manager import register_all_kvcache_specs
 from vllm.v1.engine import FinishReason
+from vllm.v1.engine.core import EngineCore, EngineCoreProc
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
@@ -1354,6 +1355,38 @@ def test_scheduler_reset_prefix_cache():
 
     for i, request in enumerate(requests):
         assert scheduler.waiting[i] == request
+
+
+def test_decode_only_dcp_rejects_forced_prefix_cache_reset():
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler._decode_only_dcp_no_preemption = True
+    scheduler.running = [Mock(status=RequestStatus.RUNNING)]
+    scheduler.kv_cache_manager = Mock()
+    scheduler._preempt_request = Mock()
+
+    with pytest.raises(RuntimeError, match="strict DCP decode"):
+        scheduler.reset_prefix_cache(reset_running_requests=True)
+
+    assert len(scheduler.running) == 1
+    scheduler._preempt_request.assert_not_called()
+    scheduler.kv_cache_manager.reset_prefix_cache.assert_not_called()
+
+
+@pytest.mark.parametrize("core_cls", [EngineCore, EngineCoreProc])
+def test_keep_pause_rejects_unsafe_strict_dcp_cache_reset(core_cls):
+    core = core_cls.__new__(core_cls)
+    core.scheduler = Mock()
+    core.scheduler.validate_prefix_cache_reset.side_effect = RuntimeError(
+        "strict DCP decode"
+    )
+
+    with pytest.raises(RuntimeError, match="strict DCP decode"):
+        core.pause_scheduler(mode="keep", clear_cache=True)
+
+    core.scheduler.validate_prefix_cache_reset.assert_called_once_with(
+        reset_running_requests=True
+    )
+    core.scheduler.set_pause_state.assert_not_called()
 
 
 def test_reset_connector_cache_no_connector_is_no_op_success():

--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -3431,6 +3431,19 @@ def test_scheduler_request_finished():
     assert "id-1" in scheduler_connector._reqs_not_processed
 
 
+@pytest.mark.asyncio
+async def test_worker_ignores_unknown_not_processed_transfer():
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.shutdown = MagicMock()
+    worker.reqs_need_send = {}
+    metadata = MooncakeConnectorMetadata()
+    metadata.reqs_not_processed.add("aborted-before-first-schedule")
+
+    await worker.record_send_reqs(metadata)
+
+    assert worker.reqs_need_send == {}
+
+
 @contextlib.contextmanager
 def patch_worker_dependencies():
     """Helper to mock all distributed and network dependencies for Worker tests."""

--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -19,7 +19,10 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector im
     KVConnectorRole,
     MooncakeConnector,
     MooncakeConnectorMetadata,
+    MooncakeConnectorScheduler,
     MooncakeConnectorWorker,
+    MooncakeRegionIdentity,
+    MooncakeRequestPageMap,
     MooncakeXferMetadata,
     MooncakeXferResponse,
     MooncakeXferResponseStatus,
@@ -28,20 +31,32 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector im
     TransferRegion,
     _align_transfer_regions,
     _compute_sender_transfer_plan,
+    _get_full_temporal_suffix_blocks,
+    _get_owned_dcp_suffix_blocks,
+    _index_full_temporal_region_page_maps,
+    _pair_cp_block_ids,
+    _pair_dcp_blocks_by_global_page,
+    _pair_full_temporal_blocks_by_global_page,
     _pair_pcp_block_ids,
     _validate_asymmetric_region_lengths,
+    _validate_full_temporal_stage_coverage,
+    _validate_region_layouts,
     get_mooncake_bootstrap_addr,
     should_launch_bootstrap_server,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_utils import (
+    MOONCAKE_CP_BLOCK_PAIRING_VERSION,
+    MOONCAKE_KV_REGION_LAYOUT_VERSION,
     MooncakeBootstrapServer,
 )
 from vllm.utils.network_utils import get_open_port
 from vllm.v1.attention.backends.flash_attn import FlashAttentionBackend
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
+    KVCacheChildPageMapping,
     KVCacheConfig,
     KVCacheGroupSpec,
+    KVCacheTemporalLayout,
     SlidingWindowSpec,
 )
 from vllm.v1.request import RequestStatus
@@ -154,8 +169,40 @@ def test_sender_plan_fully_replicated_tp4_to_tp2(
         remote_kv_block_len=4096,
         producer_cache_replicated=True,
     )
+    assert plan == ((True, 0, 0, 4096) if should_transfer else (False, 0, 0, 4096))
+
+
+@pytest.mark.parametrize(
+    ("producer_tp_rank", "consumer_tp_rank"),
+    [(producer, consumer) for producer in range(4) for consumer in range(8)],
+)
+def test_sender_plan_maps_tp4_draft_heads_to_tp8_consumers(
+    producer_tp_rank: int,
+    consumer_tp_rank: int,
+) -> None:
+    bytes_per_head_page = 128 * 128 * 2
+    plan = _compute_sender_transfer_plan(
+        local_tp_rank=producer_tp_rank,
+        local_tp_size=4,
+        remote_tp_rank=consumer_tp_rank,
+        remote_tp_size=8,
+        local_kv_block_len=16 * bytes_per_head_page,
+        remote_kv_block_len=8 * bytes_per_head_page,
+        producer_cache_replicated=False,
+        transfer_unique_kv_heads=True,
+        total_num_kv_heads=64,
+    )
+
+    if producer_tp_rank != consumer_tp_rank // 2:
+        assert plan == (False, 0, 0, 0)
+        return
+
+    expected_src_offset = (consumer_tp_rank % 2) * 8 * bytes_per_head_page
     assert plan == (
-        (True, 0, 0, 4096) if should_transfer else (False, 0, 0, 4096)
+        True,
+        expected_src_offset,
+        0,
+        8 * bytes_per_head_page,
     )
 
 
@@ -271,9 +318,7 @@ def test_sender_plan_replicated_heads_tp4_to_tp2(
         transfer_unique_kv_heads=True,
         total_num_kv_heads=1,
     )
-    assert plan == (
-        (True, 0, 0, 32768) if should_transfer else (False, 0, 0, 0)
-    )
+    assert plan == ((True, 0, 0, 32768) if should_transfer else (False, 0, 0, 0))
 
 
 @pytest.mark.parametrize(
@@ -310,11 +355,7 @@ def test_sender_plan_mimo_equal_region_tp16_to_tp8(local_tp_rank):
         producer_cache_replicated=True,
         transfer_unique_kv_heads=True,
         total_num_kv_heads=8,
-    ) == (
-        (True, 0, 0, 32768)
-        if local_tp_rank % 2 == 0
-        else (False, 0, 0, 0)
-    )
+    ) == ((True, 0, 0, 32768) if local_tp_rank % 2 == 0 else (False, 0, 0, 0))
 
 
 def _make_test_kv_cache_config() -> KVCacheConfig:
@@ -512,6 +553,817 @@ def test_pair_pcp_blocks_fails_closed_for_unsupported_page_geometry():
     assert "interleave" in error
 
 
+@pytest.mark.parametrize("dcp_rank", [0, 1])
+def test_pair_cp_blocks_scatters_global_pages_to_consumer_dcp(dcp_rank: int):
+    local_blocks = list(range(28))
+    remote_blocks = list(range(100 + 100 * dcp_rank, 114 + 100 * dcp_rank))
+    remote_pages = list(range(dcp_rank, 28, 2))
+
+    paired_local, paired_remote, error = _pair_dcp_blocks_by_global_page(
+        local_blocks,
+        remote_blocks,
+        remote_pages,
+        total_tokens=3563,
+        num_external_tokens=3563,
+        external_start_token=0,
+        consumer_dcp_size=2,
+        consumer_dcp_rank=dcp_rank,
+        page_size=128,
+        interleave_size=128,
+    )
+
+    assert error is None
+    assert paired_local == list(range(dcp_rank, 28, 2))
+    assert paired_remote == remote_blocks
+
+
+@pytest.mark.parametrize("dcp_rank", [0, 1])
+def test_pair_cp_blocks_maps_consumer_dcp_prefix_suffix(dcp_rank: int):
+    paired_local, paired_remote, error = _pair_dcp_blocks_by_global_page(
+        [4, 5, 6, 7],
+        [100, 101],
+        [4 + dcp_rank, 6 + dcp_rank],
+        total_tokens=1024,
+        num_external_tokens=512,
+        external_start_token=512,
+        consumer_dcp_size=2,
+        consumer_dcp_rank=dcp_rank,
+        page_size=128,
+        interleave_size=128,
+    )
+
+    assert error is None
+    assert paired_local == [4 + dcp_rank, 6 + dcp_rank]
+    assert paired_remote == [100, 101]
+
+
+def test_pair_cp_blocks_skips_consumer_dcp_rank_without_tokens():
+    result = _pair_dcp_blocks_by_global_page(
+        [0],
+        [],
+        [],
+        total_tokens=9,
+        num_external_tokens=9,
+        external_start_token=0,
+        consumer_dcp_size=2,
+        consumer_dcp_rank=1,
+        page_size=128,
+        interleave_size=128,
+    )
+
+    assert result == ([], [], None)
+
+
+@pytest.mark.parametrize(
+    ("dcp_rank", "expected_blocks", "expected_pages"),
+    [
+        (0, list(range(100, 114)), list(range(0, 28, 2))),
+        (1, list(range(200, 214)), list(range(1, 28, 2))),
+    ],
+)
+def test_describe_consumer_dcp_blocks_with_global_pages(
+    dcp_rank: int,
+    expected_blocks: list[int],
+    expected_pages: list[int],
+):
+    blocks, pages, error = _get_owned_dcp_suffix_blocks(
+        expected_blocks,
+        total_tokens=3563,
+        num_external_tokens=3563,
+        external_start_token=0,
+        dcp_size=2,
+        dcp_rank=dcp_rank,
+        page_size=128,
+        interleave_size=128,
+    )
+
+    assert error is None
+    assert blocks == expected_blocks
+    assert pages == expected_pages
+
+
+@pytest.mark.parametrize(
+    ("total_tokens", "external_start_token", "expected_page"),
+    [(257, 0, 1), (257, 128, 1), (513, 256, 3)],
+)
+def test_describe_consumer_dcp_partial_tail_uses_valid_local_page(
+    total_tokens: int,
+    external_start_token: int,
+    expected_page: int,
+):
+    blocks, pages, error = _get_owned_dcp_suffix_blocks(
+        [100, 101],
+        total_tokens=total_tokens,
+        num_external_tokens=total_tokens - external_start_token,
+        external_start_token=external_start_token,
+        dcp_size=2,
+        dcp_rank=1,
+        page_size=128,
+        interleave_size=128,
+    )
+
+    assert error is None
+    assert blocks == [100]
+    assert pages == [expected_page]
+
+
+def test_describe_consumer_dcp_blocks_maps_clipped_suffix_tail():
+    blocks, pages, error = _get_owned_dcp_suffix_blocks(
+        [100, 101],
+        total_tokens=1024,
+        num_external_tokens=1024,
+        external_start_token=0,
+        dcp_size=2,
+        dcp_rank=0,
+        page_size=128,
+        interleave_size=128,
+    )
+
+    assert error is None
+    assert blocks == [100, 101]
+    assert pages == [4, 6]
+
+
+def test_describe_consumer_dcp_blocks_rejects_missing_owned_pages():
+    blocks, pages, error = _get_owned_dcp_suffix_blocks(
+        [],
+        total_tokens=1024,
+        num_external_tokens=1024,
+        external_start_token=0,
+        dcp_size=2,
+        dcp_rank=0,
+        page_size=128,
+        interleave_size=128,
+    )
+
+    assert blocks == []
+    assert pages == []
+    assert error is not None
+    assert "missing owned global pages" in error
+
+
+@pytest.mark.parametrize(
+    ("prompt_tokens", "parent_blocks", "expected_blocks", "expected_pages"),
+    [
+        (1, [100], [], []),
+        (128, [100], [200], [0]),
+        (129, [100], [200], [0]),
+        (256, [100], [200, 201], [0, 1]),
+        (257, [100, 101], [200, 201], [0, 1]),
+    ],
+)
+def test_describe_full_temporal_draft_excludes_final_prompt_token(
+    prompt_tokens: int,
+    parent_blocks: list[int],
+    expected_blocks: list[int],
+    expected_pages: list[int],
+):
+    transferred_tokens = max(prompt_tokens - 1, 0)
+
+    blocks, pages, error = _get_full_temporal_suffix_blocks(
+        parent_blocks,
+        total_tokens=transferred_tokens,
+        num_external_tokens=transferred_tokens,
+        external_start_token=0,
+        child_page_factor=2,
+        page_size=128,
+    )
+
+    assert error is None
+    assert blocks == expected_blocks
+    assert pages == expected_pages
+
+
+def test_describe_full_temporal_factor1_preserves_absolute_suffix_pages():
+    blocks, pages, error = _get_full_temporal_suffix_blocks(
+        [10, 11, 12],
+        total_tokens=256,
+        num_external_tokens=256,
+        external_start_token=0,
+        child_page_factor=1,
+        page_size=128,
+    )
+
+    assert error is None
+    assert blocks == [10, 11]
+    assert pages == [0, 1]
+
+
+@pytest.mark.parametrize(
+    ("prompt_tokens", "expected_external_tokens"),
+    [(0, 0), (1, 0), (2, 1), (257, 256)],
+)
+def test_replicated_draft_remote_prefill_leaves_one_token_local(
+    prompt_tokens: int,
+    expected_external_tokens: int,
+):
+    scheduler = MooncakeConnectorScheduler.__new__(MooncakeConnectorScheduler)
+    scheduler._has_full_temporal_draft = True
+    scheduler._has_mamba = False
+
+    assert (
+        scheduler._get_remote_prefill_token_count(prompt_tokens)
+        == expected_external_tokens
+    )
+
+
+@pytest.mark.parametrize(
+    ("num_external_tokens", "expected_start"),
+    [
+        (512, 0),
+        (256, 256),
+        (0, 512),
+    ],
+)
+def test_full_temporal_prefix_uses_atomic_target_draft_suffix(
+    num_external_tokens: int,
+    expected_start: int,
+):
+    scheduler = MooncakeConnectorScheduler.__new__(MooncakeConnectorScheduler)
+    scheduler._has_full_temporal_draft = True
+    scheduler._has_mamba = False
+
+    total_tokens, external_start_token = scheduler._get_remote_prefill_transfer_range(
+        num_prompt_tokens=513,
+        num_external_tokens=num_external_tokens,
+    )
+
+    assert total_tokens == 512
+    assert external_start_token == expected_start
+    assert total_tokens - external_start_token == num_external_tokens
+
+
+def test_pair_full_temporal_pages_uses_absolute_source_page_at_boundary():
+    paired_local, paired_remote, error = _pair_full_temporal_blocks_by_global_page(
+        [10, 11, 12],
+        [200, 201],
+        [0, 1],
+        total_tokens=256,
+        num_external_tokens=256,
+        external_start_token=0,
+        page_size=128,
+    )
+
+    assert error is None
+    assert paired_local == [10, 11]
+    assert paired_remote == [200, 201]
+
+
+@pytest.mark.parametrize(
+    ("dcp_rank", "remote_pages", "expected_local"),
+    [
+        (0, [0], [10]),
+        (1, [1], [11]),
+    ],
+)
+def test_pair_dcp_pages_uses_absolute_source_page_at_recompute_boundary(
+    dcp_rank: int,
+    remote_pages: list[int],
+    expected_local: list[int],
+):
+    paired_local, paired_remote, error = _pair_dcp_blocks_by_global_page(
+        [10, 11, 12],
+        [200 + dcp_rank],
+        remote_pages,
+        total_tokens=256,
+        num_external_tokens=256,
+        external_start_token=0,
+        consumer_dcp_size=2,
+        consumer_dcp_rank=dcp_rank,
+        page_size=128,
+        interleave_size=128,
+    )
+
+    assert error is None
+    assert paired_local == expected_local
+    assert paired_remote == [200 + dcp_rank]
+
+
+def test_index_full_temporal_region_page_maps_fails_closed():
+    target = TransferRegion(
+        layer_name="model.layers.0.self_attn",
+        layer_index=0,
+        base_addr=0x1000,
+        block_len=128,
+        kv_block_len=128,
+        group_index=0,
+        region_index=0,
+        identity=MooncakeRegionIdentity(
+            layer_name="model.layers.0.self_attn",
+            temporal_layout=KVCacheTemporalLayout.SHARDED_DCP.value,
+            protocol_version=MOONCAKE_KV_REGION_LAYOUT_VERSION,
+            child_page_mapping=KVCacheChildPageMapping.IDENTITY.value,
+            child_page_factor=1,
+        ),
+    )
+    draft = TransferRegion(
+        layer_name="model.layers.60.self_attn.attn",
+        layer_index=60,
+        base_addr=0x2000,
+        block_len=128,
+        kv_block_len=128,
+        group_index=0,
+        region_index=1,
+        identity=MooncakeRegionIdentity(
+            layer_name="model.layers.60.self_attn.attn",
+            temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL.value,
+            protocol_version=MOONCAKE_KV_REGION_LAYOUT_VERSION,
+            child_page_mapping=(KVCacheChildPageMapping.GLOBAL_PAGE_MODULO.value),
+            child_page_factor=2,
+        ),
+    )
+    valid = MooncakeRequestPageMap(
+        region_index=1,
+        group_index=0,
+        valid_start_token=0,
+        valid_end_token_exclusive=256,
+        global_page_ids=[0, 1],
+        dst_physical_block_ids=[200, 201],
+    )
+
+    indexed, error = _index_full_temporal_region_page_maps(
+        [valid],
+        [target, draft],
+        valid_start_token=0,
+        valid_end_token_exclusive=256,
+    )
+    assert error is None
+    assert indexed == {1: valid}
+
+    _, error = _index_full_temporal_region_page_maps(
+        [],
+        [target, draft],
+        valid_start_token=0,
+        valid_end_token_exclusive=256,
+    )
+    assert error is not None
+    assert "missing" in error
+
+    _, error = _index_full_temporal_region_page_maps(
+        [valid, valid],
+        [target, draft],
+        valid_start_token=0,
+        valid_end_token_exclusive=256,
+    )
+    assert error is not None
+    assert "duplicate" in error
+
+    invalid_child = msgspec.structs.replace(
+        valid,
+        dst_physical_block_ids=[201, 200],
+    )
+    _, error = _index_full_temporal_region_page_maps(
+        [invalid_child],
+        [target, draft],
+        valid_start_token=0,
+        valid_end_token_exclusive=256,
+    )
+    assert error is not None
+    assert "parity" in error
+
+    duplicate_child = msgspec.structs.replace(
+        valid,
+        dst_physical_block_ids=[200, 200],
+    )
+    _, error = _index_full_temporal_region_page_maps(
+        [duplicate_child],
+        [target, draft],
+        valid_start_token=0,
+        valid_end_token_exclusive=256,
+    )
+    assert error is not None
+    assert "unique" in error
+
+    duplicate_page = msgspec.structs.replace(
+        valid,
+        global_page_ids=[0, 0],
+    )
+    _, error = _index_full_temporal_region_page_maps(
+        [duplicate_page],
+        [target, draft],
+        valid_start_token=0,
+        valid_end_token_exclusive=256,
+    )
+    assert error is not None
+    assert "unique" in error
+
+
+def test_index_full_temporal_factor1_page_map():
+    layer_name = "model.layers.60.self_attn.attn"
+    region = TransferRegion(
+        layer_name=layer_name,
+        layer_index=60,
+        base_addr=0x2000,
+        block_len=128,
+        kv_block_len=128,
+        group_index=0,
+        region_index=0,
+        identity=MooncakeRegionIdentity(
+            layer_name=layer_name,
+            temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL.value,
+            protocol_version=MOONCAKE_KV_REGION_LAYOUT_VERSION,
+            child_page_mapping=KVCacheChildPageMapping.IDENTITY.value,
+            child_page_factor=1,
+        ),
+    )
+    page_map = MooncakeRequestPageMap(
+        region_index=0,
+        group_index=0,
+        valid_start_token=0,
+        valid_end_token_exclusive=256,
+        global_page_ids=[0, 1],
+        dst_physical_block_ids=[100, 101],
+    )
+
+    indexed, error = _index_full_temporal_region_page_maps(
+        [page_map],
+        [region],
+        valid_start_token=0,
+        valid_end_token_exclusive=256,
+    )
+
+    assert error is None
+    assert indexed == {0: page_map}
+
+
+def test_full_temporal_region_layout_rejects_protocol_downgrade():
+    layer_name = "model.layers.60.self_attn.attn"
+    producer = TransferRegion(
+        layer_name=layer_name,
+        layer_index=60,
+        base_addr=0x1000,
+        block_len=256,
+        kv_block_len=128,
+        identity=MooncakeRegionIdentity(
+            layer_name=layer_name,
+            temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL.value,
+            protocol_version=MOONCAKE_CP_BLOCK_PAIRING_VERSION,
+            child_page_mapping=KVCacheChildPageMapping.IDENTITY.value,
+            child_page_factor=1,
+        ),
+    )
+    consumer = TransferRegion(
+        layer_name=layer_name,
+        layer_index=60,
+        base_addr=0x2000,
+        block_len=128,
+        kv_block_len=64,
+        identity=MooncakeRegionIdentity(
+            layer_name=layer_name,
+            temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL.value,
+            protocol_version=MOONCAKE_KV_REGION_LAYOUT_VERSION,
+            child_page_mapping=(KVCacheChildPageMapping.GLOBAL_PAGE_MODULO.value),
+            child_page_factor=2,
+        ),
+    )
+
+    error = _validate_region_layouts(
+        [producer],
+        [consumer],
+        producer_dcp_size=1,
+        consumer_dcp_size=2,
+    )
+
+    assert error is not None
+    assert "protocol" in error
+
+
+def test_full_temporal_region_layout_accepts_dcp1_identity():
+    layer_name = "model.layers.60.self_attn.attn"
+    identity = MooncakeRegionIdentity(
+        layer_name=layer_name,
+        temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL.value,
+        protocol_version=MOONCAKE_KV_REGION_LAYOUT_VERSION,
+        child_page_mapping=KVCacheChildPageMapping.IDENTITY.value,
+        child_page_factor=1,
+    )
+    producer = TransferRegion(
+        layer_name=layer_name,
+        layer_index=60,
+        base_addr=0x1000,
+        block_len=128,
+        kv_block_len=128,
+        identity=identity,
+    )
+    consumer = TransferRegion(
+        layer_name=layer_name,
+        layer_index=60,
+        base_addr=0x2000,
+        block_len=128,
+        kv_block_len=128,
+        identity=identity,
+    )
+
+    assert (
+        _validate_region_layouts(
+            [producer],
+            [consumer],
+            producer_dcp_size=1,
+            consumer_dcp_size=1,
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("producer_layers", "pp_rank"),
+    [
+        (
+            [
+                "language_model.model.layers.0.self_attn.attn",
+                "language_model.model.layers.1.self_attn.attn",
+                "language_model.model.layers.2.self_attn.attn",
+            ],
+            0,
+        ),
+        (["model.layers.60.self_attn.attn"], 1),
+    ],
+    ids=["pp0-target-dense", "pp1-draft"],
+)
+def test_full_temporal_region_layout_allows_stage_local_subset(
+    producer_layers: list[str],
+    pp_rank: int,
+) -> None:
+    consumer_layers = [
+        "language_model.model.layers.0.self_attn.attn",
+        "language_model.model.layers.1.self_attn.attn",
+        "language_model.model.layers.2.self_attn.attn",
+        "model.layers.60.self_attn.attn",
+    ]
+
+    def make_region(layer_name: str, *, consumer: bool) -> TransferRegion:
+        layer_index = int(layer_name.split("layers.", 1)[1].split(".", 1)[0])
+        return TransferRegion(
+            layer_name=layer_name,
+            layer_index=layer_index,
+            base_addr=0x1000 + layer_index * 0x100,
+            block_len=128,
+            kv_block_len=64,
+            group_index=0,
+            identity=MooncakeRegionIdentity(
+                layer_name=layer_name,
+                temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL.value,
+                protocol_version=MOONCAKE_KV_REGION_LAYOUT_VERSION,
+                child_page_mapping=(
+                    KVCacheChildPageMapping.GLOBAL_PAGE_MODULO.value
+                    if consumer
+                    else KVCacheChildPageMapping.IDENTITY.value
+                ),
+                child_page_factor=2 if consumer else 1,
+            ),
+        )
+
+    producer_regions = [
+        make_region(layer_name, consumer=False) for layer_name in producer_layers
+    ]
+    consumer_regions = [
+        make_region(layer_name, consumer=True) for layer_name in consumer_layers
+    ]
+
+    aligned_producer, aligned_consumer, align_error = _align_transfer_regions(
+        producer_regions, consumer_regions
+    )
+
+    assert align_error is None
+    assert [region.layer_name for region in aligned_producer] == producer_layers
+    assert [region.layer_name for region in aligned_consumer] == producer_layers
+    assert (
+        _validate_region_layouts(
+            aligned_producer,
+            aligned_consumer,
+            producer_dcp_size=1,
+            consumer_dcp_size=2,
+        )
+        is None
+    )
+    assert (
+        _validate_full_temporal_stage_coverage(
+            producer_regions,
+            consumer_regions,
+            speculative_config=SimpleNamespace(
+                enable_eagle3_target_dense_full_temporal_kv=True,
+                enable_eagle3_prefill_draft_kv=True,
+            ),
+            total_target_layers=60,
+            pp_rank=pp_rank,
+            pp_size=2,
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("producer_layers", "pp_rank", "missing_layer"),
+    [
+        (
+            [
+                "language_model.model.layers.0.self_attn.attn",
+                "language_model.model.layers.1.self_attn.attn",
+            ],
+            0,
+            2,
+        ),
+        ([], 1, 60),
+    ],
+    ids=["pp0-missing-dense", "pp1-missing-draft"],
+)
+def test_full_temporal_stage_coverage_rejects_missing_layer(
+    producer_layers: list[str],
+    pp_rank: int,
+    missing_layer: int,
+) -> None:
+    def make_region(layer_name: str) -> TransferRegion:
+        layer_index = int(layer_name.split("layers.", 1)[1].split(".", 1)[0])
+        return TransferRegion(
+            layer_name=layer_name,
+            layer_index=layer_index,
+            base_addr=0x1000 + layer_index * 0x100,
+            block_len=128,
+            kv_block_len=64,
+            identity=MooncakeRegionIdentity(
+                layer_name=layer_name,
+                temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL.value,
+                protocol_version=MOONCAKE_KV_REGION_LAYOUT_VERSION,
+                child_page_mapping=KVCacheChildPageMapping.IDENTITY.value,
+                child_page_factor=1,
+            ),
+        )
+
+    producer_regions = [make_region(name) for name in producer_layers]
+    consumer_regions = [
+        make_region(
+            f"language_model.model.layers.{layer}.self_attn.attn"
+            if layer < 3
+            else "model.layers.60.self_attn.attn"
+        )
+        for layer in (0, 1, 2, 60)
+    ]
+
+    error = _validate_full_temporal_stage_coverage(
+        producer_regions,
+        consumer_regions,
+        speculative_config=SimpleNamespace(
+            enable_eagle3_target_dense_full_temporal_kv=True,
+            enable_eagle3_prefill_draft_kv=True,
+        ),
+        total_target_layers=60,
+        pp_rank=pp_rank,
+        pp_size=2,
+    )
+
+    assert error is not None
+    assert "incomplete full-temporal coverage" in error
+    assert str(missing_layer) in error
+
+
+def test_pair_dcp_global_pages_maps_clipped_sliding_window_tail():
+    paired_local, paired_remote, error = _pair_dcp_blocks_by_global_page(
+        [20, 21, 22, 23],
+        [100, 101],
+        [4, 6],
+        total_tokens=1024,
+        num_external_tokens=1024,
+        external_start_token=0,
+        consumer_dcp_size=2,
+        consumer_dcp_rank=0,
+        page_size=128,
+        interleave_size=128,
+    )
+
+    assert error is None
+    assert paired_local == [20, 22]
+    assert paired_remote == [100, 101]
+
+
+@pytest.mark.parametrize(
+    ("remote_pages", "match"),
+    [
+        ([0, 0], "unique"),
+        ([2, 0], "increasing"),
+        ([0, 3], "owner suffix"),
+        ([0], "counts differ"),
+    ],
+)
+def test_pair_dcp_global_pages_fails_closed(
+    remote_pages: list[int],
+    match: str,
+):
+    _, _, error = _pair_dcp_blocks_by_global_page(
+        [10, 11, 12, 13],
+        [100, 101],
+        remote_pages,
+        total_tokens=512,
+        num_external_tokens=512,
+        external_start_token=0,
+        consumer_dcp_size=2,
+        consumer_dcp_rank=0,
+        page_size=128,
+        interleave_size=128,
+    )
+
+    assert error is not None
+    assert match in error
+
+
+@pytest.mark.parametrize(
+    (
+        "producer_pcp_size",
+        "producer_dcp_size",
+        "consumer_pcp_size",
+        "consumer_dcp_size",
+        "consumer_interleave_size",
+        "match",
+    ),
+    [
+        (1, 2, 1, 1, 128, "producer DCP"),
+        (1, 1, 2, 2, 128, "consumer PCP and DCP"),
+        (2, 1, 1, 2, 128, "consumer DCP requires"),
+        (1, 1, 1, 2, 96, "interleave"),
+    ],
+)
+def test_pair_cp_blocks_rejects_unsupported_topologies(
+    producer_pcp_size: int,
+    producer_dcp_size: int,
+    consumer_pcp_size: int,
+    consumer_dcp_size: int,
+    consumer_interleave_size: int,
+    match: str,
+):
+    _, _, error = _pair_cp_block_ids(
+        [0, 1],
+        [100],
+        total_tokens=256,
+        num_external_tokens=256,
+        external_start_token=0,
+        producer_pcp_size=producer_pcp_size,
+        producer_pcp_rank=0,
+        consumer_pcp_size=consumer_pcp_size,
+        consumer_pcp_rank=0,
+        producer_dcp_size=producer_dcp_size,
+        producer_dcp_rank=0,
+        consumer_dcp_size=consumer_dcp_size,
+        consumer_dcp_rank=0,
+        group_block_size=128,
+        producer_interleave_size=128,
+        consumer_interleave_size=consumer_interleave_size,
+        consumer_cp_block_pairing_version=MOONCAKE_CP_BLOCK_PAIRING_VERSION,
+    )
+
+    assert error is not None
+    assert match in error
+
+
+def test_pair_cp_blocks_rejects_legacy_ambiguous_block_mismatch():
+    _, _, error = _pair_cp_block_ids(
+        list(range(28)),
+        list(range(100, 114)),
+        total_tokens=3563,
+        num_external_tokens=3563,
+        external_start_token=0,
+        producer_pcp_size=1,
+        producer_pcp_rank=0,
+        consumer_pcp_size=1,
+        consumer_pcp_rank=0,
+        producer_dcp_size=1,
+        producer_dcp_rank=0,
+        consumer_dcp_size=1,
+        consumer_dcp_rank=0,
+        group_block_size=128,
+        producer_interleave_size=128,
+        consumer_interleave_size=1,
+        consumer_cp_block_pairing_version=0,
+    )
+
+    assert error is not None
+    assert "CP block pairing capability" in error
+
+
+def test_pair_cp_blocks_accepts_v1_non_dcp_pairing():
+    local, remote, error = _pair_cp_block_ids(
+        list(range(28)),
+        list(range(100, 114)),
+        total_tokens=3563,
+        num_external_tokens=3563,
+        external_start_token=0,
+        producer_pcp_size=1,
+        producer_pcp_rank=0,
+        consumer_pcp_size=1,
+        consumer_pcp_rank=0,
+        producer_dcp_size=1,
+        producer_dcp_rank=0,
+        consumer_dcp_size=1,
+        consumer_dcp_rank=0,
+        group_block_size=128,
+        producer_interleave_size=128,
+        consumer_interleave_size=1,
+        consumer_cp_block_pairing_version=1,
+    )
+
+    assert error is None
+    assert local == list(range(14, 28))
+    assert remote == list(range(100, 114))
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("group_block_size", [256, 64, 8, 4])
 @pytest.mark.parametrize("pcp_rank", [0, 1])
@@ -622,6 +1474,449 @@ async def test_build_transfer_params_reassembles_pcp_pages(
         remote_base + (100 + (2 + pcp_rank) * local_pages_per_chunk) * region_block_len,
     ]
     assert lengths == [region_block_len * local_pages_per_chunk] * 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("producer_tp_rank", range(4))
+@pytest.mark.parametrize("dcp_rank", [0, 1])
+async def test_build_transfer_params_scatters_consumer_dcp_pages(
+    producer_tp_rank: int,
+    dcp_rank: int,
+):
+    layer_name = "model.layers.0.self_attn"
+    layer_spec = FullAttentionSpec(
+        block_size=128,
+        num_kv_heads=1,
+        head_size=16,
+        dtype=torch.float16,
+    )
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.shutdown = MagicMock()
+    worker.async_zmq_ctx = MagicMock()
+    worker.is_kv_consumer = False
+    worker.is_kv_producer = True
+    worker.tp_rank = producer_tp_rank
+    worker.tp_size = 4
+    worker.pcp_rank = 0
+    worker.pcp_size = 1
+    worker.dcp_rank = 0
+    worker.dcp_size = 1
+    worker.cp_kv_cache_interleave_size = 128
+    worker._physical_blocks_per_logical_kv_block = 1
+    worker.transfer_topo = SimpleNamespace(
+        local_replicates_kv_cache=False,
+        total_num_kv_heads=4,
+    )
+    worker._layer_specs = {layer_name: layer_spec}
+    worker.vllm_config = SimpleNamespace(
+        compilation_config=SimpleNamespace(
+            static_forward_context={layer_name: SimpleNamespace(total_num_kv_heads=4)}
+        )
+    )
+    worker.kv_cache_config = KVCacheConfig(
+        num_blocks=0,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                [layer_name],
+                layer_spec,
+            )
+        ],
+    )
+
+    block_len = 128
+    local_base = 0x1000
+    remote_base = 0xA000
+    local_regions = [
+        TransferRegion(
+            layer_name=layer_name,
+            layer_index=0,
+            base_addr=local_base,
+            block_len=block_len,
+            kv_block_len=block_len,
+            logical_group_indices=(0,),
+        )
+    ]
+    remote_regions = [
+        TransferRegion(
+            layer_name=layer_name,
+            layer_index=0,
+            base_addr=remote_base,
+            block_len=block_len,
+            kv_block_len=block_len,
+            logical_group_indices=(0,),
+        )
+    ]
+    transfer_id = "xfer-dcp"
+    send_meta = SendBlockMeta(
+        p_req_id="p-req-dcp",
+        transfer_id=transfer_id,
+        local_block_ids=[list(range(28))],
+        ready=asyncio.Event(),
+    )
+    remote_blocks = list(range(100, 114))
+    xfer_meta = MooncakeXferMetadata(
+        remote_hostname="consumer-host",
+        remote_port=54321,
+        remote_tp_size=8,
+        remote_tp_rank=producer_tp_rank * 2 + dcp_rank,
+        remote_pcp_size=1,
+        remote_pcp_rank=0,
+        remote_dcp_size=2,
+        remote_dcp_rank=dcp_rank,
+        remote_cp_kv_cache_interleave_size=128,
+        remote_cp_block_pairing_version=MOONCAKE_CP_BLOCK_PAIRING_VERSION,
+        req_blocks={"d-req-dcp": (transfer_id, [remote_blocks])},
+        kv_caches_base_addr=[remote_base],
+        block_lens=[block_len],
+        kv_block_lens=[block_len],
+        req_total_tokens={"d-req-dcp": 3563},
+        req_num_external_tokens={"d-req-dcp": 3563},
+        req_external_start_tokens={"d-req-dcp": 0},
+        req_global_page_ids={"d-req-dcp": [list(range(dcp_rank, 28, 2))]},
+    )
+
+    (
+        src_ptrs,
+        dst_ptrs,
+        lengths,
+        err_reqs,
+        err_msg,
+    ) = await worker._build_transfer_params(
+        ready_reqs=[("d-req-dcp", send_meta)],
+        agent_meta=xfer_meta,
+        local_regions=local_regions,
+        remote_regions=remote_regions,
+    )
+
+    assert err_reqs == []
+    assert err_msg is None
+    assert src_ptrs == [
+        local_base + block_id * block_len for block_id in range(dcp_rank, 28, 2)
+    ]
+    assert dst_ptrs == [
+        remote_base + block_id * block_len for block_id in remote_blocks
+    ]
+    assert lengths == [block_len] * 14
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("consumer_dcp_size", "dcp_rank", "remote_tp_rank", "src_offset"),
+    [
+        (1, 0, 2, 0),
+        (1, 0, 3, 128),
+        (2, 0, 2, 0),
+        (2, 1, 3, 128),
+    ],
+)
+async def test_build_transfer_params_combines_full_temporal_pages_and_tp_slicing(
+    consumer_dcp_size: int,
+    dcp_rank: int,
+    remote_tp_rank: int,
+    src_offset: int,
+):
+    producer_tp_rank = 1
+    layer_name = "model.layers.60.self_attn.attn"
+    layer_spec = FullAttentionSpec(
+        block_size=128,
+        num_kv_heads=16,
+        head_size=1,
+        dtype=torch.float16,
+    )
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.shutdown = MagicMock()
+    worker.tp_rank = producer_tp_rank
+    worker.tp_size = 4
+    worker.pcp_rank = 0
+    worker.pcp_size = 1
+    worker.dcp_rank = 0
+    worker.dcp_size = 1
+    worker.cp_kv_cache_interleave_size = 128
+    worker._physical_blocks_per_logical_kv_block = 1
+    worker.transfer_topo = SimpleNamespace(
+        local_replicates_kv_cache=False,
+        total_num_kv_heads=64,
+    )
+    worker._layer_specs = {layer_name: layer_spec}
+    worker.vllm_config = SimpleNamespace(
+        compilation_config=SimpleNamespace(
+            static_forward_context={layer_name: SimpleNamespace(total_num_kv_heads=64)}
+        )
+    )
+    worker.kv_cache_config = KVCacheConfig(
+        num_blocks=0,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                [layer_name],
+                layer_spec,
+            )
+        ],
+    )
+
+    producer_identity = MooncakeRegionIdentity(
+        layer_name=layer_name,
+        temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL.value,
+        protocol_version=MOONCAKE_KV_REGION_LAYOUT_VERSION,
+        child_page_mapping=KVCacheChildPageMapping.IDENTITY.value,
+        child_page_factor=1,
+    )
+    consumer_identity = MooncakeRegionIdentity(
+        layer_name=layer_name,
+        temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL.value,
+        protocol_version=MOONCAKE_KV_REGION_LAYOUT_VERSION,
+        child_page_mapping=(
+            KVCacheChildPageMapping.IDENTITY.value
+            if consumer_dcp_size == 1
+            else KVCacheChildPageMapping.GLOBAL_PAGE_MODULO.value
+        ),
+        child_page_factor=consumer_dcp_size,
+    )
+    local_block_len = 512
+    remote_block_len = 256
+    local_base = 0x1000
+    remote_base = 0xA000
+    local_regions = [
+        TransferRegion(
+            layer_name=layer_name,
+            layer_index=60,
+            base_addr=local_base,
+            block_len=local_block_len,
+            kv_block_len=256,
+            group_index=0,
+            logical_group_indices=(0,),
+            region_index=0,
+            identity=producer_identity,
+        )
+    ]
+    remote_regions = [
+        TransferRegion(
+            layer_name=layer_name,
+            layer_index=60,
+            base_addr=remote_base,
+            block_len=remote_block_len,
+            kv_block_len=128,
+            group_index=0,
+            logical_group_indices=(0,),
+            region_index=0,
+            identity=consumer_identity,
+        )
+    ]
+    send_meta = SendBlockMeta(
+        p_req_id="p-req-draft",
+        transfer_id="xfer-draft",
+        # Producer computed 257 prompt tokens, while Decode requests [0, 256).
+        local_block_ids=[[10, 11, 12]],
+        ready=asyncio.Event(),
+    )
+    metadata = MooncakeXferMetadata(
+        remote_hostname="consumer-host",
+        remote_port=54321,
+        remote_tp_size=8,
+        remote_tp_rank=remote_tp_rank,
+        remote_dcp_size=consumer_dcp_size,
+        remote_dcp_rank=dcp_rank,
+        remote_cp_kv_cache_interleave_size=128,
+        remote_cp_block_pairing_version=MOONCAKE_KV_REGION_LAYOUT_VERSION,
+        req_blocks={
+            "d-req-draft": (
+                "xfer-draft",
+                [[300 + dcp_rank]],
+            )
+        },
+        req_global_page_ids={"d-req-draft": [[dcp_rank]]},
+        req_region_page_maps={
+            "d-req-draft": [
+                MooncakeRequestPageMap(
+                    region_index=0,
+                    group_index=0,
+                    valid_start_token=0,
+                    valid_end_token_exclusive=256,
+                    global_page_ids=[0, 1],
+                    dst_physical_block_ids=[200, 201],
+                )
+            ]
+        },
+        kv_caches_base_addr=[remote_base],
+        block_lens=[remote_block_len],
+        kv_block_lens=[128],
+        req_total_tokens={"d-req-draft": 256},
+        req_num_external_tokens={"d-req-draft": 256},
+        req_external_start_tokens={"d-req-draft": 0},
+    )
+
+    src, dst, lengths, err_reqs, err_msg = await worker._build_transfer_params(
+        ready_reqs=[("d-req-draft", send_meta)],
+        agent_meta=metadata,
+        local_regions=local_regions,
+        remote_regions=remote_regions,
+    )
+
+    assert err_reqs == []
+    assert err_msg is None
+    assert src == [
+        local_base + 10 * local_block_len + src_offset,
+        local_base + 11 * local_block_len + src_offset,
+    ]
+    assert dst == [
+        remote_base + 200 * remote_block_len,
+        remote_base + 201 * remote_block_len,
+    ]
+    assert lengths == [128, 128]
+
+
+@pytest.mark.asyncio
+async def test_build_transfer_params_keeps_dcp_zero_transfer_handshake():
+    layer_name = "model.layers.0.self_attn"
+    layer_spec = FullAttentionSpec(
+        block_size=128,
+        num_kv_heads=1,
+        head_size=16,
+        dtype=torch.float16,
+    )
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.shutdown = MagicMock()
+    worker.async_zmq_ctx = MagicMock()
+    worker.is_kv_consumer = False
+    worker.is_kv_producer = True
+    worker.tp_rank = 0
+    worker.tp_size = 4
+    worker.pcp_rank = 0
+    worker.pcp_size = 1
+    worker.dcp_rank = 0
+    worker.dcp_size = 1
+    worker.cp_kv_cache_interleave_size = 128
+    worker._physical_blocks_per_logical_kv_block = 1
+    worker.transfer_topo = SimpleNamespace(
+        local_replicates_kv_cache=False,
+        total_num_kv_heads=4,
+    )
+    worker._layer_specs = {layer_name: layer_spec}
+    worker.vllm_config = SimpleNamespace(
+        compilation_config=SimpleNamespace(
+            static_forward_context={layer_name: SimpleNamespace(total_num_kv_heads=4)}
+        )
+    )
+    worker.kv_cache_config = KVCacheConfig(
+        num_blocks=0,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec([layer_name], layer_spec)],
+    )
+
+    send_meta = SendBlockMeta(
+        p_req_id="p-req-dcp",
+        transfer_id="xfer-dcp",
+        local_block_ids=[[]],
+        ready=asyncio.Event(),
+    )
+    xfer_meta = MooncakeXferMetadata(
+        remote_hostname="consumer-host",
+        remote_port=54321,
+        remote_tp_size=8,
+        remote_tp_rank=0,
+        remote_pcp_size=1,
+        remote_pcp_rank=0,
+        remote_dcp_size=2,
+        remote_dcp_rank=0,
+        remote_cp_kv_cache_interleave_size=128,
+        remote_cp_block_pairing_version=MOONCAKE_CP_BLOCK_PAIRING_VERSION,
+        req_blocks={"d-req-dcp": ("xfer-dcp", [[]])},
+        req_global_page_ids={"d-req-dcp": [[]]},
+        kv_caches_base_addr=[0xA000],
+        block_lens=[128],
+        kv_block_lens=[128],
+        req_total_tokens={"d-req-dcp": 1024},
+        req_num_external_tokens={"d-req-dcp": 0},
+        req_external_start_tokens={"d-req-dcp": 1024},
+    )
+
+    (
+        src_ptrs,
+        dst_ptrs,
+        lengths,
+        err_reqs,
+        err_msg,
+    ) = await worker._build_transfer_params(
+        ready_reqs=[("d-req-dcp", send_meta)],
+        agent_meta=xfer_meta,
+        local_regions=[],
+        remote_regions=[],
+    )
+
+    assert src_ptrs == []
+    assert dst_ptrs == []
+    assert lengths == []
+    assert err_reqs == []
+    assert err_msg is None
+
+
+@pytest.mark.asyncio
+async def test_dcp_v2_missing_page_identities_fails_before_descriptors():
+    layer_name = "model.layers.0.self_attn"
+    layer_spec = FullAttentionSpec(
+        block_size=128,
+        num_kv_heads=1,
+        head_size=16,
+        dtype=torch.float16,
+    )
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.shutdown = MagicMock()
+    worker._physical_blocks_per_logical_kv_block = 1
+    worker.kv_cache_config = KVCacheConfig(
+        num_blocks=0,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec([layer_name], layer_spec)],
+    )
+    send_meta = SendBlockMeta(
+        p_req_id="p-req",
+        transfer_id="xfer",
+        local_block_ids=[[0, 1]],
+        ready=asyncio.Event(),
+    )
+    metadata = MooncakeXferMetadata(
+        remote_hostname="consumer-host",
+        remote_port=54321,
+        remote_tp_size=2,
+        remote_tp_rank=0,
+        remote_dcp_size=2,
+        remote_dcp_rank=0,
+        remote_cp_kv_cache_interleave_size=128,
+        remote_cp_block_pairing_version=MOONCAKE_CP_BLOCK_PAIRING_VERSION,
+        req_blocks={"d-req": ("xfer", [[100]])},
+        kv_caches_base_addr=[0xA000],
+        block_lens=[128],
+        kv_block_lens=[128],
+        req_total_tokens={"d-req": 256},
+        req_num_external_tokens={"d-req": 256},
+        req_external_start_tokens={"d-req": 0},
+    )
+
+    src, dst, lengths, err_reqs, err_msg = await worker._build_transfer_params(
+        ready_reqs=[("d-req", send_meta)],
+        agent_meta=metadata,
+        local_regions=[],
+        remote_regions=[],
+    )
+
+    assert src == dst == lengths == []
+    assert err_reqs == ["d-req"]
+    assert err_msg is not None
+    assert "global page identities" in err_msg
+
+    worker.pcp_size = 2
+    metadata.req_global_page_ids = {"d-req": [[0]]}
+    src, dst, lengths, err_reqs, err_msg = await worker._build_transfer_params(
+        ready_reqs=[("d-req", send_meta)],
+        agent_meta=metadata,
+        local_regions=[],
+        remote_regions=[],
+    )
+
+    assert src == dst == lengths == []
+    assert err_reqs == ["d-req"]
+    assert err_msg is not None
+    assert "PCP1" in err_msg
 
 
 class FakeMooncakeWrapper:
@@ -929,6 +2224,619 @@ def test_xfer_metadata_decodes_legacy_payload_with_alias_defaults():
     assert metadata.registered_layer_index_aliases == []
     assert metadata.registered_logical_group_indices == []
     assert metadata.registered_alias_group_indices == []
+    assert metadata.remote_dcp_size == 1
+    assert metadata.remote_dcp_rank == 0
+    assert metadata.remote_cp_kv_cache_interleave_size == 1
+    assert metadata.remote_cp_block_pairing_version == 0
+    assert metadata.req_region_page_maps == {}
+    assert metadata.registered_region_identities == []
+
+
+def test_xfer_metadata_round_trips_consumer_dcp_topology():
+    metadata = MooncakeXferMetadata(
+        remote_hostname="consumer-host",
+        remote_port=54321,
+        remote_tp_size=8,
+        remote_tp_rank=1,
+        req_blocks={"d-req": ("xfer", [[1]])},
+        kv_caches_base_addr=[0x1000],
+        block_lens=[4096],
+        kv_block_lens=[4096],
+        remote_dcp_size=2,
+        remote_dcp_rank=1,
+        remote_cp_kv_cache_interleave_size=128,
+        remote_cp_block_pairing_version=MOONCAKE_CP_BLOCK_PAIRING_VERSION,
+        req_global_page_ids={"d-req": [[1, 3, 5]]},
+    )
+
+    payload = msgspec.msgpack.encode(metadata)
+    decoded = msgspec.msgpack.decode(payload, type=MooncakeXferMetadata)
+
+    assert decoded.remote_dcp_size == 2
+    assert decoded.remote_dcp_rank == 1
+    assert decoded.remote_cp_kv_cache_interleave_size == 128
+    assert decoded.remote_cp_block_pairing_version == MOONCAKE_CP_BLOCK_PAIRING_VERSION
+    assert decoded.req_global_page_ids == {"d-req": [[1, 3, 5]]}
+
+
+def test_xfer_metadata_round_trips_full_temporal_region_pages():
+    identity = MooncakeRegionIdentity(
+        layer_name="model.layers.60.self_attn.attn",
+        temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL.value,
+        protocol_version=MOONCAKE_KV_REGION_LAYOUT_VERSION,
+        child_page_mapping=(KVCacheChildPageMapping.GLOBAL_PAGE_MODULO.value),
+        child_page_factor=2,
+    )
+    page_map = MooncakeRequestPageMap(
+        region_index=0,
+        group_index=0,
+        valid_start_token=0,
+        valid_end_token_exclusive=256,
+        global_page_ids=[0, 1],
+        dst_physical_block_ids=[200, 201],
+    )
+    metadata = MooncakeXferMetadata(
+        remote_hostname="consumer-host",
+        remote_port=54321,
+        remote_tp_size=8,
+        remote_tp_rank=1,
+        req_blocks={"d-req": ("xfer", [[100]])},
+        kv_caches_base_addr=[0x1000],
+        block_lens=[4096],
+        kv_block_lens=[2048],
+        remote_dcp_size=2,
+        remote_dcp_rank=1,
+        remote_cp_kv_cache_interleave_size=128,
+        remote_cp_block_pairing_version=MOONCAKE_KV_REGION_LAYOUT_VERSION,
+        req_global_page_ids={"d-req": [[1]]},
+        req_region_page_maps={"d-req": [page_map]},
+        registered_layer_names=[identity.layer_name],
+        registered_layer_indices=[60],
+        registered_region_identities=[identity],
+    )
+
+    decoded = msgspec.msgpack.decode(
+        msgspec.msgpack.encode(metadata),
+        type=MooncakeXferMetadata,
+    )
+
+    assert decoded.registered_region_identities == [identity]
+    assert decoded.req_region_page_maps == {"d-req": [page_map]}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("dcp_rank", "expected_target_blocks", "expected_target_pages"),
+    [
+        (0, [100], [0]),
+        (1, [100], [1]),
+    ],
+)
+async def test_consumer_requests_owner_target_and_all_full_temporal_pages(
+    dcp_rank: int,
+    expected_target_blocks: list[int],
+    expected_target_pages: list[int],
+):
+    layer_name = "model.layers.60.self_attn.attn"
+    layer_spec = FullAttentionSpec(
+        block_size=128,
+        num_kv_heads=8,
+        head_size=128,
+        dtype=torch.float16,
+        temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL,
+    )
+    identity = MooncakeRegionIdentity(
+        layer_name=layer_name,
+        temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL.value,
+        protocol_version=MOONCAKE_KV_REGION_LAYOUT_VERSION,
+        child_page_mapping=(KVCacheChildPageMapping.GLOBAL_PAGE_MODULO.value),
+        child_page_factor=2,
+    )
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.shutdown = MagicMock()
+    worker.hostname = "consumer-host"
+    worker.rpc_port = 54321
+    worker.tp_size = 8
+    worker.tp_rank = dcp_rank
+    worker.pcp_size = 1
+    worker.pcp_rank = 0
+    worker.dcp_size = 2
+    worker.dcp_rank = dcp_rank
+    worker.cp_kv_cache_interleave_size = 128
+    worker.async_zmq_ctx = MagicMock()
+    worker._encoder = msgspec.msgpack.Encoder()
+    worker._xfer_meta_decoder = msgspec.msgpack.Decoder(MooncakeXferMetadata)
+    worker._xfer_resp_decoder = msgspec.msgpack.Decoder(MooncakeXferResponse)
+    worker.transfer_topo = SimpleNamespace(virtually_split_kv_in_blocks=False)
+    worker.kv_cache_config = KVCacheConfig(
+        num_blocks=2,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                [layer_name],
+                layer_spec,
+            )
+        ],
+    )
+    worker._layer_specs = {layer_name: layer_spec}
+    worker.kv_caches_base_addr = [0x1000]
+    worker.block_len_per_layer = [4096]
+    worker.kv_block_len_per_layer = [4096]
+    worker.registered_layer_names = [layer_name]
+    worker.registered_layer_indices = [60]
+    worker.registered_group_indices = [0]
+    worker.registered_layer_aliases = [[layer_name]]
+    worker.registered_layer_index_aliases = [[60]]
+    worker.registered_logical_group_indices = [[0]]
+    worker.registered_alias_group_indices = [[[0]]]
+    worker.registered_region_identities = [identity]
+    worker.process_pulling_result = MagicMock(return_value={"d-req"})
+
+    pull_meta = PullReqMeta(
+        d_req_id="d-req",
+        transfer_id="xfer",
+        local_block_ids=[[100, 101]],
+        remote_engine_id="p-engine",
+        remote_bootstrap_addr="http://bootstrap:33333",
+        total_tokens=256,
+        num_external_tokens=256,
+        external_start_token=0,
+        pull_tasks_count=1,
+    )
+    response = MooncakeXferResponse(
+        status=MooncakeXferResponseStatus.FINISH,
+        ok_reqs=["d-req"],
+    )
+    socket = MagicMock(spec=zmq.asyncio.Socket)
+    socket.send = AsyncMock()
+    socket.recv = AsyncMock(return_value=worker._encoder.encode(response))
+    socket_context = MagicMock()
+    socket_context.__enter__.return_value = socket
+
+    with patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+        "mooncake_connector.make_zmq_socket",
+        return_value=socket_context,
+    ):
+        await worker.receive_kv_from_single_worker(
+            "tcp://producer:1234",
+            {"d-req": pull_meta},
+        )
+
+    sent_meta = worker._xfer_meta_decoder.decode(socket.send.await_args.args[0])
+    assert sent_meta.remote_cp_block_pairing_version == (
+        MOONCAKE_KV_REGION_LAYOUT_VERSION
+    )
+    assert sent_meta.req_blocks["d-req"] == (
+        "xfer",
+        [expected_target_blocks],
+    )
+    assert sent_meta.req_global_page_ids["d-req"] == [expected_target_pages]
+    assert sent_meta.req_region_page_maps["d-req"] == [
+        MooncakeRequestPageMap(
+            region_index=0,
+            group_index=0,
+            valid_start_token=0,
+            valid_end_token_exclusive=256,
+            global_page_ids=[0, 1],
+            dst_physical_block_ids=[200, 201],
+        )
+    ]
+    assert sent_meta.registered_region_identities == [identity]
+
+
+@pytest.mark.asyncio
+async def test_dcp1_consumer_requests_full_temporal_identity_pages():
+    layer_name = "model.layers.60.self_attn.attn"
+    layer_spec = FullAttentionSpec(
+        block_size=128,
+        num_kv_heads=8,
+        head_size=128,
+        dtype=torch.float16,
+        temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL,
+    )
+    identity = MooncakeRegionIdentity(
+        layer_name=layer_name,
+        temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL.value,
+        protocol_version=MOONCAKE_KV_REGION_LAYOUT_VERSION,
+        child_page_mapping=KVCacheChildPageMapping.IDENTITY.value,
+        child_page_factor=1,
+    )
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.shutdown = MagicMock()
+    worker.hostname = "consumer-host"
+    worker.rpc_port = 54321
+    worker.tp_size = 8
+    worker.tp_rank = 0
+    worker.pcp_size = 1
+    worker.pcp_rank = 0
+    worker.dcp_size = 1
+    worker.dcp_rank = 0
+    worker.cp_kv_cache_interleave_size = 1
+    worker.async_zmq_ctx = MagicMock()
+    worker._encoder = msgspec.msgpack.Encoder()
+    worker._xfer_meta_decoder = msgspec.msgpack.Decoder(MooncakeXferMetadata)
+    worker._xfer_resp_decoder = msgspec.msgpack.Decoder(MooncakeXferResponse)
+    worker.transfer_topo = SimpleNamespace(virtually_split_kv_in_blocks=False)
+    worker.kv_cache_config = KVCacheConfig(
+        num_blocks=3,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec([layer_name], layer_spec)],
+    )
+    worker._layer_specs = {layer_name: layer_spec}
+    worker.kv_caches_base_addr = [0x1000]
+    worker.block_len_per_layer = [4096]
+    worker.kv_block_len_per_layer = [4096]
+    worker.registered_layer_names = [layer_name]
+    worker.registered_layer_indices = [60]
+    worker.registered_group_indices = [0]
+    worker.registered_layer_aliases = [[layer_name]]
+    worker.registered_layer_index_aliases = [[60]]
+    worker.registered_logical_group_indices = [[0]]
+    worker.registered_alias_group_indices = [[[0]]]
+    worker.registered_region_identities = [identity]
+    worker.process_pulling_result = MagicMock(return_value={"d-req"})
+
+    pull_meta = PullReqMeta(
+        d_req_id="d-req",
+        transfer_id="xfer",
+        local_block_ids=[[100, 101, 102]],
+        remote_engine_id="p-engine",
+        remote_bootstrap_addr="http://bootstrap:33333",
+        total_tokens=256,
+        num_external_tokens=256,
+        external_start_token=0,
+        pull_tasks_count=1,
+    )
+    response = MooncakeXferResponse(
+        status=MooncakeXferResponseStatus.FINISH,
+        ok_reqs=["d-req"],
+    )
+    socket = MagicMock(spec=zmq.asyncio.Socket)
+    socket.send = AsyncMock()
+    socket.recv = AsyncMock(return_value=worker._encoder.encode(response))
+    socket_context = MagicMock()
+    socket_context.__enter__.return_value = socket
+
+    with patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+        "mooncake_connector.make_zmq_socket",
+        return_value=socket_context,
+    ):
+        await worker.receive_kv_from_single_worker(
+            "tcp://producer:1234",
+            {"d-req": pull_meta},
+        )
+
+    sent_meta = worker._xfer_meta_decoder.decode(socket.send.await_args.args[0])
+    assert sent_meta.remote_cp_block_pairing_version == (
+        MOONCAKE_KV_REGION_LAYOUT_VERSION
+    )
+    assert sent_meta.req_blocks["d-req"] == (
+        "xfer",
+        [[100, 101, 102]],
+    )
+    assert sent_meta.req_region_page_maps["d-req"] == [
+        MooncakeRequestPageMap(
+            region_index=0,
+            group_index=0,
+            valid_start_token=0,
+            valid_end_token_exclusive=256,
+            global_page_ids=[0, 1],
+            dst_physical_block_ids=[100, 101],
+        )
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("dcp_size", [1, 2])
+async def test_full_temporal_consumer_handles_abort_before_schedule(
+    dcp_size: int,
+):
+    layer_name = "model.layers.60.self_attn.attn"
+    layer_spec = FullAttentionSpec(
+        block_size=128,
+        num_kv_heads=8,
+        head_size=128,
+        dtype=torch.float16,
+        temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL,
+    )
+    identity = MooncakeRegionIdentity(
+        layer_name=layer_name,
+        temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL.value,
+        protocol_version=MOONCAKE_KV_REGION_LAYOUT_VERSION,
+        child_page_mapping=(
+            KVCacheChildPageMapping.IDENTITY.value
+            if dcp_size == 1
+            else KVCacheChildPageMapping.GLOBAL_PAGE_MODULO.value
+        ),
+        child_page_factor=dcp_size,
+    )
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.shutdown = MagicMock()
+    worker.hostname = "consumer-host"
+    worker.rpc_port = 54321
+    worker.tp_size = 8
+    worker.tp_rank = 0
+    worker.pcp_size = 1
+    worker.pcp_rank = 0
+    worker.dcp_size = dcp_size
+    worker.dcp_rank = 0
+    worker.cp_kv_cache_interleave_size = 1 if dcp_size == 1 else 128
+    worker.async_zmq_ctx = MagicMock()
+    worker._encoder = msgspec.msgpack.Encoder()
+    worker._xfer_meta_decoder = msgspec.msgpack.Decoder(MooncakeXferMetadata)
+    worker._xfer_resp_decoder = msgspec.msgpack.Decoder(MooncakeXferResponse)
+    worker.transfer_topo = SimpleNamespace(virtually_split_kv_in_blocks=False)
+    worker.kv_cache_config = KVCacheConfig(
+        num_blocks=2,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec([layer_name], layer_spec)],
+    )
+    worker._layer_specs = {layer_name: layer_spec}
+    worker.kv_caches_base_addr = [0x1000]
+    worker.block_len_per_layer = [4096]
+    worker.kv_block_len_per_layer = [4096]
+    worker.registered_layer_names = [layer_name]
+    worker.registered_layer_indices = [60]
+    worker.registered_group_indices = [0]
+    worker.registered_layer_aliases = [[layer_name]]
+    worker.registered_layer_index_aliases = [[60]]
+    worker.registered_logical_group_indices = [[0]]
+    worker.registered_alias_group_indices = [[[0]]]
+    worker.registered_region_identities = [identity]
+    worker.finished_recving_reqs = set()
+
+    pull_meta = PullReqMeta(
+        d_req_id="d-req-aborted",
+        transfer_id="xfer-aborted",
+        local_block_ids=[],
+        remote_engine_id="p-engine",
+        remote_bootstrap_addr="http://bootstrap:33333",
+        total_tokens=0,
+        num_external_tokens=0,
+        external_start_token=0,
+        pull_tasks_count=1,
+    )
+    response = MooncakeXferResponse(
+        status=MooncakeXferResponseStatus.FINISH,
+        ok_reqs=[pull_meta.d_req_id],
+    )
+    socket = MagicMock(spec=zmq.asyncio.Socket)
+    socket.send = AsyncMock()
+    socket.recv = AsyncMock(return_value=worker._encoder.encode(response))
+    socket_context = MagicMock()
+    socket_context.__enter__.return_value = socket
+
+    with patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+        "mooncake_connector.make_zmq_socket",
+        return_value=socket_context,
+    ):
+        await worker.receive_kv_from_single_worker(
+            "tcp://producer:1234",
+            {pull_meta.d_req_id: pull_meta},
+        )
+
+    sent_meta = worker._xfer_meta_decoder.decode(socket.send.await_args.args[0])
+    assert sent_meta.req_blocks[pull_meta.d_req_id] == (
+        pull_meta.transfer_id,
+        [[]],
+    )
+    assert sent_meta.req_global_page_ids[pull_meta.d_req_id] == [[]]
+    assert sent_meta.req_region_page_maps[pull_meta.d_req_id] == [
+        MooncakeRequestPageMap(
+            region_index=0,
+            group_index=0,
+            valid_start_token=0,
+            valid_end_token_exclusive=0,
+            global_page_ids=[],
+            dst_physical_block_ids=[],
+        )
+    ]
+    assert pull_meta.pull_tasks_count == 0
+    assert worker.finished_recving_reqs == {pull_meta.d_req_id}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("dcp_size", [1, 2])
+async def test_full_temporal_abort_completes_producer_consumer_lifecycle(
+    dcp_size: int,
+):
+    scheduler_config = create_vllm_config(
+        kv_connector="MooncakeConnector",
+        kv_role="kv_consumer",
+    )
+    scheduler = create_scheduler(scheduler_config)
+    scheduler_connector = scheduler.get_kv_connector().connector_scheduler
+    request = create_request(request_id=91, do_remote_prefill=True)
+    assert request.kv_transfer_params is not None
+    request.kv_transfer_params.update(
+        {
+            "transfer_id": "xfer-aborted-lifecycle",
+            "remote_bootstrap_addr": "http://bootstrap:33333",
+        }
+    )
+    request.status = RequestStatus.FINISHED_ABORTED
+
+    delay_free, _ = scheduler_connector.request_finished(request, block_ids=([],))
+    connector_meta = scheduler_connector.build_connector_meta(MagicMock())
+    pull_metas = connector_meta.reqs_to_recv["my-engine-id"]
+    pull_meta = pull_metas[request.request_id]
+    assert delay_free is False
+    assert pull_meta.local_block_ids == []
+
+    layer_name = "model.layers.60.self_attn.attn"
+    layer_spec = FullAttentionSpec(
+        block_size=128,
+        num_kv_heads=8,
+        head_size=128,
+        dtype=torch.float16,
+        temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL,
+    )
+    producer_identity = MooncakeRegionIdentity(
+        layer_name=layer_name,
+        temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL.value,
+        protocol_version=MOONCAKE_KV_REGION_LAYOUT_VERSION,
+        child_page_mapping=KVCacheChildPageMapping.IDENTITY.value,
+        child_page_factor=1,
+    )
+    consumer_identity = MooncakeRegionIdentity(
+        layer_name=layer_name,
+        temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL.value,
+        protocol_version=MOONCAKE_KV_REGION_LAYOUT_VERSION,
+        child_page_mapping=(
+            KVCacheChildPageMapping.IDENTITY.value
+            if dcp_size == 1
+            else KVCacheChildPageMapping.GLOBAL_PAGE_MODULO.value
+        ),
+        child_page_factor=dcp_size,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=2,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec([layer_name], layer_spec)],
+    )
+
+    producer = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    producer.shutdown = MagicMock()
+    producer.hostname = "producer-host"
+    producer.tp_size = 8
+    producer.tp_rank = 0
+    producer.pp_size = 1
+    producer.pp_rank = 0
+    producer.pcp_size = 1
+    producer.pcp_rank = 0
+    producer.dcp_size = 1
+    producer.dcp_rank = 0
+    producer.cp_kv_cache_interleave_size = 1
+    producer.transfer_topo = SimpleNamespace(
+        handshake_target_ranks=lambda _size: [0],
+        virtually_split_kv_in_blocks=False,
+        local_replicates_kv_cache=False,
+        total_num_kv_heads=8,
+    )
+    producer.vllm_config = create_vllm_config(
+        kv_connector="MooncakeConnector",
+        kv_role="kv_producer",
+    )
+    producer.kv_cache_config = kv_cache_config
+    producer._layer_specs = {layer_name: layer_spec}
+    producer.kv_caches_base_addr = [0x1000]
+    producer.block_len_per_layer = [4096]
+    producer.kv_block_len_per_layer = [4096]
+    producer.registered_layer_names = [layer_name]
+    producer.registered_layer_indices = [60]
+    producer.registered_group_indices = [0]
+    producer.registered_layer_aliases = [[layer_name]]
+    producer.registered_layer_index_aliases = [[60]]
+    producer.registered_logical_group_indices = [[0]]
+    producer.registered_alias_group_indices = [[[0]]]
+    producer.registered_region_identities = [producer_identity]
+    producer._physical_blocks_per_logical_kv_block = 1
+    producer._encoder = msgspec.msgpack.Encoder()
+    producer._xfer_meta_decoder = msgspec.msgpack.Decoder(MooncakeXferMetadata)
+    producer._xfer_resp_decoder = msgspec.msgpack.Decoder(MooncakeXferResponse)
+    producer.reqs_need_send = {}
+    producer.finished_sending_reqs = set()
+    producer._send_blocks = MagicMock(return_value=0)
+
+    send_meta = SendBlockMeta(
+        p_req_id="p-req-aborted-lifecycle",
+        transfer_id=pull_meta.transfer_id,
+        local_block_ids=[[10, 11]],
+        ready=asyncio.Event(),
+    )
+    send_meta.ready.set()
+    producer.reqs_need_send[send_meta.transfer_id] = send_meta
+
+    consumer = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    consumer.shutdown = MagicMock()
+    consumer.hostname = "consumer-host"
+    consumer.rpc_port = 54321
+    consumer.tp_size = 8
+    consumer.tp_rank = 0
+    consumer.pp_size = 1
+    consumer.pp_rank = 0
+    consumer.pcp_size = 1
+    consumer.pcp_rank = 0
+    consumer.dcp_size = dcp_size
+    consumer.dcp_rank = 0
+    consumer.cp_kv_cache_interleave_size = 1 if dcp_size == 1 else 128
+    consumer.transfer_topo = SimpleNamespace(
+        handshake_target_ranks=lambda _size: [0],
+        virtually_split_kv_in_blocks=False,
+    )
+    consumer.kv_cache_config = kv_cache_config
+    consumer._layer_specs = {layer_name: layer_spec}
+    consumer.kv_caches_base_addr = [0xA000]
+    consumer.block_len_per_layer = [4096]
+    consumer.kv_block_len_per_layer = [4096]
+    consumer.registered_layer_names = [layer_name]
+    consumer.registered_layer_indices = [60]
+    consumer.registered_group_indices = [0]
+    consumer.registered_layer_aliases = [[layer_name]]
+    consumer.registered_layer_index_aliases = [[60]]
+    consumer.registered_logical_group_indices = [[0]]
+    consumer.registered_alias_group_indices = [[[0]]]
+    consumer.registered_region_identities = [consumer_identity]
+    consumer._encoder = msgspec.msgpack.Encoder()
+    consumer._xfer_meta_decoder = msgspec.msgpack.Decoder(MooncakeXferMetadata)
+    consumer._xfer_resp_decoder = msgspec.msgpack.Decoder(MooncakeXferResponse)
+    consumer.async_zmq_ctx = MagicMock()
+    consumer._remote_agents = {"my-engine-id": {0: {0: {0: "tcp://producer:1234"}}}}
+    consumer._tp_size = {"my-engine-id": 8}
+    consumer._pcp_size = {"my-engine-id": 1}
+    consumer._cp_block_pairing_version = {
+        "my-engine-id": MOONCAKE_KV_REGION_LAYOUT_VERSION
+    }
+    consumer.finished_recving_reqs = set()
+
+    producer_socket = AsyncMock(spec=zmq.asyncio.Socket)
+    producer_socket.send_multipart = AsyncMock()
+    consumer_socket = MagicMock(spec=zmq.asyncio.Socket)
+    consumer_socket.setsockopt = MagicMock()
+    consumer_socket.send = AsyncMock()
+    producer_responses: list[MooncakeXferResponse] = []
+
+    async def receive_producer_response():
+        sent_metadata = producer._xfer_meta_decoder.decode(
+            consumer_socket.send.await_args.args[0]
+        )
+        await producer.send_kv_to_decode(
+            b"consumer-id",
+            producer_socket,
+            sent_metadata,
+        )
+        _, response = producer_socket.send_multipart.await_args.args[0]
+        producer_responses.append(producer._xfer_resp_decoder.decode(response))
+        return response
+
+    consumer_socket.recv = AsyncMock(side_effect=receive_producer_response)
+    socket_context = MagicMock()
+    socket_context.__enter__.return_value = consumer_socket
+
+    with patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.mooncake."
+        "mooncake_connector.make_zmq_socket",
+        return_value=socket_context,
+    ):
+        consumer.receive_kv("my-engine-id", pull_metas)
+        for _ in range(100):
+            if request.request_id in consumer.finished_recving_reqs:
+                break
+            await asyncio.sleep(0)
+
+    producer._send_blocks.assert_not_called()
+    assert len(producer_responses) == 1
+    assert producer_responses[0].status == MooncakeXferResponseStatus.FINISH
+    assert producer_responses[0].ok_reqs == [request.request_id]
+    assert not producer_responses[0].err_reqs
+    assert pull_meta.pull_failed is False
+    assert pull_meta.pull_tasks_count == 0
+    assert consumer.finished_recving_reqs == {request.request_id}
+    assert send_meta.transfer_id not in producer.reqs_need_send
+    assert producer.finished_sending_reqs == {send_meta.p_req_id}
 
 
 @pytest.mark.asyncio
@@ -1028,6 +2936,10 @@ async def test_build_transfer_params_separates_prefill_pp_layers():
         registered_layer_names=[region.layer_name for region in remote_regions],
         registered_layer_indices=[region.layer_index for region in remote_regions],
     )
+    worker._layer_specs = {
+        region.layer_name: worker.kv_cache_config.kv_cache_groups[0].kv_cache_spec
+        for region in remote_regions
+    }
 
     for pp_rank, local_regions in producer_pp_regions.items():
         aligned_local, aligned_remote, err = _align_transfer_regions(
@@ -1048,7 +2960,6 @@ async def test_build_transfer_params_separates_prefill_pp_layers():
             lengths,
             err_reqs,
             err_msg,
-            state_transfer_events,
         ) = await worker._build_transfer_params(
             ready_reqs=[("d-req-pp", send_meta)],
             agent_meta=xfer_meta,
@@ -1058,7 +2969,6 @@ async def test_build_transfer_params_separates_prefill_pp_layers():
 
         assert err_reqs == []
         assert err_msg is None
-        assert state_transfer_events == []
         assert src_ptrs == expected_by_pp_rank[pp_rank]["src_ptrs"]
         assert dst_ptrs == expected_by_pp_rank[pp_rank]["dst_ptrs"]
         assert lengths == [2 * block_len, 2 * block_len]
@@ -1131,13 +3041,10 @@ async def test_send_kv_to_decode_aligns_consumer_regions_by_layer_metadata(
         ) as mock_send_blocks:
             await prefill_worker.send_kv_to_decode(identity, mock_socket, xfer_meta)
 
-        src_ptrs, dst_ptrs, lengths, state_transfer_events = mock_send_blocks.call_args[
-            0
-        ][1:]
+        src_ptrs, dst_ptrs, lengths = mock_send_blocks.call_args[0][1:]
         assert src_ptrs == [0x1000 + 10 * block_len]
         assert dst_ptrs == [0xB000 + 20 * block_len]
         assert lengths == [block_len]
-        assert state_transfer_events == []
 
         sent_identity, sent_payload = mock_socket.send_multipart.call_args[0][0]
         assert sent_identity == identity
@@ -1274,6 +3181,7 @@ async def test_bootstrap_server(bootstrap_server: MooncakeBootstrapServer):
         "pp_rank": 0,
         "pcp_rank": 0,
         "pcp_size": 2,
+        "cp_block_pairing_version": MOONCAKE_CP_BLOCK_PAIRING_VERSION,
         "addr": "tcp://1.1.1.1:1111",
     }
     async with httpx.AsyncClient() as client:
@@ -1288,6 +3196,7 @@ async def test_bootstrap_server(bootstrap_server: MooncakeBootstrapServer):
         "pp_rank": 0,
         "pcp_rank": 1,
         "pcp_size": 2,
+        "cp_block_pairing_version": MOONCAKE_CP_BLOCK_PAIRING_VERSION,
         "addr": "tcp://1.1.1.2:1112",
     }
     async with httpx.AsyncClient() as client:
@@ -1301,6 +3210,7 @@ async def test_bootstrap_server(bootstrap_server: MooncakeBootstrapServer):
         "pp_rank": 1,
         "pcp_rank": 0,
         "pcp_size": 2,
+        "cp_block_pairing_version": MOONCAKE_CP_BLOCK_PAIRING_VERSION,
         "addr": "tcp://2.2.2.2:2222",
     }
     async with httpx.AsyncClient() as client:
@@ -1316,9 +3226,29 @@ async def test_bootstrap_server(bootstrap_server: MooncakeBootstrapServer):
         assert "0" in data
         assert data["0"]["engine_id"] == "eng-1"
         assert data["0"]["pcp_size"] == 2
+        assert (
+            data["0"]["cp_block_pairing_version"] == MOONCAKE_CP_BLOCK_PAIRING_VERSION
+        )
         assert data["0"]["worker_addr"]["0"]["0"]["0"] == ("tcp://1.1.1.1:1111")
         assert data["0"]["worker_addr"]["0"]["0"]["1"] == ("tcp://1.1.1.2:1112")
         assert data["0"]["worker_addr"]["0"]["1"]["0"] == ("tcp://2.2.2.2:2222")
+
+    payload_version_mismatch = {
+        "engine_id": "eng-1",
+        "dp_rank": 0,
+        "tp_rank": 1,
+        "pp_rank": 0,
+        "pcp_rank": 0,
+        "pcp_size": 2,
+        "cp_block_pairing_version": 0,
+        "addr": "tcp://3.3.3.3:3333",
+    }
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{base_url}/register", json=payload_version_mismatch
+        )
+        assert response.status_code == 400
+        assert "CP block pairing version mismatch" in response.text
 
     # Test failure: re-registering the same worker
     async with httpx.AsyncClient() as client:
@@ -1480,6 +3410,7 @@ def test_scheduler_request_finished():
     )
     scheduler = create_scheduler(vllm_config)
     scheduler_connector = scheduler.get_kv_connector().connector_scheduler
+    assert scheduler_connector.kv_cache_config.kv_cache_groups
 
     request = create_request(request_id=1, do_remote_decode=True)
     request.kv_transfer_params["transfer_id"] = request.request_id
@@ -1666,6 +3597,117 @@ async def test_receive_kv_selects_remote_pp_workers(
 
     assert seen_addrs == expected_addrs
     assert pull_metas["d-req-1"].pull_tasks_count == 0
+
+
+def test_receive_kv_rejects_legacy_producer_for_consumer_dcp():
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.shutdown = MagicMock()
+    worker.dcp_size = 2
+    worker._cp_block_pairing_version = {"p-engine": 0}
+    worker.transfer_topo = SimpleNamespace(handshake_target_ranks=MagicMock())
+    worker._invalid_block_ids_lock = threading.Lock()
+    worker._invalid_block_ids = set()
+    worker.finished_recving_reqs = set()
+    worker.receive_kv_from_single_worker = MagicMock()
+    pull_meta = PullReqMeta(
+        d_req_id="d-req-old-producer",
+        transfer_id="xfer-old-producer",
+        local_block_ids=[[100, 101]],
+        remote_engine_id="p-engine",
+        remote_bootstrap_addr="http://bootstrap:33333",
+    )
+
+    worker.receive_kv("p-engine", {pull_meta.d_req_id: pull_meta})
+
+    worker.transfer_topo.handshake_target_ranks.assert_not_called()
+    worker.receive_kv_from_single_worker.assert_not_called()
+    assert pull_meta.pull_failed is True
+    assert worker.finished_recving_reqs == {pull_meta.d_req_id}
+    assert worker.get_block_ids_with_load_errors() == {100, 101}
+
+
+@pytest.mark.parametrize("dcp_size", [1, 2])
+def test_receive_kv_rejects_v2_producer_for_full_temporal_consumer(
+    dcp_size: int,
+):
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.shutdown = MagicMock()
+    worker.dcp_size = dcp_size
+    worker.registered_region_identities = [
+        MooncakeRegionIdentity(
+            layer_name="model.layers.60.self_attn.attn",
+            temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL.value,
+            protocol_version=MOONCAKE_KV_REGION_LAYOUT_VERSION,
+            child_page_mapping=(
+                KVCacheChildPageMapping.IDENTITY.value
+                if dcp_size == 1
+                else KVCacheChildPageMapping.GLOBAL_PAGE_MODULO.value
+            ),
+            child_page_factor=dcp_size,
+        )
+    ]
+    worker._cp_block_pairing_version = {"p-engine": MOONCAKE_CP_BLOCK_PAIRING_VERSION}
+    worker.transfer_topo = SimpleNamespace(handshake_target_ranks=MagicMock())
+    worker._invalid_block_ids_lock = threading.Lock()
+    worker._invalid_block_ids = set()
+    worker.finished_recving_reqs = set()
+    worker.receive_kv_from_single_worker = MagicMock()
+    pull_meta = PullReqMeta(
+        d_req_id="d-req-v2-producer",
+        transfer_id="xfer-v2-producer",
+        local_block_ids=[[100, 101]],
+        remote_engine_id="p-engine",
+        remote_bootstrap_addr="http://bootstrap:33333",
+    )
+
+    worker.receive_kv("p-engine", {pull_meta.d_req_id: pull_meta})
+
+    worker.transfer_topo.handshake_target_ranks.assert_not_called()
+    worker.receive_kv_from_single_worker.assert_not_called()
+    assert pull_meta.pull_failed is True
+    assert worker.finished_recving_reqs == {pull_meta.d_req_id}
+    assert worker.get_block_ids_with_load_errors() == {100, 101}
+
+
+def test_receive_kv_rejects_pcp_producer_for_consumer_dcp():
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.shutdown = MagicMock()
+    worker.dcp_size = 2
+    worker.pcp_size = 1
+    worker.pp_size = 1
+    worker.pp_rank = 0
+    worker._cp_block_pairing_version = {"p-engine": MOONCAKE_CP_BLOCK_PAIRING_VERSION}
+    worker.transfer_topo = SimpleNamespace(handshake_target_ranks=lambda _size: [0])
+    worker._remote_agents = {
+        "p-engine": {
+            0: {
+                0: {
+                    0: "tcp://producer-pcp0:1234",
+                    1: "tcp://producer-pcp1:1234",
+                }
+            }
+        }
+    }
+    worker._tp_size = {"p-engine": 1}
+    worker._pcp_size = {"p-engine": 2}
+    worker._invalid_block_ids_lock = threading.Lock()
+    worker._invalid_block_ids = set()
+    worker.finished_recving_reqs = set()
+    worker.receive_kv_from_single_worker = MagicMock()
+    pull_meta = PullReqMeta(
+        d_req_id="d-req-pcp-producer",
+        transfer_id="xfer-pcp-producer",
+        local_block_ids=[[100, 101]],
+        remote_engine_id="p-engine",
+        remote_bootstrap_addr="http://bootstrap:33333",
+    )
+
+    worker.receive_kv("p-engine", {pull_meta.d_req_id: pull_meta})
+
+    worker.receive_kv_from_single_worker.assert_not_called()
+    assert pull_meta.pull_failed is True
+    assert worker.finished_recving_reqs == {pull_meta.d_req_id}
+    assert worker.get_block_ids_with_load_errors() == {100, 101}
 
 
 def test_receive_kv_rejects_consumer_pp_fanout():
@@ -1869,6 +3911,36 @@ def test_resolve_need_send_accounts_for_remote_tp_fanout():
     assert send_meta.need_send == 2
 
 
+def test_finish_failed_send_attempts_release_after_all_targets():
+    worker = MooncakeConnectorWorker.__new__(MooncakeConnectorWorker)
+    worker.async_zmq_ctx = MagicMock()
+    worker.reqs_need_send = {}
+    worker.finished_sending_reqs = set()
+    send_meta = SendBlockMeta(
+        p_req_id="p-req-failed",
+        transfer_id="xfer-failed",
+        local_block_ids=[[1]],
+        ready=asyncio.Event(),
+        need_send=2,
+        sending=2,
+    )
+    worker.reqs_need_send[send_meta.transfer_id] = send_meta
+
+    worker._finish_send_attempt(send_meta)
+
+    assert send_meta.sent == 1
+    assert send_meta.sending == 1
+    assert send_meta.transfer_id in worker.reqs_need_send
+    assert worker.finished_sending_reqs == set()
+
+    worker._finish_send_attempt(send_meta)
+
+    assert send_meta.sent == 2
+    assert send_meta.sending == 0
+    assert send_meta.transfer_id not in worker.reqs_need_send
+    assert worker.finished_sending_reqs == {"p-req-failed"}
+
+
 @pytest.mark.asyncio
 @patch(
     "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector.TransferEngine",
@@ -1922,6 +3994,7 @@ async def test_kv_producer(monkeypatch):
             remote_port=54321,
             remote_tp_size=1,
             remote_tp_rank=0,
+            remote_cp_block_pairing_version=MOONCAKE_CP_BLOCK_PAIRING_VERSION,
             req_blocks={"d-req-1": (transfer_id, [[20, 21]])},
             kv_caches_base_addr=[0x2000],
             block_lens=[block_len],
@@ -1954,7 +4027,6 @@ async def test_kv_producer(monkeypatch):
                 src,
                 dst,
                 lens,
-                [],
             )
             mock_socket.send_multipart.assert_called_once()
 
@@ -1987,7 +4059,6 @@ async def test_kv_producer(monkeypatch):
                 src,
                 dst,
                 lens,
-                [],
             )
             mock_socket.send_multipart.assert_called_once()
 
@@ -2378,7 +4449,7 @@ def test_pd_trace_lifecycle_clears_on_success_and_failure(monkeypatch):
     )
 
     assert worker._pd_trace_pull_started == {}
-    assert worker.finished_recving_reqs == {"d-req-ok"}
+    assert worker.finished_recving_reqs == {"d-req-ok", "d-req-failed"}
 
 
 def test_large_request_gate_uses_largest_kv_group_block_count():

--- a/tests/v1/spec_decode/test_dcp_draft_kv_contract.py
+++ b/tests/v1/spec_decode/test_dcp_draft_kv_contract.py
@@ -1,0 +1,448 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.config import CUDAGraphMode
+from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheChildPageMapping,
+    KVCacheRegionIdentity,
+    KVCacheTemporalLayout,
+)
+from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
+from vllm.v1.spec_decode.utils import (
+    get_eagle3_draft_attention_layer_name,
+    get_prompt_draft_kv_coverage,
+)
+from vllm.v1.worker import utils as worker_utils
+
+
+def _make_replicated_draft_proposer_for_validation(
+    *,
+    connector: str = "MooncakeConnector",
+    role: str = "kv_consumer",
+    module_path: str | None = None,
+    load_failure_policy: str = "fail",
+    dcp_size: int = 2,
+    enforce_eager: bool = True,
+    cudagraph_mode: CUDAGraphMode = CUDAGraphMode.NONE,
+    enable_prefix_caching: bool = False,
+) -> SpecDecodeBaseProposer:
+    proposer = object.__new__(SpecDecodeBaseProposer)
+    proposer.replicated_draft_kv = True
+    proposer.method = "eagle3"
+    proposer.parallel_drafting = False
+    proposer.needs_extra_input_slots = False
+    proposer.draft_model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(
+            num_hidden_layers=1,
+            num_attention_heads=64,
+            num_key_value_heads=64,
+            head_dim=128,
+        )
+    )
+    parallel_config = SimpleNamespace(
+        tensor_parallel_size=8,
+        decode_context_parallel_size=dcp_size,
+        pipeline_parallel_size=1,
+        prefill_context_parallel_size=1,
+        data_parallel_size=1,
+        use_ubatching=False,
+        cp_kv_cache_interleave_size=128,
+    )
+    model_config = SimpleNamespace(
+        architectures=["MiniMaxM3ForCausalLM"],
+        enforce_eager=enforce_eager,
+        get_num_layers=lambda _: 60,
+    )
+    proposer.vllm_config = SimpleNamespace(
+        parallel_config=parallel_config,
+        model_config=model_config,
+        compilation_config=SimpleNamespace(cudagraph_mode=cudagraph_mode),
+        scheduler_config=SimpleNamespace(async_scheduling=False),
+        cache_config=SimpleNamespace(
+            enable_prefix_caching=enable_prefix_caching,
+            kv_offloading_size=None,
+            block_size=128,
+        ),
+        kv_transfer_config=SimpleNamespace(
+            kv_connector=connector,
+            kv_role=role,
+            kv_connector_module_path=module_path,
+            kv_load_failure_policy=load_failure_policy,
+        ),
+    )
+    return proposer
+
+
+def test_minimax_sparse_and_draft_temporal_layouts_are_distinct() -> None:
+    assert KVCacheTemporalLayout.SHARDED_DCP != (KVCacheTemporalLayout.FULL_TEMPORAL)
+    assert KVCacheTemporalLayout.SHARDED_DCP.value == "sharded_dcp"
+    assert KVCacheTemporalLayout.FULL_TEMPORAL.value == "full_temporal"
+
+
+@pytest.mark.parametrize("dcp_size", [1, 2])
+def test_replicated_draft_accepts_builtin_mooncake_consumer(
+    dcp_size: int,
+) -> None:
+    proposer = _make_replicated_draft_proposer_for_validation(dcp_size=dcp_size)
+
+    proposer._validate_replicated_draft_kv_config()
+
+
+def test_replicated_draft_rejects_dcp3() -> None:
+    proposer = _make_replicated_draft_proposer_for_validation(dcp_size=3)
+
+    with pytest.raises(
+        ValueError,
+        match="decode_context_parallel_size must be 1 or 2",
+    ):
+        proposer._validate_replicated_draft_kv_config()
+
+
+@pytest.mark.parametrize(
+    ("enforce_eager", "cudagraph_mode"),
+    [
+        (True, CUDAGraphMode.NONE),
+        (False, CUDAGraphMode.FULL_DECODE_ONLY),
+    ],
+)
+def test_replicated_draft_execution_mode_allowlist(
+    enforce_eager: bool,
+    cudagraph_mode: CUDAGraphMode,
+) -> None:
+    proposer = _make_replicated_draft_proposer_for_validation(
+        enforce_eager=enforce_eager,
+        cudagraph_mode=cudagraph_mode,
+    )
+
+    proposer._validate_replicated_draft_kv_config()
+
+
+def test_replicated_draft_allows_atomic_prefix_caching() -> None:
+    proposer = _make_replicated_draft_proposer_for_validation(
+        enable_prefix_caching=True
+    )
+
+    proposer._validate_replicated_draft_kv_config()
+
+
+@pytest.mark.parametrize(
+    ("enforce_eager", "cudagraph_mode", "error"),
+    [
+        (True, CUDAGraphMode.FULL_DECODE_ONLY, "eager execution requires"),
+        (False, CUDAGraphMode.NONE, "non-eager execution requires"),
+        (False, CUDAGraphMode.PIECEWISE, "non-eager execution requires"),
+        (False, CUDAGraphMode.FULL, "non-eager execution requires"),
+        (False, CUDAGraphMode.FULL_AND_PIECEWISE, "non-eager execution requires"),
+    ],
+)
+def test_replicated_draft_rejects_unsupported_graph_modes(
+    enforce_eager: bool,
+    cudagraph_mode: CUDAGraphMode,
+    error: str,
+) -> None:
+    proposer = _make_replicated_draft_proposer_for_validation(
+        enforce_eager=enforce_eager,
+        cudagraph_mode=cudagraph_mode,
+    )
+
+    with pytest.raises(ValueError, match=error):
+        proposer._validate_replicated_draft_kv_config()
+
+
+def test_replicated_draft_metadata_reuses_graph_buffers() -> None:
+    proposer = object.__new__(SpecDecodeBaseProposer)
+    proposer.dcp_world_size = 2
+    proposer.max_model_len = 512
+    proposer.block_size = 128
+    proposer.cp_kv_cache_interleave_size = 128
+    proposer.uses_mrope = False
+    proposer.uses_xdrope_dim = 0
+    proposer.draft_uses_xdrope_dim = 0
+    proposer.positions = torch.tensor([0, 127, 128, 255], dtype=torch.int64)
+    proposer._replicated_draft_block_table = torch.zeros((2, 4), dtype=torch.int32)
+    proposer._replicated_draft_reject_mask = torch.ones(8, dtype=torch.bool)
+    proposer._slot_mapping_buffer = torch.zeros(8, dtype=torch.int64)
+
+    def metadata(
+        block_table: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        seq_lens: torch.Tensor,
+    ) -> CommonAttentionMetadata:
+        return CommonAttentionMetadata(
+            query_start_loc=query_start_loc,
+            query_start_loc_cpu=query_start_loc.cpu(),
+            seq_lens=seq_lens,
+            _seq_lens_cpu=seq_lens.cpu().clone(),
+            seq_lens_cpu_upper_bound=seq_lens.cpu().clone(),
+            num_reqs=seq_lens.numel(),
+            num_actual_tokens=int(query_start_loc[-1]),
+            max_query_len=int((query_start_loc[1:] - query_start_loc[:-1]).max()),
+            max_seq_len=int(seq_lens.max()),
+            block_table_tensor=block_table,
+            slot_mapping=torch.empty(0, dtype=torch.int64),
+        )
+
+    first = proposer._build_replicated_draft_metadata(
+        metadata(
+            torch.tensor([[3, 5], [7, 9]], dtype=torch.int32),
+            torch.tensor([0, 2, 4], dtype=torch.int32),
+            torch.tensor([128, 256], dtype=torch.int32),
+        ),
+        num_tokens=4,
+    )
+    block_ptr = first.block_table_tensor.data_ptr()
+    slot_ptr = first.slot_mapping.data_ptr()
+    assert first.block_table_tensor.tolist() == [[6, 7, 10, 11], [14, 15, 18, 19]]
+    assert not proposer._replicated_draft_reject_mask[:4].any()
+
+    proposer.positions[0] = 256
+    second = proposer._build_replicated_draft_metadata(
+        metadata(
+            torch.tensor([[11, 13]], dtype=torch.int32),
+            torch.tensor([0, 1], dtype=torch.int32),
+            torch.tensor([257], dtype=torch.int32),
+        ),
+        num_tokens=1,
+    )
+    assert second.block_table_tensor.data_ptr() == block_ptr
+    assert second.slot_mapping.data_ptr() == slot_ptr
+    assert second.block_table_tensor.tolist() == [[22, 23, 26, 27]]
+    assert second.slot_mapping.tolist() == [3328]
+
+
+@pytest.mark.parametrize(
+    ("connector", "role", "module_path", "load_failure_policy"),
+    [
+        ("MooncakeConnector", "kv_producer", None, "fail"),
+        ("MooncakeConnector", "kv_consumer", "custom.connector", "fail"),
+        ("MooncakeConnector", "kv_consumer", None, "recompute"),
+        ("NixlConnector", "kv_consumer", None, "fail"),
+    ],
+)
+def test_replicated_draft_rejects_unsupported_kv_transfer(
+    connector: str,
+    role: str,
+    module_path: str | None,
+    load_failure_policy: str,
+) -> None:
+    proposer = _make_replicated_draft_proposer_for_validation(
+        connector=connector,
+        role=role,
+        module_path=module_path,
+        load_failure_policy=load_failure_policy,
+    )
+
+    with pytest.raises(ValueError, match="built-in Mooncake consumer"):
+        proposer._validate_replicated_draft_kv_config()
+
+
+def test_attention_spec_preserves_temporal_layout_when_block_size_changes() -> None:
+    spec = FullAttentionSpec(
+        block_size=128,
+        temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL,
+        num_kv_heads=8,
+        head_size=128,
+        dtype=torch.float16,
+    )
+
+    resized = spec.copy_with_new_block_size(64)
+
+    assert resized.block_size == 64
+    assert resized.temporal_layout == KVCacheTemporalLayout.FULL_TEMPORAL
+
+
+def test_attention_spec_merge_rejects_mixed_temporal_layouts() -> None:
+    common = {
+        "block_size": 128,
+        "num_kv_heads": 8,
+        "head_size": 128,
+        "dtype": torch.float16,
+    }
+    sharded = FullAttentionSpec(
+        **common,
+        temporal_layout=KVCacheTemporalLayout.SHARDED_DCP,
+    )
+    full = FullAttentionSpec(
+        **common,
+        temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL,
+    )
+
+    with pytest.raises(AssertionError):
+        FullAttentionSpec.merge([sharded, full])
+
+
+def test_parent_block_copy_moves_both_full_temporal_children(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = torch.arange(3 * 2, dtype=torch.uint8).reshape(3, 2)
+    draft = torch.arange(6 * 2, dtype=torch.uint8).reshape(6, 2)
+    target_before = target.clone()
+    draft_before = draft.clone()
+    monkeypatch.setattr(
+        worker_utils,
+        "async_tensor_h2d",
+        lambda value, device: torch.from_numpy(value).to(device),
+    )
+
+    worker_utils.copy_kv_cache_blocks_inplace(
+        [target, draft],
+        num_blocks=3,
+        kv_cache_block_copies=[(0, 2)],
+    )
+
+    assert torch.equal(target[2], target_before[0])
+    assert torch.equal(draft[4:6], draft_before[0:2])
+
+
+def test_region_identity_includes_temporal_layout() -> None:
+    layer_name = "model.layers.60.self_attn.attn"
+    sharded = KVCacheRegionIdentity(
+        layer_name,
+        KVCacheTemporalLayout.SHARDED_DCP,
+        protocol_version=3,
+        child_page_mapping=KVCacheChildPageMapping.IDENTITY,
+        child_page_factor=1,
+    )
+    full = KVCacheRegionIdentity(
+        layer_name,
+        KVCacheTemporalLayout.FULL_TEMPORAL,
+        protocol_version=3,
+        child_page_mapping=KVCacheChildPageMapping.GLOBAL_PAGE_MODULO,
+        child_page_factor=2,
+    )
+
+    assert sharded != full
+    assert sharded.protocol_key == (
+        layer_name,
+        "sharded_dcp",
+        3,
+        "identity",
+        1,
+    )
+    assert full.protocol_key == (
+        layer_name,
+        "full_temporal",
+        3,
+        "global_page_modulo",
+        2,
+    )
+
+
+def test_region_identity_rejects_protocol_or_child_mapping_mismatch() -> None:
+    base = {
+        "layer_name": "model.layers.60.self_attn.attn",
+        "temporal_layout": KVCacheTemporalLayout.FULL_TEMPORAL,
+        "protocol_version": 3,
+        "child_page_mapping": KVCacheChildPageMapping.GLOBAL_PAGE_MODULO,
+        "child_page_factor": 2,
+    }
+    expected = KVCacheRegionIdentity(**base)
+
+    assert expected != KVCacheRegionIdentity(**{**base, "protocol_version": 2})
+    assert expected != KVCacheRegionIdentity(
+        **{**base, "child_page_mapping": KVCacheChildPageMapping.IDENTITY}
+    )
+    assert expected != KVCacheRegionIdentity(**{**base, "child_page_factor": 1})
+
+
+def test_eagle3_draft_layer_identity_is_global_under_pp1_and_pp2() -> None:
+    assert get_eagle3_draft_attention_layer_name(60) == (
+        "model.layers.60.self_attn.attn"
+    )
+    assert get_eagle3_draft_attention_layer_name(60, 1) == (
+        "model.layers.61.self_attn.attn"
+    )
+
+
+@pytest.mark.parametrize(
+    ("total_target_layers", "draft_layer_index"),
+    [(0, 0), (-1, 0), (30, 0), (61, 0), (60, -1)],
+)
+def test_invalid_draft_layer_identity_fails_closed(
+    total_target_layers: int,
+    draft_layer_index: int,
+) -> None:
+    with pytest.raises(ValueError):
+        get_eagle3_draft_attention_layer_name(
+            total_target_layers,
+            draft_layer_index,
+        )
+
+
+def test_prompt_draft_kv_final_token_is_decode_owned() -> None:
+    coverage = get_prompt_draft_kv_coverage(
+        prompt_tokens=257,
+        target_prefix_tokens=0,
+        compatible_draft_prefix_tokens=0,
+    )
+
+    assert coverage.transfer_start_token == 0
+    assert coverage.transfer_end_token_exclusive == 256
+    assert coverage.transfer_token_count == 256
+    assert coverage.decode_recompute_position == 256
+
+
+def test_prompt_draft_kv_compatible_prefix_transfers_exact_suffix() -> None:
+    coverage = get_prompt_draft_kv_coverage(
+        prompt_tokens=3500,
+        target_prefix_tokens=1024,
+        compatible_draft_prefix_tokens=768,
+    )
+
+    assert coverage.transfer_start_token == 768
+    assert coverage.transfer_end_token_exclusive == 3499
+    assert coverage.transfer_token_count == 2731
+
+
+def test_target_only_prefix_does_not_shrink_draft_suffix() -> None:
+    coverage = get_prompt_draft_kv_coverage(
+        prompt_tokens=256,
+        target_prefix_tokens=128,
+        compatible_draft_prefix_tokens=0,
+    )
+
+    assert coverage.transfer_start_token == 0
+    assert coverage.transfer_end_token_exclusive == 255
+
+
+def test_full_draft_prefix_still_recomputes_final_token() -> None:
+    coverage = get_prompt_draft_kv_coverage(
+        prompt_tokens=128,
+        target_prefix_tokens=128,
+        compatible_draft_prefix_tokens=128,
+    )
+
+    assert coverage.transfer_start_token == 127
+    assert coverage.transfer_end_token_exclusive == 127
+    assert coverage.transfer_token_count == 0
+    assert coverage.decode_recompute_position == 127
+
+
+@pytest.mark.parametrize(
+    ("prompt_tokens", "target_prefix_tokens", "draft_prefix_tokens"),
+    [
+        (0, 0, 0),
+        (128, -1, 0),
+        (128, 129, 0),
+        (128, 64, -1),
+        (128, 64, 65),
+    ],
+)
+def test_invalid_prompt_or_prefix_coverage_fails_closed(
+    prompt_tokens: int,
+    target_prefix_tokens: int,
+    draft_prefix_tokens: int,
+) -> None:
+    with pytest.raises(ValueError):
+        get_prompt_draft_kv_coverage(
+            prompt_tokens,
+            target_prefix_tokens,
+            draft_prefix_tokens,
+        )

--- a/tests/v1/spec_decode/test_dcp_slot_mapping.py
+++ b/tests/v1/spec_decode/test_dcp_slot_mapping.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.spec_decode.utils import (
+    PADDING_SLOT_ID,
+    _advance_cpu_sequence_metadata,
+    compute_new_slot_mapping,
+    compute_slot_mapping_from_block_table,
+    expand_dcp_parent_block_table,
+    extend_all_queries_by_N,
+)
+
+
+def _metadata(
+    query_start_loc: torch.Tensor,
+    seq_lens: torch.Tensor,
+    block_table: torch.Tensor,
+) -> CommonAttentionMetadata:
+    query_start_loc_cpu = query_start_loc.cpu()
+    seq_lens_cpu = seq_lens.cpu()
+    return CommonAttentionMetadata(
+        query_start_loc=query_start_loc,
+        query_start_loc_cpu=query_start_loc_cpu,
+        seq_lens=seq_lens,
+        _seq_lens_cpu=seq_lens_cpu.clone(),
+        seq_lens_cpu_upper_bound=seq_lens_cpu.clone(),
+        num_reqs=seq_lens.shape[0],
+        num_actual_tokens=int(query_start_loc_cpu[-1]),
+        max_query_len=int((query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]).max()),
+        max_seq_len=int(seq_lens_cpu.max()),
+        block_table_tensor=block_table,
+        slot_mapping=torch.empty(0, dtype=torch.int64),
+    )
+
+
+@pytest.mark.parametrize(
+    ("rank", "expected"),
+    [
+        (0, [12927, -1, -1, -1, 13055, -1]),
+        (1, [-1, 12800, 12927, -1, -1, 12928]),
+    ],
+)
+def test_compute_new_slot_mapping_localizes_dcp_owner(
+    rank: int,
+    expected: list[int],
+) -> None:
+    positions = torch.tensor([127, 128, 255, 256, 383, 384])
+    metadata = _metadata(
+        torch.tensor([0, positions.numel()], dtype=torch.int32),
+        torch.tensor([385], dtype=torch.int32),
+        torch.tensor([[100, 101, 102, 103]], dtype=torch.int32),
+    )
+    rejected = torch.tensor([False, False, False, True, False, False])
+
+    slots = compute_new_slot_mapping(
+        cad=metadata,
+        new_positions=positions,
+        is_rejected_token_mask=rejected,
+        block_size=128,
+        num_new_tokens=0,
+        max_model_len=1024,
+        dcp_world_size=2,
+        dcp_rank=rank,
+        cp_kv_cache_interleave_size=128,
+    )
+
+    assert slots.tolist() == expected
+    assert slots[3].item() == PADDING_SLOT_ID
+
+
+@pytest.mark.parametrize(
+    ("rank", "expected"),
+    [
+        (0, [12927, -1, -1, 25728, -1]),
+        (1, [-1, 12800, 12927, -1, -1]),
+    ],
+)
+def test_compute_new_slot_mapping_localizes_expanded_multi_request(
+    rank: int,
+    expected: list[int],
+) -> None:
+    metadata = _metadata(
+        torch.tensor([0, 2, 3], dtype=torch.int32),
+        torch.tensor([256, 384], dtype=torch.int32),
+        torch.tensor(
+            [[100, 101, 102], [200, 201, 202]],
+            dtype=torch.int32,
+        ),
+    )
+
+    slots = compute_new_slot_mapping(
+        cad=metadata,
+        new_positions=torch.tensor([127, 128, 255, 256, 383]),
+        is_rejected_token_mask=torch.tensor([False, False, False, False, True]),
+        block_size=128,
+        num_new_tokens=1,
+        max_model_len=1024,
+        dcp_world_size=2,
+        dcp_rank=rank,
+        cp_kv_cache_interleave_size=128,
+    )
+
+    assert slots.tolist() == expected
+
+
+def test_full_temporal_parent_child_mapping_at_boundaries() -> None:
+    parent_block_table = torch.tensor(
+        [[3, 5, 0], [7, 9, 0]],
+        dtype=torch.int32,
+    )
+    expanded = expand_dcp_parent_block_table(
+        parent_block_table,
+        dcp_world_size=2,
+        max_model_len=512,
+        kernel_block_size=128,
+    )
+    assert expanded.tolist() == [[6, 7, 10, 11], [14, 15, 18, 19]]
+    assert set(expanded[0].tolist()).isdisjoint(set(expanded[1].tolist()))
+    assert torch.equal(
+        expanded,
+        expand_dcp_parent_block_table(
+            parent_block_table,
+            dcp_world_size=2,
+            max_model_len=512,
+            kernel_block_size=128,
+        ),
+    )
+
+    positions = torch.tensor([0, 127, 128, 255, 256], dtype=torch.int64)
+    metadata = _metadata(
+        torch.tensor([0, 5], dtype=torch.int32),
+        torch.tensor([257], dtype=torch.int32),
+        expanded[:1],
+    )
+    slots = compute_new_slot_mapping(
+        cad=metadata,
+        new_positions=positions,
+        is_rejected_token_mask=torch.zeros(5, dtype=torch.bool),
+        block_size=128,
+        num_new_tokens=0,
+        max_model_len=512,
+    )
+    assert slots.tolist() == [768, 895, 896, 1023, 1280]
+
+    physical_pages = torch.div(slots, 128, rounding_mode="floor")
+    offsets = slots % 128
+    assert physical_pages.tolist() == [6, 6, 7, 7, 10]
+    assert offsets.tolist() == [0, 127, 0, 127, 0]
+
+    rejected_metadata = _metadata(
+        torch.tensor([0, 3], dtype=torch.int32),
+        torch.tensor([256], dtype=torch.int32),
+        expanded[:1],
+    )
+    rejected_slots = compute_new_slot_mapping(
+        cad=rejected_metadata,
+        new_positions=torch.tensor([127, 128, 255], dtype=torch.int64),
+        is_rejected_token_mask=torch.tensor([False, True, False]),
+        block_size=128,
+        num_new_tokens=0,
+        max_model_len=512,
+    )
+    assert rejected_slots.tolist() == [895, PADDING_SLOT_ID, 1023]
+
+    expanded_with_null = expand_dcp_parent_block_table(
+        parent_block_table[:1],
+        dcp_world_size=2,
+        max_model_len=768,
+        kernel_block_size=128,
+    )
+    assert expanded_with_null.tolist() == [[6, 7, 10, 11, 0, 0]]
+
+
+def test_full_temporal_parent_mapping_is_identity_at_dcp1() -> None:
+    parent = torch.tensor([[3, 5, 0]], dtype=torch.int32)
+
+    expanded = expand_dcp_parent_block_table(
+        parent,
+        dcp_world_size=1,
+        max_model_len=384,
+        kernel_block_size=128,
+    )
+
+    assert expanded.data_ptr() == parent.data_ptr()
+    assert expanded.tolist() == [[3, 5, 0]]
+
+
+def test_full_temporal_slot_mapping_uses_global_positions_across_requests() -> None:
+    block_table = torch.tensor(
+        [
+            [6, 7, 10, 11],
+            [14, 15, 18, 19],
+            [0, 1, 0, 1],
+        ],
+        dtype=torch.int32,
+    )
+
+    slots = compute_slot_mapping_from_block_table(
+        query_start_loc=torch.tensor([0, 3, 5, 5], dtype=torch.int32),
+        block_table_tensor=block_table,
+        positions=torch.tensor([0, 127, 128, 255, 256]),
+        block_size=128,
+        max_model_len=512,
+    )
+
+    assert slots.tolist() == [768, 895, 896, 2047, 2304]
+
+
+def test_extend_queries_updates_cpu_sequence_shadows() -> None:
+    metadata = _metadata(
+        torch.tensor([0, 1, 2], dtype=torch.int32),
+        torch.tensor([127, 255], dtype=torch.int32),
+        torch.tensor([[10, 11], [20, 21]], dtype=torch.int32),
+    )
+    metadata.dcp_local_seq_lens_cpu = torch.tensor(
+        [127, 128],
+        dtype=torch.int32,
+    )
+    original_local_seq_lens_cpu = metadata.dcp_local_seq_lens_cpu.clone()
+
+    extended = extend_all_queries_by_N(
+        metadata,
+        N=3,
+        arange=torch.arange(3, dtype=torch.int32),
+        new_slot_mapping=torch.arange(8, dtype=torch.int64),
+    )
+
+    assert extended.query_start_loc_cpu.tolist() == [0, 4, 8]
+    assert extended.seq_lens.tolist() == [130, 258]
+    assert extended._seq_lens_cpu is not None
+    assert extended._seq_lens_cpu.tolist() == [130, 258]
+    assert extended.seq_lens_cpu_upper_bound is not None
+    assert extended.seq_lens_cpu_upper_bound.tolist() == [130, 258]
+    assert extended.dcp_local_seq_lens_cpu is None
+    assert metadata.dcp_local_seq_lens_cpu.tolist() == (
+        original_local_seq_lens_cpu.tolist()
+    )
+
+
+def test_advance_cpu_sequence_metadata_handles_unpadded_alias() -> None:
+    metadata = _metadata(
+        torch.tensor([0, 1, 2], dtype=torch.int32),
+        torch.tensor([127, 128], dtype=torch.int32),
+        torch.tensor([[10, 11], [20, 21]], dtype=torch.int32),
+    )
+    shared_seq_lens = torch.tensor([127, 128, 999], dtype=torch.int32)
+    num_computed_tokens = torch.tensor([126, 127, 998], dtype=torch.int32)
+    metadata._seq_lens_cpu = shared_seq_lens
+    metadata.seq_lens_cpu_upper_bound = shared_seq_lens
+    metadata._num_computed_tokens_cpu = num_computed_tokens
+
+    unpadded = metadata.unpadded(num_actual_tokens=2, num_actual_reqs=2)
+    seq_lens = unpadded._seq_lens_cpu
+    upper_bound = unpadded.seq_lens_cpu_upper_bound
+    assert seq_lens is not None
+    assert upper_bound is not None
+    assert seq_lens is not upper_bound
+    assert seq_lens.data_ptr() == upper_bound.data_ptr()
+
+    _advance_cpu_sequence_metadata(unpadded, max_model_len=128)
+
+    assert shared_seq_lens.tolist() == [128, 1, 999]
+    assert num_computed_tokens.tolist() == [127, 0, 998]

--- a/tests/v1/spec_decode/test_eagle_prefill_draft_kv.py
+++ b/tests/v1/spec_decode/test_eagle_prefill_draft_kv.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest import mock
+
+import pytest
+import torch
+
+from vllm.v1.kv_cache_interface import HiddenStateCacheSpec
+from vllm.v1.spec_decode.eagle import EagleProposer
+
+
+class _FakeAttentionLayer:
+    def __init__(self, spec) -> None:
+        self.spec = spec
+
+    def get_kv_cache_spec(self, _):
+        return self.spec
+
+
+def test_eagle3_prefill_draft_cache_has_no_hidden_state_spec() -> None:
+    proposer = EagleProposer.__new__(EagleProposer)
+    proposer.speculative_config = mock.MagicMock(enable_eagle3_prefill_draft_kv=True)
+    proposer.vllm_config = mock.MagicMock()
+    proposer.vllm_config.model_config.get_total_num_hidden_layers.return_value = 60
+    proposer._draft_attn_layer_names = {"model.layers.60.self_attn.attn"}
+    draft_layer = _FakeAttentionLayer(mock.MagicMock())
+
+    proposer._validate_prefill_draft_kv_layers(
+        {"model.layers.60.self_attn.attn": draft_layer}
+    )
+
+    hidden_layer = _FakeAttentionLayer(
+        HiddenStateCacheSpec(
+            block_size=128,
+            num_kv_heads=3,
+            head_size=6144,
+            dtype=torch.bfloat16,
+        )
+    )
+    with pytest.raises(ValueError, match="must not allocate hidden-state cache"):
+        proposer._validate_prefill_draft_kv_layers(
+            {
+                "model.layers.60.self_attn.attn": draft_layer,
+                "cache_only_layers.60": hidden_layer,
+            }
+        )

--- a/tests/v1/spec_decode/test_eagle_step_kernel.py
+++ b/tests/v1/spec_decode/test_eagle_step_kernel.py
@@ -25,6 +25,9 @@ def _reference_eagle_step_slot_mapping(
     seq_lens: torch.Tensor,
     block_size: int,
     max_model_len: int,
+    dcp_world_size: int = 1,
+    dcp_rank: int = 0,
+    cp_kv_cache_interleave_size: int = 1,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Python reference for eagle_step_update_slot_mapping_and_metadata."""
     new_positions = positions_1d + 1
@@ -32,16 +35,24 @@ def _reference_eagle_step_slot_mapping(
     clamped_positions = torch.where(
         exceeds_max, torch.zeros_like(positions_1d), new_positions
     )
-    block_numbers = (clamped_positions // block_size).clamp(
+    cp_cycle = dcp_world_size * cp_kv_cache_interleave_size
+    owner_ranks = clamped_positions.remainder(cp_cycle) // cp_kv_cache_interleave_size
+    local_positions = (
+        clamped_positions // cp_cycle * cp_kv_cache_interleave_size
+        + clamped_positions.remainder(cp_kv_cache_interleave_size)
+    )
+    block_numbers = (local_positions // block_size).clamp(
         max=block_table_tensor.shape[1] - 1
     )
     block_ids = block_table_tensor[
         torch.arange(positions_1d.shape[0], device=positions_1d.device),
         block_numbers.long(),
     ].long()
-    slot_mapping = block_ids * block_size + (clamped_positions % block_size)
+    slot_mapping = block_ids * block_size + (local_positions % block_size)
     slot_mapping = torch.where(
-        exceeds_max, torch.full_like(slot_mapping, PADDING_SLOT_ID), slot_mapping
+        exceeds_max | (owner_ranks != dcp_rank),
+        torch.full_like(slot_mapping, PADDING_SLOT_ID),
+        slot_mapping,
     )
     new_seq_lens = torch.where(exceeds_max, torch.ones_like(seq_lens), seq_lens + 1)
     new_seq_lens = new_seq_lens.clamp(max=max_model_len)
@@ -176,3 +187,62 @@ def test_eagle_step_slot_mapping_kernel_cudagraph_padding():
     # Padding slots should be PADDING_SLOT_ID
     for i in range(batch_size, input_batch_size):
         assert out_slot[i].item() == PADDING_SLOT_ID
+
+
+@pytest.mark.parametrize("rank", [0, 1])
+def test_eagle_step_slot_mapping_kernel_dcp_interleave(rank: int):
+    device = torch.device(DEVICE_TYPE)
+    positions = torch.tensor(
+        [126, 127, 254, 255, 382, 383],
+        dtype=torch.int64,
+        device=device,
+    )
+    batch_size = positions.shape[0]
+    input_batch_size = 8
+    block_size = 128
+    interleave = 128
+    block_table = (
+        torch.arange(batch_size * 4, dtype=torch.int32, device=device).view(
+            batch_size, 4
+        )
+        + 100
+    )
+    seq_lens = positions.to(torch.int32) + 1
+
+    ref_positions, ref_slots, ref_seq_lens = _reference_eagle_step_slot_mapping(
+        positions,
+        block_table,
+        seq_lens,
+        block_size,
+        max_model_len=1024,
+        dcp_world_size=2,
+        dcp_rank=rank,
+        cp_kv_cache_interleave_size=interleave,
+    )
+    out_positions = torch.empty_like(positions)
+    out_slots = torch.full(
+        (input_batch_size,),
+        -999,
+        dtype=torch.int64,
+        device=device,
+    )
+    actual_seq_lens = seq_lens.clone()
+
+    eagle_step_update_slot_mapping_and_metadata(
+        positions_1d=positions,
+        block_table_tensor=block_table,
+        seq_lens=actual_seq_lens,
+        block_size=block_size,
+        max_model_len=1024,
+        out_clamped_positions=out_positions,
+        out_slot_mapping=out_slots,
+        input_batch_size=input_batch_size,
+        dcp_world_size=2,
+        dcp_rank=rank,
+        cp_kv_cache_interleave_size=interleave,
+    )
+
+    torch.testing.assert_close(out_positions, ref_positions)
+    torch.testing.assert_close(out_slots[:batch_size], ref_slots)
+    torch.testing.assert_close(actual_seq_lens, ref_seq_lens)
+    assert torch.all(out_slots[batch_size:] == PADDING_SLOT_ID)

--- a/tests/v1/worker/test_cp_utils.py
+++ b/tests/v1/worker/test_cp_utils.py
@@ -1,10 +1,51 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+
 import pytest
 import torch
 
+import vllm.v1.worker.cp_utils as cp_utils
 from vllm.v1.attention.backends.utils import get_dcp_local_seq_lens
-from vllm.v1.worker.cp_utils import should_skip_dcp_context_attention
+from vllm.v1.worker.cp_utils import (
+    check_attention_cp_compatibility,
+    should_skip_dcp_context_attention,
+)
+
+
+def test_cp_compatibility_allows_effective_dcp1_layer(monkeypatch) -> None:
+    full_temporal = SimpleNamespace(
+        dcp_world_size=1,
+        need_to_return_lse_for_decode=False,
+        supports_mtp_with_cp_non_trivial_interleave_size=True,
+    )
+    sharded = SimpleNamespace(
+        dcp_world_size=2,
+        need_to_return_lse_for_decode=True,
+        supports_mtp_with_cp_non_trivial_interleave_size=True,
+    )
+    monkeypatch.setattr(
+        cp_utils,
+        "get_layers_from_vllm_config",
+        lambda *_args, **_kwargs: {
+            "dense": SimpleNamespace(impl=full_temporal),
+            "sparse": SimpleNamespace(impl=sharded),
+        },
+    )
+    config = SimpleNamespace(
+        speculative_config=SimpleNamespace(),
+        parallel_config=SimpleNamespace(
+            prefill_context_parallel_size=1,
+            decode_context_parallel_size=2,
+            cp_kv_cache_interleave_size=128,
+        ),
+    )
+
+    check_attention_cp_compatibility(config)
+
+    sharded.need_to_return_lse_for_decode = False
+    with pytest.raises(AssertionError, match="requires attention"):
+        check_attention_cp_compatibility(config)
 
 
 def test_skip_gate_only_for_zero_context():

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -12,6 +13,7 @@ import vllm.v1.worker.gpu_model_runner as gpu_model_runner_module
 from vllm.config import (
     AttentionConfig,
     CacheConfig,
+    CUDAGraphMode,
     KVTransferConfig,
     ModelConfig,
     ParallelConfig,
@@ -42,6 +44,7 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
+    KVCacheTemporalLayout,
     KVCacheTensor,
 )
 from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT
@@ -85,6 +88,489 @@ def test_v1_kv_producer_only_requires_active_pure_producer(
     runner.vllm_config = SimpleNamespace(kv_transfer_config=kv_transfer_config)
 
     assert runner._is_kv_producer_only_instance() is expected
+
+
+@pytest.mark.parametrize(
+    ("enforce_eager", "resolved_mode"),
+    [
+        (True, CUDAGraphMode.NONE),
+        (False, CUDAGraphMode.FULL_DECODE_ONLY),
+    ],
+)
+def test_replicated_draft_accepts_resolved_cudagraph_mode(
+    enforce_eager: bool,
+    resolved_mode: CUDAGraphMode,
+) -> None:
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.speculative_config = SimpleNamespace(enable_eagle3_replicated_draft_kv=True)
+    runner.model_config = SimpleNamespace(enforce_eager=enforce_eager)
+
+    runner._validate_replicated_draft_cudagraph_mode(resolved_mode)
+
+
+@pytest.mark.parametrize(
+    "resolved_mode",
+    [
+        CUDAGraphMode.NONE,
+        CUDAGraphMode.PIECEWISE,
+        CUDAGraphMode.FULL,
+        CUDAGraphMode.FULL_AND_PIECEWISE,
+    ],
+)
+def test_replicated_draft_rejects_backend_cudagraph_downgrade(
+    resolved_mode: CUDAGraphMode,
+) -> None:
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.speculative_config = SimpleNamespace(enable_eagle3_replicated_draft_kv=True)
+    runner.model_config = SimpleNamespace(enforce_eager=False)
+
+    with pytest.raises(ValueError, match="resolved an unsupported CUDA Graph mode"):
+        runner._validate_replicated_draft_cudagraph_mode(resolved_mode)
+
+
+@pytest.mark.parametrize("is_last_pp_rank", [False, True])
+def test_extract_hidden_states_producer_only_creates_drafter_on_last_pp_rank(
+    monkeypatch: pytest.MonkeyPatch,
+    is_last_pp_rank: bool,
+) -> None:
+    spec_config = SimpleNamespace(
+        method="extract_hidden_states",
+        num_speculative_tokens=1,
+        uses_extract_hidden_states=lambda: True,
+        draft_model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(eagle_aux_hidden_state_layer_ids=(2, 30, 57))
+        ),
+    )
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.speculative_config = spec_config
+    runner.vllm_config = SimpleNamespace(
+        kv_transfer_config=KVTransferConfig(
+            kv_connector="NixlConnector",
+            kv_role="kv_producer",
+        )
+    )
+    runner.use_aux_hidden_state_outputs = False
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_last_rank=is_last_pp_rank, world_size=2),
+    )
+
+    runner._configure_kv_producer_speculation()
+
+    if is_last_pp_rank:
+        assert runner.speculative_config is spec_config
+        assert runner._target_speculative_config is spec_config
+        assert runner.num_spec_tokens == 1
+        assert runner._producer_aux_hidden_state_layers == ()
+        assert not runner.use_aux_hidden_state_outputs
+    else:
+        assert runner.speculative_config is None
+        assert runner._target_speculative_config is spec_config
+        assert runner.num_spec_tokens == 1
+        assert runner._producer_aux_hidden_state_layers == (2, 30, 57)
+        assert runner.use_aux_hidden_state_outputs
+        assert not hasattr(runner, "drafter")
+
+
+def test_non_last_extract_hidden_states_producer_clamps_spec_placeholders() -> None:
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner._target_speculative_config = SimpleNamespace()
+    runner.input_ids = SimpleNamespace(
+        gpu=torch.tensor([41, -1, 17, -1], dtype=torch.int32)
+    )
+
+    runner._clamp_speculative_input_ids(3)
+
+    assert runner.input_ids.gpu.tolist() == [41, 0, 17, -1]
+
+
+def test_eagle_producer_only_keeps_existing_non_speculative_runner_state() -> None:
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.speculative_config = SimpleNamespace(
+        method="eagle3",
+        num_speculative_tokens=3,
+    )
+    runner.vllm_config = SimpleNamespace(
+        kv_transfer_config=KVTransferConfig(
+            kv_connector="NixlConnector",
+            kv_role="kv_producer",
+        )
+    )
+    runner.use_aux_hidden_state_outputs = False
+
+    runner._configure_kv_producer_speculation()
+
+    assert runner.speculative_config is None
+    assert runner._target_speculative_config is None
+    assert runner.num_spec_tokens == 0
+    assert runner.prev_num_spec_tokens == 0
+    assert runner._producer_aux_hidden_state_layers == ()
+    assert not runner.use_aux_hidden_state_outputs
+
+
+@pytest.mark.parametrize("is_last_pp_rank", [False, True])
+def test_eagle3_prefill_draft_kv_stage_ownership(
+    monkeypatch: pytest.MonkeyPatch,
+    is_last_pp_rank: bool,
+) -> None:
+    spec_config = SimpleNamespace(
+        method="eagle3",
+        num_speculative_tokens=1,
+        enable_eagle3_prefill_draft_kv=True,
+        draft_model_config=SimpleNamespace(hf_config=SimpleNamespace()),
+    )
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.speculative_config = spec_config
+    runner.vllm_config = SimpleNamespace(
+        kv_transfer_config=KVTransferConfig(
+            kv_connector="MooncakeConnector",
+            kv_role="kv_producer",
+            kv_load_failure_policy="fail",
+        )
+    )
+    runner.model_config = SimpleNamespace(
+        architectures=["MiniMaxM3SparseForConditionalGeneration"],
+        get_total_num_hidden_layers=lambda: 60,
+    )
+    runner.parallel_config = SimpleNamespace(
+        pipeline_parallel_size=2,
+        tensor_parallel_size=4,
+        decode_context_parallel_size=1,
+    )
+    runner.use_aux_hidden_state_outputs = False
+    monkeypatch.setattr(
+        gpu_model_runner_module.current_platform,
+        "is_cuda",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_last_rank=is_last_pp_rank, world_size=2),
+    )
+
+    runner._configure_kv_producer_speculation()
+
+    assert runner._target_speculative_config is spec_config
+    assert runner.num_spec_tokens == 1
+    if is_last_pp_rank:
+        assert runner.speculative_config is spec_config
+        assert runner._producer_aux_hidden_state_layers == ()
+        assert not runner.use_aux_hidden_state_outputs
+    else:
+        assert runner.speculative_config is None
+        assert runner._producer_aux_hidden_state_layers == (2, 30, 57)
+        assert runner.use_aux_hidden_state_outputs
+        assert not hasattr(runner, "drafter")
+
+
+@pytest.mark.parametrize(
+    "kv_transfer_config",
+    [
+        None,
+        KVTransferConfig(
+            kv_connector="MooncakeConnector",
+            kv_role="kv_consumer",
+            kv_load_failure_policy="fail",
+        ),
+        KVTransferConfig(
+            kv_connector="MooncakeConnector",
+            kv_role="kv_both",
+            kv_load_failure_policy="fail",
+        ),
+        KVTransferConfig(
+            kv_connector="NixlConnector",
+            kv_role="kv_producer",
+            kv_load_failure_policy="fail",
+        ),
+    ],
+    ids=["no-connector", "consumer", "both", "non-mooncake"],
+)
+def test_eagle3_prefill_draft_kv_rejects_non_pure_mooncake_producer(
+    monkeypatch: pytest.MonkeyPatch,
+    kv_transfer_config: KVTransferConfig | None,
+) -> None:
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.speculative_config = SimpleNamespace(
+        method="eagle3",
+        num_speculative_tokens=1,
+        enable_eagle3_prefill_draft_kv=True,
+        draft_model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(eagle_aux_hidden_state_layer_ids=(2, 30, 57))
+        ),
+    )
+    runner.vllm_config = SimpleNamespace(kv_transfer_config=kv_transfer_config)
+    runner.model_config = SimpleNamespace(
+        architectures=["MiniMaxM3SparseForConditionalGeneration"],
+        get_total_num_hidden_layers=lambda: 60,
+    )
+    runner.parallel_config = SimpleNamespace(
+        pipeline_parallel_size=2,
+        tensor_parallel_size=4,
+        decode_context_parallel_size=1,
+    )
+    runner.use_aux_hidden_state_outputs = False
+    monkeypatch.setattr(
+        gpu_model_runner_module.current_platform,
+        "is_cuda",
+        lambda: True,
+    )
+
+    with pytest.raises(ValueError, match="Mooncake pure producer"):
+        runner._configure_kv_producer_speculation()
+
+
+@pytest.mark.parametrize(
+    "feature_flag",
+    [
+        "enable_eagle3_prefill_draft_kv",
+        "enable_eagle3_replicated_draft_kv",
+    ],
+)
+def test_full_temporal_draft_kv_marks_only_global_draft_layer(
+    monkeypatch: pytest.MonkeyPatch,
+    feature_flag: str,
+) -> None:
+    class FakeAttention:
+        def __init__(self, spec: FullAttentionSpec) -> None:
+            self._spec = spec
+            self.kv_sharing_target_layer_name = None
+
+        def get_kv_cache_spec(self, _vllm_config):
+            return self._spec
+
+        def get_attn_backend(self):
+            return SimpleNamespace(indexes_kv_by_block_stride=lambda: False)
+
+    target_layer = "model.layers.0.self_attn.attn"
+    draft_layer = "model.layers.60.self_attn.attn"
+    base_spec = FullAttentionSpec(
+        block_size=128,
+        num_kv_heads=8,
+        head_size=128,
+        dtype=torch.float16,
+    )
+    layers = {
+        target_layer: FakeAttention(base_spec),
+        draft_layer: FakeAttention(base_spec),
+    }
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.speculative_config = SimpleNamespace(
+        enable_eagle3_prefill_draft_kv=False,
+        enable_eagle3_replicated_draft_kv=False,
+    )
+    setattr(runner.speculative_config, feature_flag, True)
+    runner.model_config = SimpleNamespace(get_total_num_hidden_layers=lambda: 60)
+    runner.vllm_config = SimpleNamespace()
+    runner.shared_kv_cache_layers = {}
+    monkeypatch.setattr(gpu_model_runner_module, "Attention", FakeAttention)
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "get_layers_from_vllm_config",
+        lambda *_args, **_kwargs: layers,
+    )
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "set_current_vllm_config",
+        lambda _config: nullcontext(),
+    )
+
+    specs = runner.get_kv_cache_spec()
+
+    assert specs[target_layer].temporal_layout == (KVCacheTemporalLayout.SHARDED_DCP)
+    assert specs[draft_layer].temporal_layout == (KVCacheTemporalLayout.FULL_TEMPORAL)
+
+
+@pytest.mark.parametrize("layer_prefix", ["language_model.model", "model"])
+def test_prefill_marks_minimax_target_dense_layers_full_temporal(
+    monkeypatch: pytest.MonkeyPatch,
+    layer_prefix: str,
+) -> None:
+    class FakeAttention:
+        def __init__(self, spec: FullAttentionSpec) -> None:
+            self._spec = spec
+            self.kv_sharing_target_layer_name = None
+
+        def get_kv_cache_spec(self, _vllm_config):
+            return self._spec
+
+        def get_attn_backend(self):
+            return SimpleNamespace(indexes_kv_by_block_stride=lambda: False)
+
+    layer_names = [
+        f"{layer_prefix}.layers.{layer}.self_attn.attn" for layer in range(4)
+    ]
+    base_spec = FullAttentionSpec(
+        block_size=128,
+        num_kv_heads=8,
+        head_size=128,
+        dtype=torch.float16,
+    )
+    layers = {layer_name: FakeAttention(base_spec) for layer_name in layer_names}
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.speculative_config = None
+    runner._target_speculative_config = SimpleNamespace(
+        enable_eagle3_prefill_draft_kv=True,
+        enable_eagle3_replicated_draft_kv=False,
+        enable_eagle3_target_dense_full_temporal_kv=True,
+    )
+    runner.model_config = SimpleNamespace(get_total_num_hidden_layers=lambda: 60)
+    runner.vllm_config = SimpleNamespace()
+    runner.shared_kv_cache_layers = {}
+    runner.dcp_world_size = 1
+    monkeypatch.setattr(gpu_model_runner_module, "Attention", FakeAttention)
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "get_layers_from_vllm_config",
+        lambda *_args, **_kwargs: layers,
+    )
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "set_current_vllm_config",
+        lambda _config: nullcontext(),
+    )
+
+    specs = runner.get_kv_cache_spec()
+
+    for layer_name in layer_names[:3]:
+        assert specs[layer_name].temporal_layout == (
+            KVCacheTemporalLayout.FULL_TEMPORAL
+        )
+    assert specs[layer_names[3]].temporal_layout == (KVCacheTemporalLayout.SHARDED_DCP)
+
+
+@pytest.mark.parametrize("layer_prefix", ["language_model.model", "model"])
+@pytest.mark.parametrize("dcp_size", [1, 2])
+def test_decode_target_dense_layers_use_effective_dcp1(
+    monkeypatch: pytest.MonkeyPatch,
+    layer_prefix: str,
+    dcp_size: int,
+) -> None:
+    class FakeAttention:
+        def __init__(self, spec: FullAttentionSpec) -> None:
+            self._spec = spec
+            self.kv_sharing_target_layer_name = None
+            self.impl = SimpleNamespace(
+                dcp_world_size=dcp_size,
+                dcp_rank=0 if dcp_size == 1 else 1,
+                pcp_world_size=1,
+                pcp_rank=0,
+                total_cp_world_size=dcp_size,
+                total_cp_rank=0 if dcp_size == 1 else 1,
+                need_to_return_lse_for_decode=dcp_size > 1,
+            )
+
+        def get_kv_cache_spec(self, _vllm_config):
+            return self._spec
+
+        def get_attn_backend(self):
+            return SimpleNamespace(
+                get_name=lambda: "FLASH_ATTN",
+                indexes_kv_by_block_stride=lambda: False,
+            )
+
+    dense_layers = [
+        f"{layer_prefix}.layers.{layer}.self_attn.attn" for layer in range(3)
+    ]
+    sparse_layer = f"{layer_prefix}.layers.3.self_attn.attn"
+    draft_layer = "model.layers.60.self_attn.attn"
+    base_spec = FullAttentionSpec(
+        block_size=128,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.float16,
+    )
+    layers = {
+        layer_name: FakeAttention(base_spec)
+        for layer_name in (*dense_layers, sparse_layer, draft_layer)
+    }
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.speculative_config = SimpleNamespace(
+        enable_eagle3_prefill_draft_kv=False,
+        enable_eagle3_replicated_draft_kv=True,
+        enable_eagle3_target_dense_full_temporal_kv=True,
+    )
+    runner._target_speculative_config = runner.speculative_config
+    runner.model_config = SimpleNamespace(get_total_num_hidden_layers=lambda: 60)
+    runner.vllm_config = SimpleNamespace()
+    runner.shared_kv_cache_layers = {}
+    runner.dcp_world_size = dcp_size
+    monkeypatch.setattr(gpu_model_runner_module, "Attention", FakeAttention)
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "get_layers_from_vllm_config",
+        lambda *_args, **_kwargs: layers,
+    )
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "set_current_vllm_config",
+        lambda _config: nullcontext(),
+    )
+
+    specs = runner.get_kv_cache_spec()
+
+    for layer_name in dense_layers:
+        impl = layers[layer_name].impl
+        assert specs[layer_name].temporal_layout == (
+            KVCacheTemporalLayout.FULL_TEMPORAL
+        )
+        assert impl.dcp_world_size == 1
+        assert impl.dcp_rank == 0
+        assert impl.total_cp_world_size == 1
+        assert impl.total_cp_rank == 0
+        assert impl.need_to_return_lse_for_decode is False
+    assert layers[sparse_layer].impl.dcp_world_size == dcp_size
+    assert layers[draft_layer].impl.dcp_world_size == dcp_size
+
+
+def test_full_temporal_target_mapping_expands_pages_and_masks_padding() -> None:
+    parent_table = torch.tensor(
+        [[3, 5], [7, 9], [0, 0]],
+        dtype=torch.int32,
+    )
+    block_table = SimpleNamespace(
+        block_size=128,
+        block_table=SimpleNamespace(gpu=parent_table),
+        get_device_tensor=lambda num_reqs: parent_table[:num_reqs],
+    )
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.input_batch = SimpleNamespace(block_table=[block_table])
+    runner.query_start_loc = SimpleNamespace(
+        gpu=torch.tensor([0, 3, 5, 5], dtype=torch.int32)
+    )
+    runner.positions = torch.tensor([0, 127, 128, 255, 256, 0])
+    runner.dcp_world_size = 2
+    runner.max_model_len = 512
+    runner.max_num_tokens = 6
+    runner.device = torch.device("cpu")
+    runner._full_temporal_block_tables = {}
+    runner._full_temporal_slot_mappings = {}
+
+    expanded, slots = runner._get_full_temporal_target_mapping(
+        kv_cache_gid=0,
+        num_tokens_padded=6,
+        num_reqs_padded=3,
+        num_tokens_unpadded=5,
+    )
+
+    assert expanded.tolist() == [
+        [6, 7, 10, 11],
+        [14, 15, 18, 19],
+        [0, 0, 0, 0],
+    ]
+    assert slots.tolist() == [768, 895, 896, 2047, 2304, -1]
+
+
+def test_clear_full_temporal_target_mappings_releases_buffers() -> None:
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner._full_temporal_block_tables = {0: torch.empty(1)}
+    runner._full_temporal_slot_mappings = {0: torch.empty(1)}
+
+    runner._clear_full_temporal_target_mappings()
+
+    assert runner._full_temporal_block_tables == {}
+    assert runner._full_temporal_slot_mappings == {}
 
 
 def test_calc_spec_decode_metadata_rejects_all_draft_schedule():

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -16,6 +16,7 @@ from vllm.config.model import HfOverrides, ModelConfig
 from vllm.config.parallel import ParallelConfig
 from vllm.config.utils import config
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
 from vllm.transformers_utils.config import get_hf_text_config
 from vllm.utils.hashing import safe_hash
 from vllm.utils.import_utils import LazyLoader, has_arctic_inference
@@ -168,6 +169,20 @@ class SpeculativeConfig:
     in parallel rather than sequentially. This can improve performance but
     requires the speculative model be trained to support parallel drafting.
     Only compatible with EAGLE and draft model methods."""
+
+    enable_eagle3_prefill_draft_kv: bool = False
+    """Run EAGLE3 K=1 as a last-stage sidecar on a supported PP Prefill
+    producer to materialize prompt draft KV. This does not enable draft-KV
+    transfer or Decode consumption."""
+
+    enable_eagle3_replicated_draft_kv: bool = False
+    """Give the EAGLE3 draft layer full-temporal KV storage and effective-DCP1
+    attention on a supported DCP Decode instance."""
+
+    enable_eagle3_target_dense_full_temporal_kv: bool = False
+    """Give MiniMax-M3 target dense layers 0..2 full-temporal KV storage and
+    effective-DCP1 attention. Requires a supported Prefill draft-KV producer
+    or replicated-draft Decode configuration."""
 
     # required configuration params passed from engine
     target_model_config: SkipValidation[ModelConfig] = None  # type: ignore
@@ -325,6 +340,9 @@ class SpeculativeConfig:
             "dspark",
         )
         factors.append(uses_aux_hidden_states)
+        factors.append(self.enable_eagle3_prefill_draft_kv)
+        factors.append(self.enable_eagle3_replicated_draft_kv)
+        factors.append(self.enable_eagle3_target_dense_full_temporal_kv)
 
         if uses_aux_hidden_states and self.draft_model_config is not None:
             factors.append(self.draft_model_config.compute_hash())
@@ -1203,6 +1221,113 @@ class SpeculativeConfig:
             return AttentionBackendEnum[value.upper()]
         return value
 
+    def _verify_eagle3_prefill_draft_kv(self) -> None:
+        errors: list[str] = []
+        parallel_config = self.target_parallel_config
+        target_architectures = self.target_model_config.architectures or []
+        draft_config = self.draft_model_config
+        if self.method != "eagle3":
+            errors.append("method must be eagle3")
+        if self.num_speculative_tokens != 1:
+            errors.append("num_speculative_tokens must be 1")
+        if not current_platform.is_cuda():
+            errors.append("CUDA is required")
+        if not any("MiniMaxM3" in str(arch) for arch in target_architectures):
+            errors.append("target architecture must be MiniMaxM3")
+        if self.target_model_config.get_total_num_hidden_layers() != 60:
+            errors.append("target model must contain exactly 60 layers")
+        if parallel_config.pipeline_parallel_size != 2:
+            errors.append("pipeline_parallel_size must be 2")
+        if parallel_config.tensor_parallel_size != 4:
+            errors.append("tensor_parallel_size must be 4")
+        if parallel_config.decode_context_parallel_size != 1:
+            errors.append("decode_context_parallel_size must be 1")
+        if self.parallel_drafting:
+            errors.append("parallel drafting must be disabled")
+        if self.uses_dynamic_speculative_decoding():
+            errors.append("dynamic speculative decoding must be disabled")
+        if draft_config is None:
+            errors.append("draft model config is required")
+        else:
+            draft_hf_config = draft_config.hf_config
+            if getattr(draft_hf_config, "num_hidden_layers", None) != 1:
+                errors.append("draft model must contain exactly one layer")
+            if getattr(draft_hf_config, "num_attention_heads", None) != 64:
+                errors.append("draft model must have 64 attention heads")
+            if getattr(draft_hf_config, "num_key_value_heads", None) != 64:
+                errors.append("draft model must have 64 KV heads")
+            if getattr(draft_hf_config, "head_dim", None) != 128:
+                errors.append("draft model head_dim must be 128")
+        draft_parallel_config = self.draft_parallel_config
+        if (
+            draft_parallel_config is None
+            or draft_parallel_config.tensor_parallel_size != 4
+        ):
+            errors.append("draft tensor_parallel_size must be 4")
+        if errors:
+            raise ValueError(
+                "EAGLE3 Prefill draft-KV requirements not met: " + "; ".join(errors)
+            )
+
+    def _verify_eagle3_replicated_draft_kv(self) -> None:
+        errors: list[str] = []
+        parallel_config = self.target_parallel_config
+        target_architectures = self.target_model_config.architectures or []
+        draft_config = self.draft_model_config
+        if self.method != "eagle3":
+            errors.append("method must be eagle3")
+        if self.num_speculative_tokens != 3:
+            errors.append("num_speculative_tokens must be 3")
+        if not current_platform.is_cuda():
+            errors.append("CUDA is required")
+        if not any("MiniMaxM3" in str(arch) for arch in target_architectures):
+            errors.append("target architecture must be MiniMaxM3")
+        if self.target_model_config.get_total_num_hidden_layers() != 60:
+            errors.append("target model must contain exactly 60 layers")
+        if parallel_config.pipeline_parallel_size != 1:
+            errors.append("pipeline_parallel_size must be 1")
+        if parallel_config.tensor_parallel_size != 8:
+            errors.append("tensor_parallel_size must be 8")
+        if parallel_config.decode_context_parallel_size not in (1, 2):
+            errors.append("decode_context_parallel_size must be 1 or 2")
+        if parallel_config.prefill_context_parallel_size != 1:
+            errors.append("prefill_context_parallel_size must be 1")
+        if parallel_config.data_parallel_size != 1:
+            errors.append("data_parallel_size must be 1")
+        if parallel_config.use_ubatching:
+            errors.append("ubatching must be disabled")
+        if self.parallel_drafting:
+            errors.append("parallel drafting must be disabled")
+        if self.uses_dynamic_speculative_decoding():
+            errors.append("dynamic speculative decoding must be disabled")
+        if draft_config is None:
+            errors.append("draft model config is required")
+        else:
+            draft_hf_config = draft_config.hf_config
+            if getattr(draft_hf_config, "num_hidden_layers", None) != 1:
+                errors.append("draft model must contain exactly one layer")
+            if getattr(draft_hf_config, "num_attention_heads", None) != 64:
+                errors.append("draft model must have 64 attention heads")
+            if getattr(draft_hf_config, "num_key_value_heads", None) != 64:
+                errors.append("draft model must have 64 KV heads")
+            if getattr(draft_hf_config, "head_dim", None) != 128:
+                errors.append("draft model head_dim must be 128")
+        draft_parallel_config = self.draft_parallel_config
+        if (
+            draft_parallel_config is None
+            or draft_parallel_config.tensor_parallel_size != 8
+        ):
+            errors.append("draft tensor_parallel_size must be 8")
+        if errors:
+            raise ValueError(
+                "EAGLE3 replicated draft-KV requirements not met: " + "; ".join(errors)
+            )
+
+    def _verify_eagle3_target_dense_full_temporal_kv(self) -> None:
+        # Execution-mode validation belongs to the Decode proposer, where the
+        # resolved CUDA Graph mode is available.
+        return None
+
     @model_validator(mode="after")
     def _verify_args(self) -> Self:
         if self.tensor_parallel_size is not None:
@@ -1242,9 +1367,53 @@ class SpeculativeConfig:
             )
 
         if self.draft_model_config:
-            self.draft_model_config.verify_with_parallel_config(
-                self.draft_parallel_config
+            if self.uses_extract_hidden_states() or self.enable_eagle3_prefill_draft_kv:
+                pp_size = self.target_parallel_config.pipeline_parallel_size
+                if self.uses_extract_hidden_states():
+                    supports_transport = getattr(
+                        self.target_model_config.hf_text_config,
+                        "supports_pp_aux_hidden_state_transport",
+                        False,
+                    )
+                else:
+                    supports_transport = True
+                if pp_size > 1 and (
+                    not supports_transport or not current_platform.is_cuda()
+                ):
+                    raise NotImplementedError(
+                        "The target model does not support pipeline-parallel "
+                        "auxiliary hidden-state transport required by "
+                        f"{self.method}."
+                    )
+                # These modes instantiate their draft/cache writer only on
+                # the last target PP rank. They are sidecars, not
+                # pipeline-partitioned draft models. The target model has
+                # already been validated for PP.
+            else:
+                self.draft_model_config.verify_with_parallel_config(
+                    self.draft_parallel_config
+                )
+
+        if self.enable_eagle3_prefill_draft_kv:
+            self._verify_eagle3_prefill_draft_kv()
+        if self.enable_eagle3_replicated_draft_kv:
+            if self.enable_eagle3_prefill_draft_kv:
+                raise ValueError(
+                    "Prefill draft-KV production and Decode replicated "
+                    "draft-KV cannot be enabled together"
+                )
+            self._verify_eagle3_replicated_draft_kv()
+        if (
+            self.enable_eagle3_target_dense_full_temporal_kv
+            and not self.enable_eagle3_prefill_draft_kv
+            and not self.enable_eagle3_replicated_draft_kv
+        ):
+            raise ValueError(
+                "EAGLE3 target dense full-temporal KV requires either "
+                "Prefill draft-KV production or Decode replicated draft-KV"
             )
+        if self.enable_eagle3_target_dense_full_temporal_kv:
+            self._verify_eagle3_target_dense_full_temporal_kv()
 
         if (
             self.dynamic_sd_dp_batch_policy is not None

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2207,6 +2207,18 @@ class VllmConfig:
                 and self.parallel_config.pipeline_parallel_size > 1
             ):
                 unsupported.append("EAGLE3 with pipeline parallelism")
+            if getattr(
+                speculative_config,
+                "enable_eagle3_replicated_draft_kv",
+                False,
+            ):
+                unsupported.append("EAGLE3 replicated draft KV")
+            if getattr(
+                speculative_config,
+                "enable_eagle3_target_dense_full_temporal_kv",
+                False,
+            ):
+                unsupported.append("EAGLE3 target dense full-temporal KV")
 
         if self.parallel_config.enable_dbo:
             unsupported.append("dual batch overlap")
@@ -2289,15 +2301,40 @@ class VllmConfig:
                 "than or equal to and divisible by cp_kv_cache_interleave_size "
                 f"({self.parallel_config.cp_kv_cache_interleave_size})."
             )
-            if (
-                self.speculative_config is not None
-                and self.speculative_config.method in ("dflash", "dspark")
-            ):
-                raise NotImplementedError(
-                    "DFlash/DSpark speculative decoding does not support "
-                    "decode context parallelism; use "
-                    "decode_context_parallel_size=1 or another speculative method."
+            speculative_config = self.speculative_config
+            if speculative_config is not None:
+                method = speculative_config.method
+                if method in ("dflash", "dspark"):
+                    raise NotImplementedError(
+                        "DFlash/DSpark speculative decoding does not support "
+                        "decode context parallelism; use "
+                        "decode_context_parallel_size=1 or another speculative "
+                        "method."
+                    )
+                if method == "draft_model":
+                    raise NotImplementedError(
+                        "Draft-model speculative decoding does not support "
+                        "decode context parallelism because the draft parallel "
+                        "configuration does not inherit DCP; use "
+                        "decode_context_parallel_size=1 or another speculative "
+                        "method."
+                    )
+
+                draft_model_config = getattr(
+                    speculative_config, "draft_model_config", None
                 )
+                draft_hf_config = getattr(draft_model_config, "hf_config", None)
+                if (
+                    method == "mtp"
+                    and getattr(draft_hf_config, "model_type", None) == "step3p5_mtp"
+                ):
+                    raise NotImplementedError(
+                        "Step3 MTP speculative decoding does not support decode "
+                        "context parallelism because secondary KV-cache groups "
+                        "are not DCP-localized; use "
+                        "decode_context_parallel_size=1 or another speculative "
+                        "method."
+                    )
 
         # Mamba cache align-mode constraints
         if self.cache_config.mamba_cache_mode == "align":

--- a/vllm/distributed/cp_mapping.py
+++ b/vllm/distributed/cp_mapping.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Canonical context-parallel token and page ownership helpers."""
+
+from collections.abc import Iterator
+
+import torch
+
+
+def _validate_cp(cp_world_size: int, interleave_size: int) -> None:
+    if cp_world_size <= 0:
+        raise ValueError("cp_world_size must be positive")
+    if interleave_size <= 0:
+        raise ValueError("interleave_size must be positive")
+
+
+def _validate_rank(cp_rank: int, cp_world_size: int) -> None:
+    if not 0 <= cp_rank < cp_world_size:
+        raise ValueError(f"cp_rank must be in [0, {cp_world_size}), got {cp_rank}")
+
+
+def get_cp_token_owner(
+    global_position: int,
+    cp_world_size: int,
+    interleave_size: int,
+) -> int:
+    """Return the context-parallel rank that owns a global token position."""
+    _validate_cp(cp_world_size, interleave_size)
+    if global_position < 0:
+        raise ValueError("global_position must be non-negative")
+    return (global_position // interleave_size) % cp_world_size
+
+
+def get_cp_local_position(
+    global_position: int,
+    cp_world_size: int,
+    interleave_size: int,
+) -> int:
+    """Map a global token position to its compact owner-local position."""
+    _validate_cp(cp_world_size, interleave_size)
+    if global_position < 0:
+        raise ValueError("global_position must be non-negative")
+    cycle_size = cp_world_size * interleave_size
+    return (
+        global_position // cycle_size * interleave_size
+        + global_position % interleave_size
+    )
+
+
+def get_cp_global_position(
+    cp_rank: int,
+    local_position: int,
+    cp_world_size: int,
+    interleave_size: int,
+) -> int:
+    """Map an owner-local token position back to its global position."""
+    _validate_cp(cp_world_size, interleave_size)
+    _validate_rank(cp_rank, cp_world_size)
+    if local_position < 0:
+        raise ValueError("local_position must be non-negative")
+    local_cycle, cycle_offset = divmod(local_position, interleave_size)
+    return (
+        local_cycle * cp_world_size * interleave_size
+        + cp_rank * interleave_size
+        + cycle_offset
+    )
+
+
+def map_cp_positions(
+    global_positions: torch.Tensor,
+    cp_world_size: int,
+    interleave_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Vectorized global-position mapping for runtime metadata paths."""
+    _validate_cp(cp_world_size, interleave_size)
+    cycle_size = cp_world_size * interleave_size
+    owners = global_positions.div(interleave_size, rounding_mode="floor").remainder(
+        cp_world_size
+    )
+    local_positions = global_positions.div(
+        cycle_size, rounding_mode="floor"
+    ) * interleave_size + global_positions.remainder(interleave_size)
+    return owners, local_positions
+
+
+def get_cp_local_seq_lens(
+    seq_lens: torch.Tensor,
+    cp_world_size: int = 1,
+    cp_rank: int | None = None,
+    interleave_size: int = 1,
+) -> torch.Tensor:
+    """Return compact sequence lengths for one or every CP rank."""
+    _validate_cp(cp_world_size, interleave_size)
+    if cp_rank is not None:
+        _validate_rank(cp_rank, cp_world_size)
+
+    seq_lens_i32 = seq_lens.to(torch.int32)
+    if cp_rank is None:
+        rank_offsets = torch.arange(
+            cp_world_size,
+            dtype=torch.int32,
+            device=seq_lens.device,
+        ).view(
+            *((1,) * seq_lens_i32.dim()),
+            cp_world_size,
+        )
+        seq_lens_tiled = seq_lens_i32.unsqueeze(-1)
+    else:
+        rank_offsets = torch.tensor(
+            cp_rank,
+            dtype=torch.int32,
+            device=seq_lens.device,
+        )
+        seq_lens_tiled = seq_lens_i32
+
+    cycle_size = cp_world_size * interleave_size
+    full_cycles, remainder = (
+        torch.div(
+            seq_lens_tiled,
+            cycle_size,
+            rounding_mode="floor",
+        ),
+        seq_lens_tiled.remainder(cycle_size),
+    )
+    rank_tail = torch.clamp(
+        remainder - rank_offsets * interleave_size,
+        0,
+        interleave_size,
+    )
+    return full_cycles * interleave_size + rank_tail
+
+
+def get_cp_local_seq_len(
+    seq_len: int,
+    cp_world_size: int,
+    cp_rank: int,
+    interleave_size: int,
+) -> int:
+    """Scalar equivalent of :func:`get_cp_local_seq_lens`."""
+    _validate_cp(cp_world_size, interleave_size)
+    _validate_rank(cp_rank, cp_world_size)
+    if seq_len < 0:
+        raise ValueError("seq_len must be non-negative")
+    cycle_size = cp_world_size * interleave_size
+    full_cycles, remainder = divmod(seq_len, cycle_size)
+    rank_tail = min(
+        max(remainder - cp_rank * interleave_size, 0),
+        interleave_size,
+    )
+    return full_cycles * interleave_size + rank_tail
+
+
+def global_page_to_local_page(
+    global_page: int,
+    cp_world_size: int,
+    page_size: int,
+    interleave_size: int,
+) -> tuple[int, int]:
+    """Map a global page to ``(owner, compact local page)``.
+
+    The production contract initially requires one ownership interleave per
+    physical page.
+    """
+    _validate_cp(cp_world_size, interleave_size)
+    if page_size != interleave_size:
+        raise ValueError("CP page mapping requires page_size == interleave_size")
+    if global_page < 0:
+        raise ValueError("global_page must be non-negative")
+    return global_page % cp_world_size, global_page // cp_world_size
+
+
+def local_page_to_global_page(
+    cp_rank: int,
+    local_page: int,
+    cp_world_size: int,
+    page_size: int,
+    interleave_size: int,
+) -> int:
+    """Map an owner-local physical page back to its global page."""
+    _validate_cp(cp_world_size, interleave_size)
+    _validate_rank(cp_rank, cp_world_size)
+    if page_size != interleave_size:
+        raise ValueError("CP page mapping requires page_size == interleave_size")
+    if local_page < 0:
+        raise ValueError("local_page must be non-negative")
+    return local_page * cp_world_size + cp_rank
+
+
+def get_suffix_global_page_range(
+    total_tokens: int,
+    external_start_token: int,
+    page_size: int,
+) -> range:
+    """Return global pages touched by an exact suffix token range."""
+    if page_size <= 0:
+        raise ValueError("page_size must be positive")
+    if total_tokens < 0 or not 0 <= external_start_token <= total_tokens:
+        raise ValueError("suffix token range is invalid")
+    if external_start_token == total_tokens:
+        return range(0)
+    first_page = external_start_token // page_size
+    end_page = (total_tokens + page_size - 1) // page_size
+    return range(first_page, end_page)
+
+
+def iter_owned_suffix_pages(
+    total_tokens: int,
+    external_start_token: int,
+    cp_world_size: int,
+    cp_rank: int,
+    page_size: int,
+    interleave_size: int,
+) -> Iterator[tuple[int, int]]:
+    """Yield ``(global_page, local_page)`` pairs owned by one CP rank."""
+    _validate_rank(cp_rank, cp_world_size)
+    for global_page in get_suffix_global_page_range(
+        total_tokens,
+        external_start_token,
+        page_size,
+    ):
+        owner, local_page = global_page_to_local_page(
+            global_page,
+            cp_world_size,
+            page_size,
+            interleave_size,
+        )
+        if owner == cp_rank:
+            yield global_page, local_page

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -4352,8 +4352,8 @@ class MooncakeConnectorWorker:
                         ready=asyncio.Event(),
                     )
         for transfer_id in metadata.reqs_not_processed:
-            send_meta = self.reqs_need_send.pop(transfer_id)
-            if send_meta:
+            send_meta = self.reqs_need_send.pop(transfer_id, None)
+            if send_meta is not None:
                 assert not send_meta.ready.is_set()
 
     def start_load_kv(self, metadata: MooncakeConnectorMetadata):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -22,6 +22,10 @@ import zmq.asyncio
 
 from vllm import envs
 from vllm.config import VllmConfig
+from vllm.distributed.cp_mapping import (
+    get_suffix_global_page_range,
+    iter_owned_suffix_pages,
+)
 from vllm.distributed.kv_transfer.kv_connector.utils import (
     EngineId,
     TransferTopology,
@@ -35,6 +39,9 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
 from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_utils import (
+    MOONCAKE_CP_BLOCK_PAIRING_VERSION,
+    MOONCAKE_KV_REGION_LAYOUT_VERSION,
+    MOONCAKE_LEGACY_CP_BLOCK_PAIRING_VERSION,
     MooncakeBootstrapServer,
     RegisterWorkerPayload,
 )
@@ -42,6 +49,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.stats import (
     MooncakeKVConnectorStats,
 )
 from vllm.distributed.parallel_state import (
+    get_dcp_group,
     get_pcp_group,
     get_pp_group,
     get_tensor_model_parallel_rank,
@@ -59,17 +67,24 @@ from vllm.v1.core.kv_cache_utils import resolve_kv_cache_block_sizes
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
+    KVCacheChildPageMapping,
     KVCacheSpec,
+    KVCacheTemporalLayout,
     MambaSpec,
     MLAAttentionSpec,
     SlidingWindowMLASpec,
     SlidingWindowSpec,
 )
 from vllm.v1.request import RequestStatus
+from vllm.v1.spec_decode.utils import (
+    MINIMAX_M3_DENSE_TARGET_LAYER_IDS,
+    get_prompt_draft_kv_coverage,
+)
 from vllm.v1.worker.block_table import BlockTable
 from vllm.v1.worker.utils import select_common_block_size
 
 logger = init_logger(__name__)
+T = TypeVar("T")
 
 try:
     from mooncake.engine import TransferEngine
@@ -91,6 +106,23 @@ TransferId = str  # KV transfer coordination ID (shared by P/D)
 _T = TypeVar("_T")
 
 
+class MooncakeRegionIdentity(msgspec.Struct):
+    layer_name: str
+    temporal_layout: str
+    protocol_version: int
+    child_page_mapping: str
+    child_page_factor: int
+
+
+class MooncakeRequestPageMap(msgspec.Struct):
+    region_index: int
+    group_index: int
+    valid_start_token: int
+    valid_end_token_exclusive: int
+    global_page_ids: list[int]
+    dst_physical_block_ids: list[int]
+
+
 @dataclass(frozen=True)
 class TransferRegion:
     """A registered KV region plus its logical cache identities."""
@@ -105,6 +137,8 @@ class TransferRegion:
     layer_indices: tuple[int, ...] = ()
     logical_group_indices: tuple[int, ...] = ()
     alias_group_indices: tuple[tuple[int, ...], ...] = ()
+    region_index: int = 0
+    identity: MooncakeRegionIdentity | None = None
 
     @property
     def match_layer_names(self) -> tuple[str, ...]:
@@ -113,6 +147,72 @@ class TransferRegion:
     @property
     def match_layer_indices(self) -> tuple[int, ...]:
         return self.layer_indices or (self.layer_index,)
+
+
+def _validate_full_temporal_stage_coverage(
+    local_regions: list[TransferRegion],
+    remote_regions: list[TransferRegion],
+    *,
+    speculative_config: Any,
+    total_target_layers: int,
+    pp_rank: int,
+    pp_size: int,
+) -> str | None:
+    full_temporal = KVCacheTemporalLayout.FULL_TEMPORAL.value
+
+    def full_temporal_indices(regions: list[TransferRegion]) -> set[int]:
+        return {
+            layer_index
+            for region in regions
+            if region.identity is not None
+            and region.identity.temporal_layout == full_temporal
+            for layer_index in region.match_layer_indices
+        }
+
+    local_indices = full_temporal_indices(local_regions)
+    remote_indices = full_temporal_indices(remote_regions)
+    target_dense_enabled = bool(
+        speculative_config is not None
+        and getattr(
+            speculative_config,
+            "enable_eagle3_target_dense_full_temporal_kv",
+            False,
+        )
+    )
+    prefill_draft_enabled = bool(
+        speculative_config is not None
+        and getattr(
+            speculative_config,
+            "enable_eagle3_prefill_draft_kv",
+            False,
+        )
+    )
+    if not target_dense_enabled and not prefill_draft_enabled:
+        if not local_indices.issubset(remote_indices):
+            return (
+                "Mooncake producer full-temporal layers are not present "
+                "with the same layout on the consumer"
+            )
+        return None
+
+    expected_indices: set[int] = set()
+    if target_dense_enabled and pp_rank == 0:
+        expected_indices.update(MINIMAX_M3_DENSE_TARGET_LAYER_IDS)
+    if prefill_draft_enabled and pp_rank == pp_size - 1:
+        expected_indices.add(total_target_layers)
+
+    if local_indices != expected_indices:
+        return (
+            "Mooncake producer PP stage has incomplete full-temporal coverage: "
+            f"pp_rank={pp_rank}, expected layer indices "
+            f"{sorted(expected_indices)!r}, got {sorted(local_indices)!r}"
+        )
+    if not expected_indices.issubset(remote_indices):
+        return (
+            "Mooncake consumer is missing producer full-temporal layer indices: "
+            f"expected {sorted(expected_indices)!r}, got {sorted(remote_indices)!r}"
+        )
+    return None
 
 
 def _get_tp_ratio(local_tp_size: int, remote_tp_size: int) -> int:
@@ -149,6 +249,7 @@ def _expand_transfer_regions(
     layer_index_aliases: list[list[int]] | None = None,
     logical_group_indices: list[list[int]] | None = None,
     alias_group_indices: list[list[list[int]]] | None = None,
+    region_identities: list[MooncakeRegionIdentity] | None = None,
 ) -> list[TransferRegion]:
     """Expand registered KV tensors into the regions transferred by Mooncake."""
     assert (
@@ -177,6 +278,12 @@ def _expand_transfer_regions(
         f"got split_kv_regions={len(split_kv_regions)}, "
         f"layer_names={len(layer_names)}."
     )
+    if region_identities is not None:
+        assert len(region_identities) == len(layer_names), (
+            "Mooncake transfer regions require matching layout metadata, "
+            f"got region_identities={len(region_identities)}, "
+            f"layer_names={len(layer_names)}."
+        )
     regions: list[TransferRegion] = []
     for idx, (
         base_addr,
@@ -197,6 +304,21 @@ def _expand_transfer_regions(
             split_kv_regions,
         )
     ):
+        identity = (
+            region_identities[idx]
+            if region_identities is not None
+            else MooncakeRegionIdentity(
+                layer_name=layer_name,
+                temporal_layout=KVCacheTemporalLayout.SHARDED_DCP.value,
+                protocol_version=0,
+                child_page_mapping=KVCacheChildPageMapping.IDENTITY.value,
+                child_page_factor=1,
+            )
+        )
+        assert identity.layer_name == layer_name, (
+            "Mooncake region identity layer name mismatch: "
+            f"{identity.layer_name!r} != {layer_name!r}"
+        )
         if split_kv_region:
             aliases: tuple[str, ...] = ()
             index_aliases: tuple[int, ...] = ()
@@ -224,6 +346,8 @@ def _expand_transfer_regions(
                 layer_indices=index_aliases,
                 logical_group_indices=region_logical_group_indices,
                 alias_group_indices=region_alias_group_indices,
+                region_index=len(regions),
+                identity=identity,
             )
         )
         if split_kv_region:
@@ -235,6 +359,8 @@ def _expand_transfer_regions(
                     block_len=block_len,
                     kv_block_len=kv_block_len,
                     group_index=group_index,
+                    region_index=len(regions),
+                    identity=identity,
                 )
             )
     return regions
@@ -527,6 +653,83 @@ def _validate_asymmetric_region_lengths(
     return None
 
 
+def _validate_region_layouts(
+    local_regions: list[TransferRegion],
+    remote_regions: list[TransferRegion],
+    *,
+    producer_dcp_size: int,
+    consumer_dcp_size: int,
+) -> str | None:
+    full_temporal = KVCacheTemporalLayout.FULL_TEMPORAL.value
+    strict = any(
+        region.identity is not None and region.identity.temporal_layout == full_temporal
+        for region in (*local_regions, *remote_regions)
+    )
+    if not strict:
+        return None
+    if producer_dcp_size != 1 or consumer_dcp_size <= 0:
+        return "Mooncake full-temporal transfer requires a DCP1 producer"
+
+    for index, (local_region, remote_region) in enumerate(
+        zip(local_regions, remote_regions)
+    ):
+        local = local_region.identity
+        remote = remote_region.identity
+        if local is None or remote is None:
+            return f"Mooncake region {index} is missing layout identity"
+        if (
+            local.protocol_version != MOONCAKE_KV_REGION_LAYOUT_VERSION
+            or remote.protocol_version != MOONCAKE_KV_REGION_LAYOUT_VERSION
+        ):
+            return (
+                f"Mooncake region {index} requires layout protocol "
+                f"v{MOONCAKE_KV_REGION_LAYOUT_VERSION}"
+            )
+        if local.layer_name != local_region.layer_name:
+            return f"Mooncake producer region {index} has a wrong layer identity"
+        if remote.layer_name != remote_region.layer_name:
+            return f"Mooncake consumer region {index} has a wrong layer identity"
+        if local.temporal_layout != remote.temporal_layout:
+            return (
+                f"Mooncake region {index} temporal layout mismatch: "
+                f"producer={local.temporal_layout}, "
+                f"consumer={remote.temporal_layout}"
+            )
+
+        if local.temporal_layout == full_temporal:
+            if (
+                local.child_page_mapping != KVCacheChildPageMapping.IDENTITY.value
+                or local.child_page_factor != 1
+            ):
+                return (
+                    f"Mooncake producer full-temporal region {index} must use "
+                    "identity pages with factor 1"
+                )
+            expected_mapping = (
+                KVCacheChildPageMapping.IDENTITY.value
+                if consumer_dcp_size == 1
+                else KVCacheChildPageMapping.GLOBAL_PAGE_MODULO.value
+            )
+            if (
+                remote.child_page_mapping != expected_mapping
+                or remote.child_page_factor != consumer_dcp_size
+            ):
+                return (
+                    f"Mooncake consumer full-temporal region {index} must use "
+                    f"{expected_mapping} pages with factor {consumer_dcp_size}"
+                )
+        elif (
+            local.temporal_layout != KVCacheTemporalLayout.SHARDED_DCP.value
+            or local.child_page_mapping != KVCacheChildPageMapping.IDENTITY.value
+            or remote.child_page_mapping != KVCacheChildPageMapping.IDENTITY.value
+            or local.child_page_factor != 1
+            or remote.child_page_factor != 1
+        ):
+            return f"Mooncake sharded region {index} has invalid page mapping"
+
+    return None
+
+
 def _region_has_aliases(region: TransferRegion) -> bool:
     return bool(region.layer_aliases)
 
@@ -566,6 +769,40 @@ def _regions_share_layer_identity(
     return bool(
         set(local_region.match_layer_names) & set(remote_region.match_layer_names)
     )
+
+
+def _shared_alias_group_pairs(
+    local_region: TransferRegion, remote_region: TransferRegion
+) -> tuple[tuple[str, int, int, int], ...] | None:
+    """Map matching alias identities to producer and consumer KV groups."""
+    if not local_region.alias_group_indices or not remote_region.alias_group_indices:
+        return None
+
+    local_alias_groups = _alias_group_map(local_region)
+    remote_alias_groups = _alias_group_map(remote_region)
+    pairs: set[tuple[str, int, int, int]] = set()
+    for alias in set(local_alias_groups) & set(remote_alias_groups):
+        common_layer_indices = set(local_alias_groups[alias]) & set(
+            remote_alias_groups[alias]
+        )
+        for layer_index in common_layer_indices:
+            local_groups = local_alias_groups[alias][layer_index]
+            remote_groups = remote_alias_groups[alias][layer_index]
+            common_groups = local_groups & remote_groups
+            if common_groups:
+                pairs.update(
+                    (alias, layer_index, group, group) for group in common_groups
+                )
+            elif len(local_groups) == 1 and len(remote_groups) == 1:
+                pairs.add(
+                    (
+                        alias,
+                        layer_index,
+                        next(iter(local_groups)),
+                        next(iter(remote_groups)),
+                    )
+                )
+    return tuple(sorted(pairs))
 
 
 def _align_transfer_regions_by_occurrence(
@@ -693,7 +930,7 @@ def _align_transfer_regions(
     aligned_local: list[TransferRegion] = []
     aligned_remote: list[TransferRegion] = []
     matched_local_indices: set[int] = set()
-    matched_remote_keys: set[tuple[int, tuple[str, int, int]]] = set()
+    matched_remote_keys: set[tuple[int, str, int, int]] = set()
 
     for local_idx, local_region in enumerate(alias_local_regions):
         index_mismatch_region: TransferRegion | None = None
@@ -704,19 +941,25 @@ def _align_transfer_regions(
             if not _regions_have_bound_alias_layer_indices(local_region, remote_region):
                 index_mismatch_region = index_mismatch_region or remote_region
                 continue
-            shared_keys = _shared_alias_group_keys(local_region, remote_region)
-            if not shared_keys:
+            shared_pairs = _shared_alias_group_pairs(local_region, remote_region)
+            if not shared_pairs:
                 continue
-            available_keys = [
-                key
-                for key in shared_keys
-                if (remote_idx, key) not in matched_remote_keys
-                and key not in matched_local_keys
+            available_pairs = [
+                pair
+                for pair in shared_pairs
+                if (remote_idx, pair[0], pair[1], pair[3]) not in matched_remote_keys
+                and (pair[0], pair[1], pair[2]) not in matched_local_keys
             ]
-            if not available_keys:
+            if not available_pairs:
                 continue
-            matched_local_keys.update(available_keys)
-            matched_remote_keys.update((remote_idx, key) for key in available_keys)
+            matched_local_keys.update(
+                (alias, layer_index, local_group)
+                for alias, layer_index, local_group, _ in available_pairs
+            )
+            matched_remote_keys.update(
+                (remote_idx, alias, layer_index, remote_group)
+                for alias, layer_index, _, remote_group in available_pairs
+            )
             aligned_local.append(local_region)
             aligned_remote.append(remote_region)
             matched_local_indices.add(local_idx)
@@ -754,9 +997,11 @@ def _align_transfer_regions(
         for local_region in alias_local_regions:
             if not _regions_share_layer_identity(local_region, remote_region):
                 continue
-            shared_keys = _shared_alias_group_keys(local_region, remote_region)
-            if shared_keys and any(
-                (remote_idx, key) not in matched_remote_keys for key in shared_keys
+            shared_pairs = _shared_alias_group_pairs(local_region, remote_region)
+            if shared_pairs and any(
+                (remote_idx, alias, layer_index, remote_group)
+                not in matched_remote_keys
+                for alias, layer_index, _, remote_group in shared_pairs
             ):
                 return (
                     [],
@@ -777,6 +1022,52 @@ def _align_transfer_regions(
         aligned_remote + legacy_remote,
         None,
     )
+
+
+def _mapped_group_indices_for_regions(
+    local_region: TransferRegion,
+    remote_region: TransferRegion,
+    local_num_groups: int,
+    remote_num_groups: int,
+) -> tuple[tuple[int, int], ...]:
+    if local_num_groups <= 0 or remote_num_groups <= 0:
+        return ()
+
+    alias_pairs = _shared_alias_group_pairs(local_region, remote_region)
+    if alias_pairs is not None:
+        return tuple(
+            sorted(
+                {
+                    (local_group, remote_group)
+                    for _, _, local_group, remote_group in alias_pairs
+                    if 0 <= local_group < local_num_groups
+                    and 0 <= remote_group < remote_num_groups
+                }
+            )
+        )
+
+    if local_region.logical_group_indices and remote_region.logical_group_indices:
+        return tuple(
+            (group, group)
+            for group in sorted(
+                set(local_region.logical_group_indices)
+                & set(remote_region.logical_group_indices)
+            )
+            if 0 <= group < local_num_groups and group < remote_num_groups
+        )
+    if bool(local_region.logical_group_indices) != bool(
+        remote_region.logical_group_indices
+    ):
+        return tuple(
+            (group, group) for group in range(min(local_num_groups, remote_num_groups))
+        )
+    if (
+        local_region.group_index == remote_region.group_index
+        and local_region.group_index < local_num_groups
+        and local_region.group_index < remote_num_groups
+    ):
+        return ((local_region.group_index, remote_region.group_index),)
+    return ()
 
 
 def _common_group_indices_for_regions(
@@ -961,6 +1252,424 @@ def _pair_pcp_block_ids(
     return paired_local, paired_remote, None
 
 
+def _pair_cp_block_ids(
+    local_block_ids: list[int],
+    remote_block_ids: list[int],
+    *,
+    total_tokens: int,
+    num_external_tokens: int,
+    external_start_token: int,
+    producer_pcp_size: int,
+    producer_pcp_rank: int,
+    consumer_pcp_size: int,
+    consumer_pcp_rank: int,
+    producer_dcp_size: int,
+    producer_dcp_rank: int,
+    consumer_dcp_size: int,
+    consumer_dcp_rank: int,
+    group_block_size: int,
+    producer_interleave_size: int,
+    consumer_interleave_size: int,
+    consumer_cp_block_pairing_version: int,
+) -> tuple[list[int], list[int], str | None]:
+    """Pair producer and consumer pages for one supported CP topology."""
+    if producer_dcp_size <= 0 or consumer_dcp_size <= 0:
+        return [], [], "DCP world sizes must be positive"
+    if not 0 <= producer_dcp_rank < producer_dcp_size:
+        return [], [], "Invalid producer DCP rank"
+    if not 0 <= consumer_dcp_rank < consumer_dcp_size:
+        return [], [], "Invalid consumer DCP rank"
+    if producer_pcp_size > 1 and producer_dcp_size > 1:
+        return [], [], "Mooncake producer PCP and DCP cannot both exceed one"
+    if consumer_pcp_size > 1 and consumer_dcp_size > 1:
+        return [], [], "Mooncake consumer PCP and DCP cannot both exceed one"
+    if producer_dcp_size > 1:
+        return [], [], "Mooncake producer DCP is not supported"
+    if (
+        consumer_cp_block_pairing_version < MOONCAKE_CP_BLOCK_PAIRING_VERSION
+        and consumer_dcp_size > 1
+    ):
+        return [], [], "Mooncake consumer DCP requires CP block pairing capability"
+    if (
+        consumer_cp_block_pairing_version < MOONCAKE_LEGACY_CP_BLOCK_PAIRING_VERSION
+        and producer_pcp_size == consumer_pcp_size == 1
+        and len(local_block_ids) != len(remote_block_ids)
+    ):
+        return (
+            [],
+            [],
+            "Mooncake block count mismatch requires CP block pairing capability",
+        )
+
+    if consumer_dcp_size > 1:
+        if producer_pcp_size != 1 or consumer_pcp_size != 1:
+            return (
+                [],
+                [],
+                "Mooncake consumer DCP requires producer and consumer PCP size one",
+            )
+        compact_remote, global_local, error = _pair_pcp_block_ids(
+            remote_block_ids,
+            local_block_ids,
+            total_tokens=total_tokens,
+            num_external_tokens=num_external_tokens,
+            external_start_token=external_start_token,
+            producer_pcp_size=consumer_dcp_size,
+            producer_pcp_rank=consumer_dcp_rank,
+            consumer_pcp_size=1,
+            consumer_pcp_rank=0,
+            group_block_size=group_block_size,
+            interleave_size=consumer_interleave_size,
+        )
+        return global_local, compact_remote, error
+
+    return _pair_pcp_block_ids(
+        local_block_ids,
+        remote_block_ids,
+        total_tokens=total_tokens,
+        num_external_tokens=num_external_tokens,
+        external_start_token=external_start_token,
+        producer_pcp_size=producer_pcp_size,
+        producer_pcp_rank=producer_pcp_rank,
+        consumer_pcp_size=consumer_pcp_size,
+        consumer_pcp_rank=consumer_pcp_rank,
+        group_block_size=group_block_size,
+        interleave_size=producer_interleave_size,
+    )
+
+
+def _get_owned_dcp_suffix_blocks(
+    block_ids: list[int],
+    *,
+    total_tokens: int,
+    num_external_tokens: int,
+    external_start_token: int,
+    dcp_size: int,
+    dcp_rank: int,
+    page_size: int,
+    interleave_size: int,
+) -> tuple[list[int], list[int], str | None]:
+    """Describe compact DCP blocks with explicit global page identities."""
+    if external_start_token + num_external_tokens != total_tokens:
+        return [], [], "Mooncake DCP transfer requires an exact suffix token range"
+    if page_size != interleave_size:
+        return [], [], "Mooncake DCP v2 requires page size equal to interleave"
+    try:
+        owned_pages = list(
+            iter_owned_suffix_pages(
+                total_tokens,
+                external_start_token,
+                dcp_size,
+                dcp_rank,
+                page_size,
+                interleave_size,
+            )
+        )
+    except ValueError as exc:
+        return [], [], str(exc)
+    if not owned_pages:
+        return [], [], None
+    if not block_ids:
+        return [], [], "DCP compact block list is missing owned global pages"
+    retained_owned_pages = _retain_trailing_suffix_items(owned_pages, len(block_ids))
+    if len(block_ids) < len(retained_owned_pages):
+        return [], [], "DCP compact block list is missing owned global pages"
+    if len(block_ids) < len(owned_pages):
+        return (
+            list(block_ids),
+            [global_page for global_page, _ in retained_owned_pages],
+            None,
+        )
+    suffix_first_local_page = owned_pages[0][1]
+    selected_blocks: list[int] = []
+    global_pages: list[int] = []
+    for global_page, local_page in retained_owned_pages:
+        block_offset = local_page - suffix_first_local_page
+        if not 0 <= block_offset < len(block_ids):
+            return [], [], "DCP compact block list is missing owned global pages"
+        selected_blocks.append(block_ids[block_offset])
+        global_pages.append(global_page)
+    return selected_blocks, global_pages, None
+
+
+def _get_full_temporal_suffix_blocks(
+    parent_block_ids: list[int],
+    *,
+    total_tokens: int,
+    num_external_tokens: int,
+    external_start_token: int,
+    child_page_factor: int,
+    page_size: int,
+) -> tuple[list[int], list[int], str | None]:
+    """Map scheduler parent blocks to full-temporal physical child pages."""
+    if external_start_token + num_external_tokens != total_tokens:
+        return [], [], "Mooncake full-temporal transfer requires an exact suffix"
+    if child_page_factor <= 0:
+        return [], [], "Mooncake full-temporal transfer requires positive child factor"
+    if page_size <= 0:
+        return [], [], "Mooncake full-temporal transfer requires positive page size"
+    if num_external_tokens <= 0:
+        return [], [], None
+
+    try:
+        global_pages = list(
+            get_suffix_global_page_range(
+                total_tokens,
+                external_start_token,
+                page_size,
+            )
+        )
+    except ValueError as exc:
+        return [], [], str(exc)
+    if not global_pages:
+        return [], [], None
+    if not parent_block_ids:
+        return [], [], "Full-temporal parent block list is missing global pages"
+
+    total_parent_pages = cdiv(
+        total_tokens,
+        page_size * child_page_factor,
+    )
+    first_parent_page = (
+        0
+        if len(parent_block_ids) >= total_parent_pages
+        else total_parent_pages - len(parent_block_ids)
+    )
+    child_block_ids: list[int] = []
+    for global_page in global_pages:
+        parent_page = global_page // child_page_factor
+        parent_offset = parent_page - first_parent_page
+        if not 0 <= parent_offset < len(parent_block_ids):
+            return [], [], "Full-temporal parent block list is missing global pages"
+        parent_block = parent_block_ids[parent_offset]
+        if parent_block == NULL_BLOCK_ID:
+            return [], [], "Full-temporal parent block list contains a null block"
+        child_block_ids.append(
+            child_page_factor * parent_block + global_page % child_page_factor
+        )
+
+    if len(child_block_ids) != len(set(child_block_ids)):
+        return [], [], "Full-temporal child block IDs must be unique"
+    return child_block_ids, global_pages, None
+
+
+def _retain_trailing_suffix_items(items: list[T], block_count: int) -> list[T]:
+    if block_count <= 0:
+        return []
+    if block_count < len(items):
+        return items[-block_count:]
+    return items
+
+
+def _pair_dcp_blocks_by_global_page(
+    local_block_ids: list[int],
+    remote_block_ids: list[int],
+    remote_global_page_ids: list[int],
+    *,
+    total_tokens: int,
+    num_external_tokens: int,
+    external_start_token: int,
+    consumer_dcp_size: int,
+    consumer_dcp_rank: int,
+    page_size: int,
+    interleave_size: int,
+) -> tuple[list[int], list[int], str | None]:
+    """Pair producer and DCP-consumer blocks by canonical global page ID."""
+    if external_start_token + num_external_tokens != total_tokens:
+        return [], [], "Mooncake DCP transfer requires an exact suffix token range"
+    if page_size != interleave_size:
+        return [], [], "Mooncake DCP v2 requires page size equal to interleave"
+    if len(remote_block_ids) != len(remote_global_page_ids):
+        return [], [], "DCP block and global page identity counts differ"
+    if remote_global_page_ids != sorted(set(remote_global_page_ids)):
+        return [], [], "DCP global page identities must be unique and increasing"
+
+    try:
+        source_global_pages = list(
+            get_suffix_global_page_range(
+                total_tokens,
+                external_start_token,
+                page_size,
+            )
+        )
+        expected_remote_pages = _retain_trailing_suffix_items(
+            [
+                global_page
+                for global_page, _ in iter_owned_suffix_pages(
+                    total_tokens,
+                    external_start_token,
+                    consumer_dcp_size,
+                    consumer_dcp_rank,
+                    page_size,
+                    interleave_size,
+                )
+            ],
+            len(remote_block_ids),
+        )
+    except ValueError as exc:
+        return [], [], str(exc)
+    if remote_global_page_ids != expected_remote_pages:
+        return [], [], "DCP global page identities do not match owner suffix"
+    if not source_global_pages:
+        return [], [], None
+    source_end_page = source_global_pages[-1] + 1
+    if len(local_block_ids) >= source_end_page:
+        source_blocks = [
+            local_block_ids[global_page] for global_page in source_global_pages
+        ]
+    elif len(local_block_ids) <= len(source_global_pages):
+        source_global_pages = _retain_trailing_suffix_items(
+            source_global_pages,
+            len(local_block_ids),
+        )
+        source_blocks = list(local_block_ids)
+    else:
+        return [], [], "Producer block list is missing suffix global pages"
+    source_by_page = dict(zip(source_global_pages, source_blocks))
+    if len(source_by_page) != len(source_global_pages):
+        return [], [], "Producer global page identities are not unique"
+    try:
+        paired_local = [source_by_page[page] for page in remote_global_page_ids]
+    except KeyError:
+        return [], [], "Producer is missing a requested DCP global page"
+    return paired_local, list(remote_block_ids), None
+
+
+def _pair_full_temporal_blocks_by_global_page(
+    local_block_ids: list[int],
+    remote_child_block_ids: list[int],
+    remote_global_page_ids: list[int],
+    *,
+    total_tokens: int,
+    num_external_tokens: int,
+    external_start_token: int,
+    page_size: int,
+) -> tuple[list[int], list[int], str | None]:
+    """Pair producer DCP1 pages with consumer full-temporal child pages."""
+    if external_start_token + num_external_tokens != total_tokens:
+        return [], [], "Mooncake full-temporal transfer requires an exact suffix"
+    if len(remote_child_block_ids) != len(remote_global_page_ids):
+        return [], [], "Full-temporal block and global page counts differ"
+    if remote_global_page_ids != sorted(set(remote_global_page_ids)):
+        return [], [], "Full-temporal global pages must be unique and increasing"
+
+    try:
+        source_global_pages = list(
+            get_suffix_global_page_range(
+                total_tokens,
+                external_start_token,
+                page_size,
+            )
+        )
+    except ValueError as exc:
+        return [], [], str(exc)
+    if remote_global_page_ids != source_global_pages:
+        return [], [], "Full-temporal global pages do not match the source suffix"
+    if not source_global_pages:
+        return [], [], None
+
+    source_end_page = source_global_pages[-1] + 1
+    if len(local_block_ids) >= source_end_page:
+        source_blocks = [
+            local_block_ids[global_page] for global_page in source_global_pages
+        ]
+    elif len(local_block_ids) == len(source_global_pages):
+        source_blocks = list(local_block_ids)
+    else:
+        return [], [], "Producer block list is missing full-temporal pages"
+    return source_blocks, list(remote_child_block_ids), None
+
+
+def _index_full_temporal_region_page_maps(
+    page_maps: list[MooncakeRequestPageMap],
+    remote_regions: list[TransferRegion],
+    *,
+    valid_start_token: int,
+    valid_end_token_exclusive: int,
+) -> tuple[dict[int, MooncakeRequestPageMap], str | None]:
+    """Validate and index request-scoped full-temporal destination pages."""
+    full_temporal = KVCacheTemporalLayout.FULL_TEMPORAL.value
+    expected_regions = {
+        region.region_index: region
+        for region in remote_regions
+        if region.identity is not None
+        and region.identity.temporal_layout == full_temporal
+    }
+    indexed: dict[int, MooncakeRequestPageMap] = {}
+    for page_map in page_maps:
+        if page_map.region_index in indexed:
+            return {}, (
+                "Mooncake full-temporal request has duplicate region page maps "
+                f"for region {page_map.region_index}"
+            )
+        region = expected_regions.get(page_map.region_index)
+        if region is None:
+            return {}, (
+                "Mooncake request page map refers to a non-full-temporal "
+                f"region {page_map.region_index}"
+            )
+        valid_group_indices = set(region.logical_group_indices or (region.group_index,))
+        if page_map.group_index not in valid_group_indices:
+            return {}, (
+                "Mooncake full-temporal page map has an invalid KV group for "
+                f"region {page_map.region_index}"
+            )
+        if (
+            page_map.valid_start_token != valid_start_token
+            or page_map.valid_end_token_exclusive != valid_end_token_exclusive
+        ):
+            return {}, (
+                "Mooncake full-temporal page map token range does not match "
+                f"the request for region {page_map.region_index}"
+            )
+        if len(page_map.global_page_ids) != len(page_map.dst_physical_block_ids):
+            return {}, (
+                "Mooncake full-temporal page and child-block counts differ "
+                f"for region {page_map.region_index}"
+            )
+        if page_map.global_page_ids != sorted(set(page_map.global_page_ids)):
+            return {}, (
+                "Mooncake full-temporal global pages must be unique and "
+                f"increasing for region {page_map.region_index}"
+            )
+        if (
+            len(page_map.dst_physical_block_ids)
+            != len(set(page_map.dst_physical_block_ids))
+            or NULL_BLOCK_ID in page_map.dst_physical_block_ids
+        ):
+            return {}, (
+                "Mooncake full-temporal child block IDs must be non-null and "
+                f"unique for region {page_map.region_index}"
+            )
+        assert region.identity is not None
+        child_page_factor = region.identity.child_page_factor
+        if child_page_factor <= 0:
+            return {}, (
+                "Mooncake full-temporal child page factor must be positive "
+                f"for region {page_map.region_index}"
+            )
+        if any(
+            child_block % child_page_factor != global_page % child_page_factor
+            for global_page, child_block in zip(
+                page_map.global_page_ids,
+                page_map.dst_physical_block_ids,
+            )
+        ):
+            return {}, (
+                "Mooncake full-temporal child block parity does not match "
+                f"global pages for region {page_map.region_index}"
+            )
+        indexed[page_map.region_index] = page_map
+
+    missing_regions = sorted(set(expected_regions) - set(indexed))
+    if missing_regions:
+        return {}, (
+            "Mooncake request is missing full-temporal region page maps: "
+            f"{missing_regions}"
+        )
+    return indexed, None
+
+
 def _get_tensor_dense_flag(tensor: torch.Tensor) -> bool | None:
     is_dense = getattr(tensor, "is_non_overlapping_and_dense", None)
     if callable(is_dense):
@@ -982,9 +1691,19 @@ class MooncakeXferMetadata(
     kv_block_lens: list[int]
     remote_pcp_size: int = 1
     remote_pcp_rank: int = 0
+    remote_dcp_size: int = 1
+    remote_dcp_rank: int = 0
+    remote_cp_kv_cache_interleave_size: int = 1
+    remote_cp_block_pairing_version: int = 0
     req_total_tokens: dict[ReqId, int] = msgspec.field(default_factory=dict)
     req_num_external_tokens: dict[ReqId, int] = msgspec.field(default_factory=dict)
     req_external_start_tokens: dict[ReqId, int] = msgspec.field(default_factory=dict)
+    req_global_page_ids: dict[ReqId, list[list[int]]] = msgspec.field(
+        default_factory=dict
+    )
+    req_region_page_maps: dict[ReqId, list[MooncakeRequestPageMap]] = msgspec.field(
+        default_factory=dict
+    )
     registered_layer_names: list[str] = msgspec.field(default_factory=list)
     registered_layer_indices: list[int] = msgspec.field(default_factory=list)
     registered_group_indices: list[int] = msgspec.field(default_factory=list)
@@ -996,6 +1715,9 @@ class MooncakeXferMetadata(
         default_factory=list
     )
     registered_alias_group_indices: list[list[list[int]]] = msgspec.field(
+        default_factory=list
+    )
+    registered_region_identities: list[MooncakeRegionIdentity] = msgspec.field(
         default_factory=list
     )
 
@@ -1242,6 +1964,7 @@ class MooncakeConnectorScheduler:
         kv_cache_config: "KVCacheConfig",
     ):
         self.vllm_config = vllm_config
+        self.kv_cache_config = kv_cache_config
         self.block_size, _ = resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)
 
         assert vllm_config.kv_transfer_config
@@ -1263,6 +1986,15 @@ class MooncakeConnectorScheduler:
         # GDN is represented as a MambaSpec in vLLM. This Mooncake MambaSpec
         # path is currently tested with GDN; Mamba2 is not validated yet.
         self._has_mamba = kv_cache_config.has_mamba_layers
+        speculative_config = vllm_config.speculative_config
+        self._has_full_temporal_draft = bool(
+            speculative_config is not None
+            and getattr(
+                speculative_config,
+                "enable_eagle3_replicated_draft_kv",
+                False,
+            )
+        )
 
         # Requests that need to start recv/send.
         # New requests are added by update_state_after_alloc in
@@ -1309,11 +2041,37 @@ class MooncakeConnectorScheduler:
         ]
 
     def _get_remote_prefill_token_count(self, num_prompt_tokens: int) -> int:
-        """D-side only. Returns N-1 for Mamba models since the decoder
-        always recomputes the last token and must start from h(N-1)."""
+        """Return external prompt coverage, leaving the final token local."""
+        if self._has_full_temporal_draft:
+            return max(num_prompt_tokens - 1, 0)
         if self._has_mamba and num_prompt_tokens > 1:
             return num_prompt_tokens - 1
         return num_prompt_tokens
+
+    def _get_remote_prefill_transfer_range(
+        self,
+        num_prompt_tokens: int,
+        num_external_tokens: int,
+    ) -> tuple[int, int]:
+        total_tokens = self._get_remote_prefill_token_count(num_prompt_tokens)
+        if not 0 <= num_external_tokens <= total_tokens:
+            raise ValueError("external token count must be within remote prefill range")
+        external_start_token = total_tokens - num_external_tokens
+        if self._has_full_temporal_draft and num_prompt_tokens > 0:
+            coverage = get_prompt_draft_kv_coverage(
+                prompt_tokens=num_prompt_tokens,
+                target_prefix_tokens=external_start_token,
+                compatible_draft_prefix_tokens=external_start_token,
+            )
+            if coverage.transfer_token_count != num_external_tokens:
+                raise ValueError(
+                    "Target and Draft prefix coverage must share one parent range"
+                )
+            return (
+                coverage.transfer_end_token_exclusive,
+                coverage.transfer_start_token,
+            )
+        return total_tokens, external_start_token
 
     def _truncate_mamba_request_for_prefill(self, request: "Request") -> None:
         """P-side only: drop the last prompt token so the prefiller computes
@@ -1409,16 +2167,17 @@ class MooncakeConnectorScheduler:
                 # If remote_blocks and num_external_tokens = 0, we have
                 # a full prefix cache hit on the D worker. We need to call
                 # send_notif in _read_blocks to free the memory on the P.
-                unhashed_block_ids = (
-                    blocks.get_unhashed_block_ids_all_groups()
-                    if num_external_tokens > 0
-                    else ()
+                if num_external_tokens > 0:
+                    unhashed_block_ids = blocks.get_unhashed_block_ids_all_groups()
+                    local_block_ids = self.get_sw_clipped_blocks(unhashed_block_ids)
+                else:
+                    local_block_ids = [[] for _ in self.kv_cache_config.kv_cache_groups]
+                total_tokens, external_start_token = (
+                    self._get_remote_prefill_transfer_range(
+                        request.num_prompt_tokens,
+                        num_external_tokens,
+                    )
                 )
-                local_block_ids = self.get_sw_clipped_blocks(unhashed_block_ids)
-                total_tokens = self._get_remote_prefill_token_count(
-                    request.num_prompt_tokens
-                )
-                external_start_token = max(total_tokens - num_external_tokens, 0)
                 # Get unhashed blocks to pull from remote.
                 self._reqs_need_recv[request.request_id] = (
                     request,
@@ -1682,6 +2441,7 @@ class MooncakeConnectorWorker:
         self.registered_layer_index_aliases: list[list[int]] = []
         self.registered_logical_group_indices: list[list[int]] = []
         self.registered_alias_group_indices: list[list[list[int]]] = []
+        self.registered_region_identities: list[MooncakeRegionIdentity] = []
         self.seen_base_addresses: list[int] = []
 
         assert (parallel_config := vllm_config.parallel_config)
@@ -1692,6 +2452,8 @@ class MooncakeConnectorWorker:
         self.pp_rank = get_pp_group().rank_in_group
         self.pcp_size = vllm_config.parallel_config.prefill_context_parallel_size
         self.pcp_rank = get_pcp_group().rank_in_group if self.pcp_size > 1 else 0
+        self.dcp_size = vllm_config.parallel_config.decode_context_parallel_size
+        self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_size > 1 else 0
         self.cp_kv_cache_interleave_size = (
             vllm_config.parallel_config.cp_kv_cache_interleave_size
         )
@@ -1764,14 +2526,10 @@ class MooncakeConnectorWorker:
 
         self._tp_size: dict[EngineId, int] = {self.engine_id: self.tp_size}
         self._pcp_size: dict[EngineId, int] = {self.engine_id: self.pcp_size}
-        self._layer_specs: dict[str, KVCacheSpec] = {}
-        for group in kv_cache_config.kv_cache_groups:
-            group_spec = group.kv_cache_spec
-            specs_by_layer = getattr(group_spec, "kv_cache_specs", {})
-            for layer_name in group.layer_names:
-                self._layer_specs[layer_name] = specs_by_layer.get(
-                    layer_name, group_spec
-                )
+        self._cp_block_pairing_version: dict[EngineId, int] = {
+            self.engine_id: MOONCAKE_KV_REGION_LAYOUT_VERSION
+        }
+        self._layer_specs = self._build_layer_specs()
         self._layer_group_indices: dict[str, int] = {
             layer: group_index
             for group_index, group in enumerate(kv_cache_config.kv_cache_groups)
@@ -1847,6 +2605,7 @@ class MooncakeConnectorWorker:
             pp_rank=self.pp_rank,
             pcp_rank=self.pcp_rank,
             pcp_size=self.pcp_size,
+            cp_block_pairing_version=MOONCAKE_KV_REGION_LAYOUT_VERSION,
             addr=worker_addr,
         )
         while True:
@@ -2024,8 +2783,9 @@ class MooncakeConnectorWorker:
             self.registered_layer_index_aliases,
             self.registered_logical_group_indices,
             self.registered_alias_group_indices,
+            self.registered_region_identities or None,
         )
-        remote_regions = self._get_transfer_regions(
+        registered_remote_regions = self._get_transfer_regions(
             meta.kv_caches_base_addr,
             meta.block_lens,
             meta.kv_block_lens,
@@ -2036,14 +2796,101 @@ class MooncakeConnectorWorker:
             meta.registered_layer_index_aliases,
             meta.registered_logical_group_indices,
             meta.registered_alias_group_indices,
+            meta.registered_region_identities or None,
         )
+        full_temporal = KVCacheTemporalLayout.FULL_TEMPORAL.value
+        local_full_temporal_layers = {
+            region.layer_name
+            for region in local_regions
+            if region.identity is not None
+            and region.identity.temporal_layout == full_temporal
+        }
+        remote_full_temporal_layers = {
+            region.layer_name
+            for region in registered_remote_regions
+            if region.identity is not None
+            and region.identity.temporal_layout == full_temporal
+        }
+        speculative_config = self.vllm_config.speculative_config
+        full_temporal_feature_enabled = bool(
+            speculative_config is not None
+            and (
+                getattr(
+                    speculative_config,
+                    "enable_eagle3_target_dense_full_temporal_kv",
+                    False,
+                )
+                or getattr(
+                    speculative_config,
+                    "enable_eagle3_prefill_draft_kv",
+                    False,
+                )
+            )
+        )
+        if (
+            local_full_temporal_layers
+            or remote_full_temporal_layers
+            or full_temporal_feature_enabled
+        ):
+            layout_error = None
+            if meta.remote_cp_block_pairing_version < MOONCAKE_KV_REGION_LAYOUT_VERSION:
+                layout_error = (
+                    "Mooncake full-temporal transfer requires region layout "
+                    f"protocol v{MOONCAKE_KV_REGION_LAYOUT_VERSION}"
+                )
+            else:
+                layout_error = _validate_full_temporal_stage_coverage(
+                    local_regions,
+                    registered_remote_regions,
+                    speculative_config=speculative_config,
+                    total_target_layers=(
+                        self.vllm_config.model_config.get_total_num_hidden_layers()
+                    ),
+                    pp_rank=self.pp_rank,
+                    pp_size=self.pp_size,
+                )
+            if layout_error is not None:
+                response = MooncakeXferResponse(
+                    status=MooncakeXferResponseStatus.ERROR,
+                    err_msg=layout_error,
+                )
+                await sock.send_multipart((identity, self._encoder.encode(response)))
+                return
+        for d_req_id in meta.req_blocks:
+            _, page_map_err = _index_full_temporal_region_page_maps(
+                meta.req_region_page_maps.get(d_req_id, []),
+                registered_remote_regions,
+                valid_start_token=meta.req_external_start_tokens.get(d_req_id, 0),
+                valid_end_token_exclusive=meta.req_total_tokens.get(d_req_id, 0),
+            )
+            if page_map_err is not None:
+                response = MooncakeXferResponse(
+                    status=MooncakeXferResponseStatus.ERROR,
+                    err_reqs=[d_req_id],
+                    err_msg=page_map_err,
+                )
+                await sock.send_multipart((identity, self._encoder.encode(response)))
+                return
         local_regions, remote_regions, align_err = _align_transfer_regions(
-            local_regions, remote_regions
+            local_regions, registered_remote_regions
         )
         if align_err is not None:
             response = MooncakeXferResponse(
                 status=MooncakeXferResponseStatus.ERROR,
                 err_msg=align_err,
+            )
+            await sock.send_multipart((identity, self._encoder.encode(response)))
+            return
+        layout_err = _validate_region_layouts(
+            local_regions,
+            remote_regions,
+            producer_dcp_size=self.dcp_size,
+            consumer_dcp_size=meta.remote_dcp_size,
+        )
+        if layout_err is not None:
+            response = MooncakeXferResponse(
+                status=MooncakeXferResponseStatus.ERROR,
+                err_msg=layout_err,
             )
             await sock.send_multipart((identity, self._encoder.encode(response)))
             return
@@ -2207,18 +3054,8 @@ class MooncakeConnectorWorker:
                         err_req_set.add(d_req_id)
                     ok_ready_reqs = []
 
-            for d_req_id, send_meta in ready_reqs:
-                send_meta.sending -= 1
-
-                if d_req_id in err_req_set:
-                    continue
-
-                send_meta.sent += 1
-                if (
-                    send_meta.sent == send_meta.need_send
-                    and self.reqs_need_send.pop(send_meta.transfer_id, None) is not None
-                ):
-                    self.finished_sending_reqs.add(send_meta.p_req_id)
+            for _, send_meta in ready_reqs:
+                self._finish_send_attempt(send_meta)
 
             response = MooncakeXferResponse(
                 status=response_status,
@@ -2227,6 +3064,17 @@ class MooncakeConnectorWorker:
                 err_msg=err_msg,
             )
             await sock.send_multipart((identity, self._encoder.encode(response)))
+
+    def _finish_send_attempt(self, send_meta: SendBlockMeta) -> None:
+        """Release producer blocks after every target reaches a terminal state."""
+        send_meta.sending -= 1
+        send_meta.sent += 1
+        if (
+            send_meta.sent >= send_meta.need_send
+            and send_meta.sending == 0
+            and self.reqs_need_send.pop(send_meta.transfer_id, None) is not None
+        ):
+            self.finished_sending_reqs.add(send_meta.p_req_id)
 
     def resolve_need_send(
         self,
@@ -2253,20 +3101,27 @@ class MooncakeConnectorWorker:
         if self._physical_blocks_per_logical_kv_block == 1:
             return block_ids
 
+        return [
+            self._logical_group_to_kernel_block_ids(group, i)
+            for i, group in enumerate(block_ids)
+        ]
+
+    def _logical_group_to_kernel_block_ids(
+        self, block_ids: list[int], group_index: int
+    ) -> list[int]:
+        if self._physical_blocks_per_logical_kv_block == 1:
+            return list(block_ids)
+        group_spec = self.kv_cache_config.kv_cache_groups[group_index].kv_cache_spec
+        if isinstance(group_spec, MambaSpec):
+            return list(block_ids)
         block_arange = np.arange(self._physical_blocks_per_logical_kv_block).reshape(
             1, -1
         )
-        group_specs = self.kv_cache_config.kv_cache_groups
-        return [
-            BlockTable.map_to_kernel_blocks(
-                np.array(group),
-                self._physical_blocks_per_logical_kv_block,
-                block_arange,
-            ).tolist()
-            if not isinstance(group_specs[i].kv_cache_spec, MambaSpec)
-            else group
-            for i, group in enumerate(block_ids)
-        ]
+        return BlockTable.map_to_kernel_blocks(
+            np.array(block_ids),
+            self._physical_blocks_per_logical_kv_block,
+            block_arange,
+        ).tolist()
 
     async def _build_transfer_params(
         self,
@@ -2284,128 +3139,258 @@ class MooncakeConnectorWorker:
 
         for d_req_id, send_meta in ready_reqs:
             _, remote_block_ids_per_group = agent_meta.req_blocks[d_req_id]
-
-            if not remote_block_ids_per_group or all(
-                len(g) == 0 for g in remote_block_ids_per_group
-            ):
-                continue
-
-            if len(send_meta.local_block_ids) != len(remote_block_ids_per_group):
-                logger.error(
-                    "req %s: KV group count mismatch: local=%d, remote=%d",
-                    d_req_id,
-                    len(send_meta.local_block_ids),
-                    len(remote_block_ids_per_group),
-                )
+            remote_global_page_ids_per_group = agent_meta.req_global_page_ids.get(
+                d_req_id
+            )
+            aligned_full_temporal_region_indices = {
+                region.region_index
+                for region in remote_regions
+                if region.identity is not None
+                and region.identity.temporal_layout
+                == KVCacheTemporalLayout.FULL_TEMPORAL.value
+            }
+            relevant_region_page_maps = [
+                page_map
+                for page_map in agent_meta.req_region_page_maps.get(d_req_id, [])
+                if page_map.region_index in aligned_full_temporal_region_indices
+            ]
+            region_page_maps, page_map_error = _index_full_temporal_region_page_maps(
+                relevant_region_page_maps,
+                remote_regions,
+                valid_start_token=agent_meta.req_external_start_tokens.get(d_req_id, 0),
+                valid_end_token_exclusive=agent_meta.req_total_tokens.get(d_req_id, 0),
+            )
+            if page_map_error is not None:
                 err_reqs.append(d_req_id)
                 if err_msg is None:
-                    err_msg = "KV group count mismatch"
+                    err_msg = page_map_error
                 continue
 
-            # Keep KV-cache group identity. Hybrid/HMA groups can carry
-            # different semantics (e.g. full-attention KV pages vs GDN/Mamba
-            # inner-state slots), so their block IDs must not be flattened and
-            # reused for every registered region.
-            local_block_ids_by_group: list[list[int]] = []
-            remote_block_ids_by_group: list[list[int]] = []
-            has_block_error = False
-            group_specs = self.kv_cache_config.kv_cache_groups
-            for group_index, (local_group, remote_group) in enumerate(
-                zip(send_meta.local_block_ids, remote_block_ids_per_group)
+            if agent_meta.remote_dcp_size <= 1 and (
+                not remote_block_ids_per_group
+                or all(len(g) == 0 for g in remote_block_ids_per_group)
             ):
-                is_mamba_group = isinstance(
-                    group_specs[group_index].kv_cache_spec,
-                    MambaSpec,
-                )
-                if is_mamba_group:
-                    # Mamba/GDN prefix caching can use null blocks only as
-                    # align-mode placeholders. They do not carry transferable
-                    # state, so skip them on both producer and consumer sides.
-                    local_group = [
-                        block_id
-                        for block_id in local_group
-                        if block_id != NULL_BLOCK_ID
-                    ]
-                    remote_group = [
-                        block_id
-                        for block_id in remote_group
-                        if block_id != NULL_BLOCK_ID
-                    ]
+                continue
 
-                local_group, remote_group, pair_error = _pair_pcp_block_ids(
-                    local_group,
-                    remote_group,
-                    total_tokens=agent_meta.req_total_tokens.get(d_req_id, 0),
-                    num_external_tokens=(
-                        agent_meta.req_num_external_tokens.get(d_req_id, 0)
-                    ),
-                    external_start_token=(
-                        agent_meta.req_external_start_tokens.get(d_req_id, 0)
-                    ),
-                    producer_pcp_size=getattr(self, "pcp_size", 1),
-                    producer_pcp_rank=getattr(self, "pcp_rank", 0),
-                    consumer_pcp_size=agent_meta.remote_pcp_size,
-                    consumer_pcp_rank=agent_meta.remote_pcp_rank,
-                    group_block_size=group_specs[group_index].kv_cache_spec.block_size,
-                    interleave_size=getattr(self, "cp_kv_cache_interleave_size", 1),
-                )
-                if pair_error is not None:
-                    logger.error(
-                        "req %s: failed to pair PCP blocks for KV group %d: %s",
-                        d_req_id,
-                        group_index,
-                        pair_error,
+            if agent_meta.remote_dcp_size > 1 and (
+                getattr(self, "dcp_size", 1) != 1
+                or getattr(self, "pcp_size", 1) != 1
+                or agent_meta.remote_pcp_size != 1
+            ):
+                err_reqs.append(d_req_id)
+                if err_msg is None:
+                    err_msg = (
+                        "Mooncake DCP v2 requires producer DCP1 and PCP1 on both sides"
                     )
-                    has_block_error = True
-                    if err_msg is None:
-                        err_msg = pair_error
-                    break
-                local_block_ids_by_group.append(local_group)
-                remote_block_ids_by_group.append(remote_group)
-
-            if has_block_error:
+                continue
+            if agent_meta.remote_dcp_size > 1 and (
+                agent_meta.remote_cp_block_pairing_version
+                < MOONCAKE_CP_BLOCK_PAIRING_VERSION
+                or remote_global_page_ids_per_group is None
+                or len(remote_global_page_ids_per_group)
+                != len(remote_block_ids_per_group)
+            ):
                 err_reqs.append(d_req_id)
                 if err_msg is None:
-                    err_msg = "Failed to pair Mooncake PCP blocks"
+                    err_msg = "Mooncake DCP requires protocol v2 global page identities"
                 continue
 
-            if not any(local_block_ids_by_group):
+            group_specs = self.kv_cache_config.kv_cache_groups
+            if len(group_specs) != len(send_meta.local_block_ids):
+                err_reqs.append(d_req_id)
+                if err_msg is None:
+                    err_msg = "Producer KV cache spec and request group counts differ"
                 continue
-
-            local_block_ids_by_group = self._logical_to_kernel_block_ids(
-                local_block_ids_by_group
-            )
-            remote_block_ids_by_group = self._logical_to_kernel_block_ids(
-                remote_block_ids_by_group
-            )
+            if not any(send_meta.local_block_ids):
+                continue
 
             selected_region_blocks: list[
                 tuple[TransferRegion, TransferRegion, list[int], list[int]]
             ] = []
             selected_block_count = 0
-            num_groups = len(remote_block_ids_by_group)
+            has_block_error = False
             for local_region, remote_region in zip(local_regions, remote_regions):
-                region_group_indices = _common_group_indices_for_regions(
-                    local_region, remote_region, num_groups
+                is_full_temporal_region = (
+                    remote_region.identity is not None
+                    and remote_region.identity.temporal_layout
+                    == KVCacheTemporalLayout.FULL_TEMPORAL.value
                 )
-                (
-                    local_block_ids,
-                    remote_block_ids,
-                    select_err,
-                ) = _select_region_block_ids(
-                    local_block_ids_by_group,
-                    remote_block_ids_by_group,
-                    region_group_indices,
+                region_group_pairs = _mapped_group_indices_for_regions(
+                    local_region,
+                    remote_region,
+                    len(send_meta.local_block_ids),
+                    len(remote_block_ids_per_group),
                 )
-                if select_err is not None:
-                    logger.error(
-                        "req %s: local blocks < remote blocks for KV groups %s",
-                        d_req_id,
-                        region_group_indices,
-                    )
-                    err_reqs.append(d_req_id)
+                if not region_group_pairs:
+                    has_block_error = True
                     if err_msg is None:
-                        err_msg = select_err
+                        err_msg = (
+                            "No compatible producer/consumer KV group mapping "
+                            f"for {local_region.match_layer_names}"
+                        )
+                    break
+                if is_full_temporal_region and len(region_group_pairs) != 1:
+                    has_block_error = True
+                    if err_msg is None:
+                        err_msg = (
+                            "Mooncake full-temporal regions require exactly "
+                            "one producer/consumer KV group mapping"
+                        )
+                    break
+
+                local_block_ids: list[int] = []
+                remote_block_ids: list[int] = []
+                for local_group_index, remote_group_index in region_group_pairs:
+                    local_group = list(send_meta.local_block_ids[local_group_index])
+                    remote_pages: list[int] | None = None
+                    if is_full_temporal_region:
+                        page_map = region_page_maps.get(remote_region.region_index)
+                        if (
+                            page_map is None
+                            or page_map.group_index != remote_group_index
+                        ):
+                            pair_error = (
+                                "Mooncake full-temporal region page map does "
+                                "not match its KV group"
+                            )
+                            has_block_error = True
+                            if err_msg is None:
+                                err_msg = pair_error
+                            break
+                        remote_group = list(page_map.dst_physical_block_ids)
+                        remote_pages = list(page_map.global_page_ids)
+                    else:
+                        remote_group = list(
+                            remote_block_ids_per_group[remote_group_index]
+                        )
+                    if not remote_group:
+                        continue
+
+                    group_spec = group_specs[local_group_index].kv_cache_spec
+                    if isinstance(group_spec, MambaSpec):
+                        if agent_meta.remote_dcp_size > 1:
+                            pair_error = "Mooncake DCP v2 does not support Mamba state"
+                            has_block_error = True
+                            if err_msg is None:
+                                err_msg = pair_error
+                            break
+                        local_group = [
+                            block_id
+                            for block_id in local_group
+                            if block_id != NULL_BLOCK_ID
+                        ]
+                        remote_group = [
+                            block_id
+                            for block_id in remote_group
+                            if block_id != NULL_BLOCK_ID
+                        ]
+
+                    if is_full_temporal_region:
+                        assert remote_pages is not None
+                        local_group, remote_group, pair_error = (
+                            _pair_full_temporal_blocks_by_global_page(
+                                local_group,
+                                remote_group,
+                                remote_pages,
+                                total_tokens=agent_meta.req_total_tokens.get(
+                                    d_req_id, 0
+                                ),
+                                num_external_tokens=(
+                                    agent_meta.req_num_external_tokens.get(d_req_id, 0)
+                                ),
+                                external_start_token=(
+                                    agent_meta.req_external_start_tokens.get(
+                                        d_req_id, 0
+                                    )
+                                ),
+                                page_size=group_spec.block_size,
+                            )
+                        )
+                    elif agent_meta.remote_dcp_size > 1:
+                        assert remote_global_page_ids_per_group is not None
+                        remote_pages = list(
+                            remote_global_page_ids_per_group[remote_group_index]
+                        )
+                        local_group, remote_group, pair_error = (
+                            _pair_dcp_blocks_by_global_page(
+                                local_group,
+                                remote_group,
+                                remote_pages,
+                                total_tokens=agent_meta.req_total_tokens.get(
+                                    d_req_id, 0
+                                ),
+                                num_external_tokens=(
+                                    agent_meta.req_num_external_tokens.get(d_req_id, 0)
+                                ),
+                                external_start_token=(
+                                    agent_meta.req_external_start_tokens.get(
+                                        d_req_id, 0
+                                    )
+                                ),
+                                consumer_dcp_size=agent_meta.remote_dcp_size,
+                                consumer_dcp_rank=agent_meta.remote_dcp_rank,
+                                page_size=group_spec.block_size,
+                                interleave_size=(
+                                    agent_meta.remote_cp_kv_cache_interleave_size
+                                ),
+                            )
+                        )
+                    else:
+                        local_group, remote_group, pair_error = _pair_cp_block_ids(
+                            local_group,
+                            remote_group,
+                            total_tokens=agent_meta.req_total_tokens.get(d_req_id, 0),
+                            num_external_tokens=(
+                                agent_meta.req_num_external_tokens.get(d_req_id, 0)
+                            ),
+                            external_start_token=(
+                                agent_meta.req_external_start_tokens.get(d_req_id, 0)
+                            ),
+                            producer_pcp_size=getattr(self, "pcp_size", 1),
+                            producer_pcp_rank=getattr(self, "pcp_rank", 0),
+                            consumer_pcp_size=agent_meta.remote_pcp_size,
+                            consumer_pcp_rank=agent_meta.remote_pcp_rank,
+                            producer_dcp_size=getattr(self, "dcp_size", 1),
+                            producer_dcp_rank=getattr(self, "dcp_rank", 0),
+                            consumer_dcp_size=agent_meta.remote_dcp_size,
+                            consumer_dcp_rank=agent_meta.remote_dcp_rank,
+                            group_block_size=group_spec.block_size,
+                            producer_interleave_size=getattr(
+                                self, "cp_kv_cache_interleave_size", 1
+                            ),
+                            consumer_interleave_size=(
+                                agent_meta.remote_cp_kv_cache_interleave_size
+                            ),
+                            consumer_cp_block_pairing_version=(
+                                agent_meta.remote_cp_block_pairing_version
+                            ),
+                        )
+                    if pair_error is not None:
+                        logger.error(
+                            "req %s: failed to pair CP blocks for KV group "
+                            "%d -> %d: %s",
+                            d_req_id,
+                            local_group_index,
+                            remote_group_index,
+                            pair_error,
+                        )
+                        has_block_error = True
+                        if err_msg is None:
+                            err_msg = pair_error
+                        break
+
+                    local_block_ids.extend(
+                        self._logical_group_to_kernel_block_ids(
+                            local_group, local_group_index
+                        )
+                    )
+                    remote_block_ids.extend(
+                        self._logical_group_to_kernel_block_ids(
+                            remote_group, local_group_index
+                        )
+                    )
+
+                if has_block_error:
                     selected_region_blocks = []
                     break
                 if not local_block_ids:
@@ -2414,6 +3399,12 @@ class MooncakeConnectorWorker:
                 selected_region_blocks.append(
                     (local_region, remote_region, local_block_ids, remote_block_ids)
                 )
+
+            if has_block_error:
+                err_reqs.append(d_req_id)
+                if err_msg is None:
+                    err_msg = "Failed to map Mooncake KV groups"
+                continue
 
             if not selected_region_blocks:
                 continue
@@ -2424,10 +3415,16 @@ class MooncakeConnectorWorker:
                 local_block_ids,
                 remote_block_ids,
             ) in selected_region_blocks:
-                layer_spec = self._layer_specs[local_region.layer_name]
-                region_fully_replicated = _spec_transfers_fully_replicated(
-                    layer_spec
-                )
+                layer_spec = self._get_layer_spec(local_region.layer_name)
+                if layer_spec is None:
+                    err_reqs.append(d_req_id)
+                    if err_msg is None:
+                        err_msg = (
+                            "No KV cache spec is present for layer "
+                            f"{local_region.layer_name}"
+                        )
+                    continue
+                region_fully_replicated = _spec_transfers_fully_replicated(layer_spec)
                 # Group by indices within this region's KV-cache group only.
                 group_local_block_ids, group_remote_block_ids = (
                     group_concurrent_contiguous(local_block_ids, remote_block_ids)
@@ -2571,21 +3568,25 @@ class MooncakeConnectorWorker:
         self.registered_layer_index_aliases = []
         self.registered_logical_group_indices = []
         self.registered_alias_group_indices = []
+        self.registered_region_identities = []
         overlay_to_region: dict[tuple[int, int, int, int], int] = {}
         speculative_method = getattr(
             self.vllm_config.speculative_config, "method", None
         )
-        is_mtp_speculative = speculative_method == "mtp" or (
+        # Draft models append decode-local KV layers at indices above the base
+        # model range. These caches are not produced or transferred by PD.
+        is_draft_kv_speculative = speculative_method in ("mtp", "dspark", "dflash") or (
             isinstance(speculative_method, str) and speculative_method.endswith("_mtp")
         )
         total_num_hidden_layers = self.model_config.get_total_num_hidden_layers()
 
         for layer_name, cache_or_caches in kv_caches.items():
             layer_index = extract_layer_index(layer_name)
-            if is_mtp_speculative and layer_index >= total_num_hidden_layers:
+            if is_draft_kv_speculative and layer_index >= total_num_hidden_layers:
                 logger.debug(
-                    "Skipping MTP speculative KV cache layer %s outside the "
-                    "base model layer range [0, %d)",
+                    "Skipping %s speculative draft KV cache layer %s outside "
+                    "the base model layer range [0, %d)",
+                    speculative_method,
                     layer_name,
                     total_num_hidden_layers,
                 )
@@ -2597,6 +3598,7 @@ class MooncakeConnectorWorker:
                     layer_name,
                 )
                 continue
+            region_identity = self._get_region_identity(layer_name)
             if isinstance(layer_spec, MambaSpec):
                 conv, _ = cache_or_caches
                 cache_list = [conv]
@@ -2637,6 +3639,19 @@ class MooncakeConnectorWorker:
                 )
                 if overlay_key in overlay_to_region:
                     region_idx = overlay_to_region[overlay_key]
+                    existing_identity = self.registered_region_identities[region_idx]
+                    if (
+                        existing_identity.temporal_layout
+                        != region_identity.temporal_layout
+                        or existing_identity.child_page_mapping
+                        != region_identity.child_page_mapping
+                        or existing_identity.child_page_factor
+                        != region_identity.child_page_factor
+                    ):
+                        raise ValueError(
+                            "Mooncake aliased KV layers must have identical "
+                            "temporal layouts"
+                        )
                     if layer_name not in self.registered_layer_aliases[region_idx]:
                         self.registered_layer_aliases[region_idx].append(layer_name)
                         self.registered_layer_index_aliases[region_idx].append(
@@ -2668,6 +3683,7 @@ class MooncakeConnectorWorker:
                 self.registered_layer_index_aliases.append([layer_index])
                 self.registered_logical_group_indices.append(list(logical_groups))
                 self.registered_alias_group_indices.append([list(logical_groups)])
+                self.registered_region_identities.append(region_identity)
 
         self.kv_caches_base_addr = region_base_addresses
         self.seen_base_addresses = kv_data_ptrs
@@ -2685,7 +3701,6 @@ class MooncakeConnectorWorker:
             self.block_len_per_layer,
             self.kv_block_len_per_layer,
         )
-
         # No need to launch server for D node.
         if self.is_kv_consumer:
             return
@@ -2776,8 +3791,10 @@ class MooncakeConnectorWorker:
             block_id for group in pull_meta.local_block_ids for block_id in group
         }
         if invalid_blocks:
-            with self._invalid_block_ids_lock:
-                self._invalid_block_ids.update(invalid_blocks)
+            invalid_block_ids_lock = getattr(self, "_invalid_block_ids_lock", None)
+            if invalid_block_ids_lock is not None:
+                with invalid_block_ids_lock:
+                    self._invalid_block_ids.update(invalid_blocks)
         self.finished_recving_reqs.add(pull_meta.d_req_id)
 
     def _account_failed_pull_tasks(
@@ -2808,34 +3825,174 @@ class MooncakeConnectorWorker:
     ):
         trace_enabled = envs.VLLM_MOONCAKE_PD_TRACE
         worker_started = time.perf_counter() if trace_enabled else 0.0
-        req_ids = list(pull_metas)
+        req_blocks: dict[ReqId, tuple[TransferId, list[list[int]]]] = {}
+        req_global_page_ids: dict[ReqId, list[list[int]]] = {}
+        req_region_page_maps: dict[ReqId, list[MooncakeRequestPageMap]] = {}
+        consumer_regions = self._get_transfer_regions(
+            self.kv_caches_base_addr,
+            self.block_len_per_layer,
+            self.kv_block_len_per_layer,
+            self.registered_layer_names,
+            self.registered_layer_indices,
+            self.registered_group_indices,
+            self.registered_layer_aliases,
+            self.registered_layer_index_aliases,
+            self.registered_logical_group_indices,
+            self.registered_alias_group_indices,
+            self.registered_region_identities or None,
+        )
+        has_full_temporal_regions = any(
+            region.identity is not None
+            and region.identity.temporal_layout
+            == KVCacheTemporalLayout.FULL_TEMPORAL.value
+            for region in consumer_regions
+        )
+        for req_id, pull_meta in pull_metas.items():
+            if self.dcp_size <= 1 and not has_full_temporal_regions:
+                req_blocks[req_id] = (
+                    pull_meta.transfer_id,
+                    pull_meta.local_block_ids,
+                )
+                continue
+
+            filtered_groups: list[list[int]] = []
+            page_id_groups: list[list[int]] = []
+            region_page_maps: list[MooncakeRequestPageMap] = []
+            preflight_error: str | None = None
+            group_specs = self.kv_cache_config.kv_cache_groups
+            local_block_ids = pull_meta.local_block_ids
+            if pull_meta.num_external_tokens == 0 and not local_block_ids:
+                local_block_ids = [[] for _ in group_specs]
+
+            if len(local_block_ids) != len(group_specs):
+                preflight_error = "DCP KV group count mismatch"
+            elif self.dcp_size <= 1:
+                filtered_groups = [list(block_ids) for block_ids in local_block_ids]
+                page_id_groups = [[] for _ in group_specs]
+            else:
+                for group_index, block_ids in enumerate(local_block_ids):
+                    group_spec = group_specs[group_index].kv_cache_spec
+                    if isinstance(group_spec, MambaSpec):
+                        preflight_error = "Mooncake DCP v2 does not support Mamba state"
+                        break
+                    blocks, global_pages, preflight_error = (
+                        _get_owned_dcp_suffix_blocks(
+                            block_ids,
+                            total_tokens=pull_meta.total_tokens,
+                            num_external_tokens=pull_meta.num_external_tokens,
+                            external_start_token=pull_meta.external_start_token,
+                            dcp_size=self.dcp_size,
+                            dcp_rank=self.dcp_rank,
+                            page_size=group_spec.block_size,
+                            interleave_size=self.cp_kv_cache_interleave_size,
+                        )
+                    )
+                    if preflight_error is not None:
+                        break
+                    filtered_groups.append(blocks)
+                    page_id_groups.append(global_pages)
+            if preflight_error is None:
+                for region in consumer_regions:
+                    identity = region.identity
+                    if (
+                        identity is None
+                        or identity.temporal_layout
+                        != KVCacheTemporalLayout.FULL_TEMPORAL.value
+                    ):
+                        continue
+                    region_group_indices = tuple(
+                        region.logical_group_indices or (region.group_index,)
+                    )
+                    if len(region_group_indices) != 1:
+                        preflight_error = (
+                            "Mooncake full-temporal regions require exactly "
+                            "one KV cache group"
+                        )
+                        break
+                    group_index = region_group_indices[0]
+                    if not 0 <= group_index < len(local_block_ids):
+                        preflight_error = (
+                            "Mooncake full-temporal region has an invalid "
+                            "KV cache group"
+                        )
+                        break
+                    layer_spec = self._get_layer_spec(region.layer_name)
+                    if layer_spec is None or isinstance(layer_spec, MambaSpec):
+                        preflight_error = (
+                            "Mooncake full-temporal region requires an "
+                            "attention KV cache spec"
+                        )
+                        break
+                    child_blocks, global_pages, preflight_error = (
+                        _get_full_temporal_suffix_blocks(
+                            local_block_ids[group_index],
+                            total_tokens=pull_meta.total_tokens,
+                            num_external_tokens=pull_meta.num_external_tokens,
+                            external_start_token=pull_meta.external_start_token,
+                            child_page_factor=identity.child_page_factor,
+                            page_size=layer_spec.block_size,
+                        )
+                    )
+                    if preflight_error is not None:
+                        break
+                    region_page_maps.append(
+                        MooncakeRequestPageMap(
+                            region_index=region.region_index,
+                            group_index=group_index,
+                            valid_start_token=(pull_meta.external_start_token),
+                            valid_end_token_exclusive=pull_meta.total_tokens,
+                            global_page_ids=global_pages,
+                            dst_physical_block_ids=child_blocks,
+                        )
+                    )
+            if preflight_error is not None:
+                logger.error(
+                    "Mooncake DCP preflight failed for request %s: %s",
+                    req_id,
+                    preflight_error,
+                )
+                self._account_failed_pull_tasks(pull_metas, [req_id])
+                continue
+            req_blocks[req_id] = (pull_meta.transfer_id, filtered_groups)
+            req_global_page_ids[req_id] = page_id_groups
+            req_region_page_maps[req_id] = region_page_maps
+
+        req_ids = list(req_blocks)
+        if not req_ids:
+            return
         outstanding_req_ids = set(req_ids)
         metadata = MooncakeXferMetadata(
             remote_hostname=self.hostname,
             remote_port=self.rpc_port,
             remote_tp_size=self.tp_size,
             remote_tp_rank=self.tp_rank,
-            req_blocks={
-                req_id: (pull_meta.transfer_id, pull_meta.local_block_ids)
-                for req_id, pull_meta in pull_metas.items()
-            },
+            req_blocks=req_blocks,
             kv_caches_base_addr=self.kv_caches_base_addr,
             block_lens=self.block_len_per_layer,
             kv_block_lens=self.kv_block_len_per_layer,
             remote_pcp_size=self.pcp_size,
             remote_pcp_rank=self.pcp_rank,
+            remote_dcp_size=self.dcp_size,
+            remote_dcp_rank=self.dcp_rank,
+            remote_cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
+            remote_cp_block_pairing_version=MOONCAKE_KV_REGION_LAYOUT_VERSION,
             req_total_tokens={
                 req_id: pull_meta.total_tokens
                 for req_id, pull_meta in pull_metas.items()
+                if req_id in req_blocks
             },
             req_num_external_tokens={
                 req_id: pull_meta.num_external_tokens
                 for req_id, pull_meta in pull_metas.items()
+                if req_id in req_blocks
             },
             req_external_start_tokens={
                 req_id: pull_meta.external_start_token
                 for req_id, pull_meta in pull_metas.items()
+                if req_id in req_blocks
             },
+            req_global_page_ids=req_global_page_ids,
+            req_region_page_maps=req_region_page_maps,
             registered_layer_names=self.registered_layer_names,
             registered_layer_indices=self.registered_layer_indices,
             registered_group_indices=self.registered_group_indices,
@@ -2843,6 +4000,7 @@ class MooncakeConnectorWorker:
             registered_layer_index_aliases=self.registered_layer_index_aliases,
             registered_logical_group_indices=self.registered_logical_group_indices,
             registered_alias_group_indices=self.registered_alias_group_indices,
+            registered_region_identities=self.registered_region_identities,
         )
 
         encoded_data = self._encoder.encode(metadata)
@@ -2971,6 +4129,9 @@ class MooncakeConnectorWorker:
                     }
                     self._tp_size[remote_engine_id] = len(dp_entry["worker_addr"])
                     self._pcp_size[remote_engine_id] = int(dp_entry.get("pcp_size", 1))
+                    self._cp_block_pairing_version[remote_engine_id] = int(
+                        dp_entry.get("cp_block_pairing_version", 0)
+                    )
         except Exception as e:
             logger.error(
                 "Failed to connect to bootstrap server %s: %s",
@@ -2987,6 +4148,34 @@ class MooncakeConnectorWorker:
         remote_engine_id: EngineId,
         pull_metas: dict[ReqId, PullReqMeta],
     ):
+        remote_cp_version = getattr(self, "_cp_block_pairing_version", {}).get(
+            remote_engine_id, 0
+        )
+        requires_region_layout = any(
+            identity.temporal_layout == KVCacheTemporalLayout.FULL_TEMPORAL.value
+            for identity in getattr(
+                self,
+                "registered_region_identities",
+                [],
+            )
+        )
+        required_cp_version = (
+            MOONCAKE_KV_REGION_LAYOUT_VERSION
+            if requires_region_layout
+            else MOONCAKE_CP_BLOCK_PAIRING_VERSION
+        )
+        if (
+            requires_region_layout or getattr(self, "dcp_size", 1) > 1
+        ) and remote_cp_version < required_cp_version:
+            logger.error(
+                "Mooncake producer engine %s does not advertise protocol v%d",
+                remote_engine_id,
+                required_cp_version,
+            )
+            for pull_meta in pull_metas.values():
+                pull_meta.pull_failed = True
+                self._mark_pull_failed(pull_meta)
+            return
         remote_tp_ranks = self.transfer_topo.handshake_target_ranks(
             self._tp_size[remote_engine_id]
         )
@@ -3013,6 +4202,17 @@ class MooncakeConnectorWorker:
         selected_remote_pp: dict[int, list[int]] = {}
         selected_remote_pcp: dict[tuple[int, int], list[int]] = {}
         remote_pcp_size = self._pcp_size[remote_engine_id]
+        if getattr(self, "dcp_size", 1) > 1 and (
+            self.pcp_size != 1 or remote_pcp_size != 1
+        ):
+            logger.error(
+                "Mooncake DCP v2 requires PCP1 on both sides for engine %s",
+                remote_engine_id,
+            )
+            for pull_meta in pull_metas.values():
+                pull_meta.pull_failed = True
+                self._mark_pull_failed(pull_meta)
+            return
         if self.pcp_size != remote_pcp_size and self.pcp_size != 1:
             logger.error(
                 "Unsupported Mooncake PCP topology for engine %s: "
@@ -3184,6 +4384,7 @@ class MooncakeConnectorWorker:
         layer_index_aliases: list[list[int]] | None = None,
         logical_group_indices: list[list[int]] | None = None,
         alias_group_indices: list[list[list[int]]] | None = None,
+        region_identities: list[MooncakeRegionIdentity] | None = None,
     ) -> list[TransferRegion]:
         if not group_indices:
             group_indices = [
@@ -3194,7 +4395,7 @@ class MooncakeConnectorWorker:
         if self.transfer_topo.virtually_split_kv_in_blocks:
             split_kv_regions = [
                 not isinstance(
-                    self._layer_specs[layer_name],
+                    self._get_layer_spec(layer_name),
                     (MambaSpec, MLAAttentionSpec, SlidingWindowMLASpec),
                 )
                 for layer_name in layer_names
@@ -3212,6 +4413,7 @@ class MooncakeConnectorWorker:
             layer_index_aliases=layer_index_aliases,
             logical_group_indices=logical_group_indices,
             alias_group_indices=alias_group_indices,
+            region_identities=region_identities,
         )
 
     def _get_sender_transfer_plan(
@@ -3243,16 +4445,56 @@ class MooncakeConnectorWorker:
         )
 
     def _get_layer_total_num_kv_heads(self, layer_name: str) -> int:
-        layer = self.vllm_config.compilation_config.static_forward_context.get(
-            layer_name
-        )
-        return int(
+        static_forward_context = getattr(
             getattr(
-                layer,
-                "total_num_kv_heads",
-                self.transfer_topo.total_num_kv_heads,
-            )
+                getattr(self, "vllm_config", None),
+                "compilation_config",
+                None,
+            ),
+            "static_forward_context",
+            {},
         )
+        layer = static_forward_context.get(layer_name)
+        fallback = getattr(self.transfer_topo, "total_num_kv_heads", None)
+        if fallback is None:
+            layer_spec = self._get_layer_spec(layer_name)
+            fallback = getattr(layer_spec, "num_kv_heads", 1)
+        return int(getattr(layer, "total_num_kv_heads", fallback))
+
+    def _build_layer_specs(self) -> dict[str, KVCacheSpec]:
+        layer_specs: dict[str, KVCacheSpec] = {}
+        for group in self.kv_cache_config.kv_cache_groups:
+            group_spec = group.kv_cache_spec
+            specs_by_layer = getattr(group_spec, "kv_cache_specs", {})
+            for layer_name in group.layer_names:
+                layer_specs[layer_name] = specs_by_layer.get(layer_name, group_spec)
+        return layer_specs
+
+    def _get_region_identity(self, layer_name: str) -> MooncakeRegionIdentity:
+        layer_spec = self._get_layer_spec(layer_name)
+        if layer_spec is None:
+            raise ValueError(f"No KV cache spec is present for {layer_name}")
+        temporal_layout = layer_spec.temporal_layout
+        if temporal_layout == KVCacheTemporalLayout.FULL_TEMPORAL and self.dcp_size > 1:
+            child_page_mapping = KVCacheChildPageMapping.GLOBAL_PAGE_MODULO
+            child_page_factor = self.dcp_size
+        else:
+            child_page_mapping = KVCacheChildPageMapping.IDENTITY
+            child_page_factor = 1
+        return MooncakeRegionIdentity(
+            layer_name=layer_name,
+            temporal_layout=temporal_layout.value,
+            protocol_version=MOONCAKE_KV_REGION_LAYOUT_VERSION,
+            child_page_mapping=child_page_mapping.value,
+            child_page_factor=child_page_factor,
+        )
+
+    def _get_layer_spec(self, layer_name: str) -> KVCacheSpec | None:
+        layer_specs = getattr(self, "_layer_specs", None)
+        if layer_specs is None:
+            layer_specs = self._build_layer_specs()
+            self._layer_specs = layer_specs
+        return layer_specs.get(layer_name)
 
     def _log_debug_cache_registration(
         self, layer_name: str, cache: torch.Tensor

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_utils.py
@@ -13,6 +13,9 @@ from vllm.distributed.kv_transfer.kv_connector.utils import EngineId
 from vllm.logger import init_logger
 
 WorkerAddr = str
+MOONCAKE_LEGACY_CP_BLOCK_PAIRING_VERSION = 1
+MOONCAKE_CP_BLOCK_PAIRING_VERSION = 2
+MOONCAKE_KV_REGION_LAYOUT_VERSION = 3
 
 logger = init_logger(__name__)
 
@@ -33,6 +36,7 @@ class RegisterWorkerPayload(BaseModel):
     pp_rank: int
     pcp_rank: int = 0
     pcp_size: int = 1
+    cp_block_pairing_version: int = 0
     addr: WorkerAddr
 
 
@@ -40,6 +44,7 @@ class RegisterWorkerPayload(BaseModel):
 class EngineEntry:
     engine_id: EngineId
     pcp_size: int
+    cp_block_pairing_version: int
     # {tp_rank: {pp_rank: {pcp_rank: worker_addr}}}
     worker_addr: dict[int, dict[int, dict[int, WorkerAddr]]]
 
@@ -96,6 +101,7 @@ class MooncakeBootstrapServer:
             self.workers[payload.dp_rank] = EngineEntry(
                 engine_id=payload.engine_id,
                 pcp_size=payload.pcp_size,
+                cp_block_pairing_version=payload.cp_block_pairing_version,
                 worker_addr={},
             )
 
@@ -122,6 +128,15 @@ class MooncakeBootstrapServer:
                 detail=(
                     f"PCP size mismatch for dp_rank={payload.dp_rank}: "
                     f"expected {dp_entry.pcp_size}, got {payload.pcp_size}"
+                ),
+            )
+        if dp_entry.cp_block_pairing_version != payload.cp_block_pairing_version:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"CP block pairing version mismatch for dp_rank={payload.dp_rank}: "
+                    f"expected {dp_entry.cp_block_pairing_version}, "
+                    f"got {payload.cp_block_pairing_version}"
                 ),
             )
         if payload.tp_rank not in dp_entry.worker_addr:

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -1385,6 +1385,8 @@ class MinimaxM3QKVParallelLinearWithIndexer(QKVParallelLinear):
         bias: bool = False,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
+        dcp_q_replicate: bool = False,
+        dcp_world_size: int = 1,
     ) -> None:
         # index_q rides the KV-head sharding/replication path, so its head count
         # must match the KV heads.
@@ -1399,9 +1401,19 @@ class MinimaxM3QKVParallelLinearWithIndexer(QKVParallelLinear):
         self.total_num_kv_heads = total_num_kv_heads
         self.total_num_index_heads = total_num_index_heads
         self.index_head_size = index_head_size
+        self.dcp_q_replicate = dcp_q_replicate
+        self.dcp_world_size = dcp_world_size
 
         tp_size = get_tensor_model_parallel_world_size()
-        self.num_heads = divide(self.total_num_heads, tp_size)
+        tp_rank = get_tensor_model_parallel_rank()
+        self.q_tp_size = tp_size
+        self.q_shard_rank = tp_rank
+        if self.dcp_q_replicate:
+            assert dcp_world_size > 1
+            assert tp_size % dcp_world_size == 0
+            self.q_tp_size = divide(tp_size, dcp_world_size)
+            self.q_shard_rank = tp_rank // dcp_world_size
+        self.num_heads = divide(self.total_num_heads, self.q_tp_size)
         if tp_size >= self.total_num_kv_heads:
             self.num_kv_heads = 1
             self.num_kv_head_replicas = divide(tp_size, self.total_num_kv_heads)
@@ -1412,7 +1424,9 @@ class MinimaxM3QKVParallelLinearWithIndexer(QKVParallelLinear):
         self.num_index_heads = self.num_kv_heads
 
         # Global per-group sizes (replicated groups counted x tp_size, matching
-        # the QKVParallelLinear convention). index_k is a single replicated head.
+        # the QKVParallelLinear convention). When DCP Q replication is enabled,
+        # Q is intentionally over-counted so each DCP peer materializes the same
+        # larger Q shard while K/V/index sharding remains unchanged.
         q = self.num_heads * self.head_size
         kv = self.num_kv_heads * self.head_size
         iq = self.num_index_heads * self.index_head_size
@@ -1492,12 +1506,14 @@ class MinimaxM3QKVParallelLinearWithIndexer(QKVParallelLinear):
         num_heads = (
             self.tp_size if loaded_shard_id == "index_k" else self.num_kv_head_replicas
         )
+        shard_rank = self.q_shard_rank if loaded_shard_id == "q" else None
         param.load_qkv_weight(
             loaded_weight=loaded_weight,
             num_heads=num_heads,
             shard_id=loaded_shard_id,
             shard_offset=shard_offset,
             shard_size=shard_size,
+            shard_rank=shard_rank,
         )
 
     def weight_loader(
@@ -1524,7 +1540,7 @@ class MinimaxM3QKVParallelLinearWithIndexer(QKVParallelLinear):
 
         param_data = param.data.narrow(output_dim, shard_offset, shard_size)
         if loaded_shard_id == "q":
-            shard_rank = self.tp_rank
+            shard_rank = self.q_shard_rank
         elif loaded_shard_id == "index_k":
             shard_rank = 0  # replicated to every rank
         else:

--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -32,6 +32,21 @@ from .utils import (
 logger = init_logger(__name__)
 
 
+def _get_eagle3_target_layer_count(vllm_config: VllmConfig) -> int:
+    speculative_config = vllm_config.speculative_config
+    assert speculative_config is not None
+    if getattr(
+        speculative_config,
+        "enable_eagle3_prefill_draft_kv",
+        False,
+    ):
+        target_layer_count = vllm_config.model_config.get_total_num_hidden_layers()
+        if target_layer_count != 60:
+            raise ValueError("EAGLE3 Prefill draft-KV requires 60 global target layers")
+        return target_layer_count
+    return vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
+
+
 class LlamaDecoderLayer(LlamaDecoderLayer):
     def __init__(
         self,
@@ -278,9 +293,7 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
         if getattr(self.config, "draft_vocab_size", None) is None:
             base_vocab_size = getattr(self.config, "vocab_size", None)
             self.config.draft_vocab_size = base_vocab_size
-        target_layer_num = vllm_config.model_config.get_num_layers(
-            vllm_config.parallel_config
-        )
+        target_layer_num = _get_eagle3_target_layer_count(vllm_config)
 
         # Store target layer count in draft config for
         # proper layer_types indexing in draft models

--- a/vllm/model_executor/parameter.py
+++ b/vllm/model_executor/parameter.py
@@ -180,6 +180,7 @@ class _ColumnvLLMParameter(BasevLLMParameter):
         shard_size: int = kwargs["shard_size"]
         shard_id: str = kwargs["shard_id"]
         num_heads: int = kwargs["num_heads"]
+        shard_rank: int | None = kwargs.get("shard_rank")
 
         # TODO: move these to PackedColumnParameter and PackedvLLMParameter
         if (
@@ -191,7 +192,11 @@ class _ColumnvLLMParameter(BasevLLMParameter):
             )
 
         param_data = self.data
-        shard_id_int = self.tp_rank if shard_id == "q" else self.tp_rank // num_heads
+        shard_id_int = (
+            shard_rank
+            if shard_rank is not None
+            else (self.tp_rank if shard_id == "q" else self.tp_rank // num_heads)
+        )
         param_data = param_data.narrow(self.output_dim, shard_offset, shard_size)
         loaded_weight = loaded_weight.narrow(
             self.output_dim, shard_id_int * shard_size, shard_size
@@ -504,6 +509,7 @@ class SharedWeightParameter(BasevLLMParameter):
         shard_offset = self.tp_rank * shard_size
         shard_id = "q"  # fake first partition
         num_heads = kwargs.get("num_heads")
+        shard_rank = kwargs.get("shard_rank")
 
         ModelWeightParameter.load_qkv_weight(
             partition,
@@ -512,6 +518,7 @@ class SharedWeightParameter(BasevLLMParameter):
             shard_size=shard_size,
             shard_id=shard_id,
             num_heads=num_heads,
+            shard_rank=shard_rank,
         )
 
     def process_weights_after_loading(self):

--- a/vllm/models/minimax_m3/common/indexer.py
+++ b/vllm/models/minimax_m3/common/indexer.py
@@ -596,8 +596,6 @@ class MiniMaxM3IndexerTritonImpl(MiniMaxM3IndexerImpl):
             selected_global_ids // self.dcp_world_size,
             selected_global_ids.new_full((), -1),
         )
-        self._dcp_canonical_global_topk = selected_global_ids
-        self._dcp_aligned_local_topk = localized
         out.copy_(localized)
         return out
 

--- a/vllm/models/minimax_m3/common/indexer.py
+++ b/vllm/models/minimax_m3/common/indexer.py
@@ -23,7 +23,8 @@ from torch import nn
 from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
 from vllm.config.attention import IndexerKVDType
 from vllm.config.cache import CacheDType
-from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.distributed import get_dcp_group, get_tensor_model_parallel_world_size
+from vllm.distributed.cp_mapping import get_cp_local_seq_len
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
@@ -38,6 +39,7 @@ if current_platform.is_rocm():
 else:
     from vllm.models.minimax_m3.common.ops.index_topk import (
         minimax_m3_index_decode,
+        minimax_m3_index_decode_score,
         minimax_m3_index_score,
         minimax_m3_index_topk,
     )
@@ -50,7 +52,10 @@ from vllm.v1.attention.backend import (
     CommonAttentionMetadata,
     MultipleOf,
 )
-from vllm.v1.attention.backends.utils import split_decodes_and_prefills
+from vllm.v1.attention.backends.utils import (
+    get_cp_local_seq_lens,
+    split_decodes_and_prefills,
+)
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     KVCacheSpec,
@@ -58,6 +63,29 @@ from vllm.v1.kv_cache_interface import (
 )
 
 logger = init_logger(__name__)
+
+
+def _stable_lexicographic_topk(
+    scores: torch.Tensor,
+    global_ids: torch.Tensor,
+    tiers: torch.Tensor,
+    k: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Order by tier desc, FP32 score desc, then global block id asc."""
+    order = torch.argsort(global_ids, dim=-1, stable=True)
+    scores = scores.gather(-1, order)
+    global_ids = global_ids.gather(-1, order)
+    tiers = tiers.gather(-1, order)
+    order = torch.argsort(scores, dim=-1, descending=True, stable=True)
+    scores = scores.gather(-1, order)
+    global_ids = global_ids.gather(-1, order)
+    tiers = tiers.gather(-1, order)
+    order = torch.argsort(tiers, dim=-1, descending=True, stable=True)[..., :k]
+    return (
+        scores.gather(-1, order),
+        global_ids.gather(-1, order),
+        tiers.gather(-1, order),
+    )
 
 
 class MiniMaxM3IndexerBackend(AttentionBackend):
@@ -192,6 +220,8 @@ class MiniMaxM3IndexerDecodeMetadata:
     max_seq_len: int
     decode_query_len: int
     max_decode_query_len: int
+    global_kv_lens: torch.Tensor | None = None  # [num_decode_tokens] int32
+    local_kv_lens: torch.Tensor | None = None  # [num_decode_tokens] int32
 
 
 @dataclass
@@ -245,7 +275,27 @@ class MiniMaxM3IndexerMetadataBuilder(
         else:
             assert tp_size % total_index_heads == 0
         self.num_index_heads = max(1, total_index_heads // tp_size)
-        self._init_reorder_batch_threshold(1, supports_spec_as_decode=True)
+        parallel_config = vllm_config.parallel_config
+        self.dcp_world_size = parallel_config.decode_context_parallel_size
+        self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
+        self.cp_kv_cache_interleave_size = parallel_config.cp_kv_cache_interleave_size
+        self.sparse_block_size = sparse_cfg["sparse_block_size"]
+        if self.dcp_world_size > 1:
+            if not current_platform.is_cuda():
+                raise NotImplementedError(
+                    "MiniMax M3 sparse-indexer DCP currently supports CUDA only."
+                )
+            if self.cp_kv_cache_interleave_size != self.sparse_block_size:
+                raise NotImplementedError(
+                    "MiniMax M3 sparse-indexer DCP requires block-level KV "
+                    f"interleave ({self.sparse_block_size}), got "
+                    f"{self.cp_kv_cache_interleave_size}."
+                )
+        self._init_reorder_batch_threshold(
+            1,
+            supports_spec_as_decode=True,
+            supports_dcp_with_varlen=True,
+        )
         assert self.reorder_batch_threshold is not None
         self.max_decode_query_len = self.reorder_batch_threshold
 
@@ -261,6 +311,22 @@ class MiniMaxM3IndexerMetadataBuilder(
             vllm_config.scheduler_config.max_num_batched_tokens,
             dtype=torch.int32,
             device=device,
+        )
+        self.global_decode_kv_lens_buffer = torch.empty(
+            vllm_config.scheduler_config.max_num_batched_tokens,
+            dtype=torch.int32,
+            device=device,
+        )
+        self.local_decode_kv_lens_buffer = torch.empty_like(
+            self.global_decode_kv_lens_buffer
+        )
+
+    def _localize_max_seq_len(self, max_seq_len: int) -> int:
+        return get_cp_local_seq_len(
+            max_seq_len,
+            cp_world_size=self.dcp_world_size,
+            cp_rank=self.dcp_rank,
+            interleave_size=self.cp_kv_cache_interleave_size,
         )
 
 
@@ -318,12 +384,44 @@ class MiniMaxM3IndexerTritonMetadataBuilder(MiniMaxM3IndexerMetadataBuilder):
                 (query_lens_cpu == decode_query_len) | (query_lens_cpu == 0)
             )
             assert num_decode_tokens == num_decodes * decode_query_len
+            global_kv_lens: torch.Tensor | None = None
+            local_kv_lens: torch.Tensor | None = None
+            if self.dcp_world_size > 1:
+                q_offsets = torch.arange(
+                    1,
+                    decode_query_len + 1,
+                    dtype=torch.int32,
+                    device=seq_lens.device,
+                )
+                global_kv_lens = self.global_decode_kv_lens_buffer[:num_decode_tokens]
+                global_kv_lens.copy_(
+                    (
+                        seq_lens[:num_decodes, None]
+                        - decode_query_len
+                        + q_offsets[None, :]
+                    )
+                    .clamp_min(0)
+                    .flatten()
+                )
+                local_kv_lens = self.local_decode_kv_lens_buffer[:num_decode_tokens]
+                local_kv_lens.copy_(
+                    get_cp_local_seq_lens(
+                        global_kv_lens,
+                        self.dcp_world_size,
+                        self.dcp_rank,
+                        self.cp_kv_cache_interleave_size,
+                    )
+                )
             decode_metadata = MiniMaxM3IndexerDecodeMetadata(
                 seq_lens=seq_lens[:num_decodes],
                 block_table=block_table[:num_decodes],
-                max_seq_len=common_attn_metadata.max_seq_len,
+                max_seq_len=self._localize_max_seq_len(
+                    common_attn_metadata.max_seq_len
+                ),
                 decode_query_len=decode_query_len,
                 max_decode_query_len=self.max_decode_query_len,
+                global_kv_lens=global_kv_lens,
+                local_kv_lens=local_kv_lens,
             )
 
         return MiniMaxM3IndexerMetadata(
@@ -403,6 +501,106 @@ class MiniMaxM3IndexerImpl(nn.Module):
 class MiniMaxM3IndexerTritonImpl(MiniMaxM3IndexerImpl):
     """Triton indexer score + top-k for both prefill and decode."""
 
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        parallel_config = get_current_vllm_config().parallel_config
+        self.dcp_world_size = parallel_config.decode_context_parallel_size
+        self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
+        self.cp_kv_cache_interleave_size = parallel_config.cp_kv_cache_interleave_size
+        if (
+            self.dcp_world_size > 1
+            and self.cp_kv_cache_interleave_size != self.block_size
+        ):
+            raise NotImplementedError(
+                "MiniMax M3 Triton indexer DCP requires block-level KV "
+                f"interleave ({self.block_size}), got "
+                f"{self.cp_kv_cache_interleave_size}."
+            )
+
+    def _select_dcp_global_topk(
+        self,
+        score: torch.Tensor,
+        global_kv_lens: torch.Tensor,
+        out: torch.Tensor,
+        max_local_blocks: int,
+    ) -> torch.Tensor:
+        """Select exact global block top-k, then localize to this owner rank."""
+        score = score[:, :, :max_local_blocks]
+        nan_mask = torch.isnan(score)
+        score = torch.where(nan_mask, score.new_full((), float("-inf")), score)
+        local_ids = torch.arange(
+            max_local_blocks, dtype=torch.int32, device=score.device
+        )
+        global_ids = local_ids * self.dcp_world_size + self.dcp_rank
+        global_num_blocks = (global_kv_lens + self.block_size - 1) // self.block_size
+        valid = global_ids[None, None, :] < global_num_blocks[None, :, None]
+        score = score.masked_fill(~valid, float("-inf"))
+
+        init_mask = global_ids[None, None, :] < self.init_blocks
+        local_start = (global_num_blocks - self.local_blocks).clamp_min(0)
+        local_mask = global_ids[None, None, :] >= local_start[None, :, None]
+        tiers = torch.zeros_like(score, dtype=torch.int32)
+        tiers = torch.where(valid & local_mask, tiers.new_full((), 1), tiers)
+        tiers = torch.where(valid & init_mask, tiers.new_full((), 2), tiers)
+        tiers.masked_fill_(~valid | (nan_mask & (tiers == 0)), -1)
+
+        local_k = min(self.topk_blocks, max_local_blocks)
+        expanded_global_ids = global_ids.view(1, 1, -1).expand_as(score)
+        candidate_scores, candidate_global_ids, candidate_tiers = (
+            _stable_lexicographic_topk(
+                score,
+                expanded_global_ids,
+                tiers,
+                local_k,
+            )
+        )
+        candidate_valid = candidate_tiers >= 0
+        candidate_global_ids.masked_fill_(~candidate_valid, -1)
+        candidate_tiers.masked_fill_(~candidate_valid, -1)
+        if local_k < self.topk_blocks:
+            pad = self.topk_blocks - local_k
+            candidate_scores = torch.nn.functional.pad(
+                candidate_scores, (0, pad), value=float("-inf")
+            )
+            candidate_global_ids = torch.nn.functional.pad(
+                candidate_global_ids, (0, pad), value=-1
+            )
+            candidate_tiers = torch.nn.functional.pad(
+                candidate_tiers, (0, pad), value=-1
+            )
+
+        packed = torch.stack(
+            (
+                candidate_scores,
+                candidate_global_ids.to(torch.float32),
+                candidate_tiers.to(torch.float32),
+            ),
+            dim=-1,
+        )
+        gathered = get_dcp_group().all_gather(packed.contiguous(), dim=2)
+        _, selected_global_ids, selected_tiers = _stable_lexicographic_topk(
+            gathered[..., 0],
+            gathered[..., 1].to(torch.int32),
+            gathered[..., 2].to(torch.int32),
+            self.topk_blocks,
+        )
+        selected_valid = selected_tiers >= 0
+        selected_global_ids.masked_fill_(~selected_valid, -1)
+        selected_tiers.masked_fill_(~selected_valid, -1)
+
+        owned = (selected_global_ids >= 0) & (
+            selected_global_ids % self.dcp_world_size == self.dcp_rank
+        )
+        localized = torch.where(
+            owned,
+            selected_global_ids // self.dcp_world_size,
+            selected_global_ids.new_full((), -1),
+        )
+        self._dcp_canonical_global_topk = selected_global_ids
+        self._dcp_aligned_local_topk = localized
+        out.copy_(localized)
+        return out
+
     def forward(
         self,
         index_query: torch.Tensor,
@@ -431,21 +629,56 @@ class MiniMaxM3IndexerTritonImpl(MiniMaxM3IndexerImpl):
         if index_md.num_decodes > 0:
             d = index_md.decode
             assert d is not None
-            decode_topk = minimax_m3_index_decode(
-                iq[:nd],
-                kv,
-                d.block_table,
-                d.seq_lens,
-                d.max_seq_len,
-                self.topk_blocks,
-                self.init_blocks,
-                self.local_blocks,
-                self.num_kv_heads,
-                d.decode_query_len,
-                d.max_decode_query_len,
-                out=buf_htk,
-            )
+            if self.dcp_world_size > 1:
+                assert d.global_kv_lens is not None
+                assert d.local_kv_lens is not None
+                if buf_htk is None:
+                    raise RuntimeError(
+                        "MiniMax M3 DCP requires a persistent top-k output buffer."
+                    )
+                score = minimax_m3_index_decode_score(
+                    iq[:nd],
+                    kv,
+                    d.block_table,
+                    d.seq_lens,
+                    d.max_seq_len,
+                    0,
+                    0,
+                    self.num_kv_heads,
+                    d.decode_query_len,
+                    d.max_decode_query_len,
+                    kv_lens=d.local_kv_lens,
+                )
+                max_local_blocks = (
+                    d.max_seq_len + self.block_size - 1
+                ) // self.block_size
+                decode_topk = self._select_dcp_global_topk(
+                    score,
+                    d.global_kv_lens,
+                    buf_htk[:, :nd, :],
+                    max_local_blocks,
+                )
+            else:
+                decode_topk = minimax_m3_index_decode(
+                    iq[:nd],
+                    kv,
+                    d.block_table,
+                    d.seq_lens,
+                    d.max_seq_len,
+                    self.topk_blocks,
+                    self.init_blocks,
+                    self.local_blocks,
+                    self.num_kv_heads,
+                    d.decode_query_len,
+                    d.max_decode_query_len,
+                    out=buf_htk,
+                )
         if index_md.num_prefills > 0:
+            if self.dcp_world_size > 1:
+                raise NotImplementedError(
+                    "MiniMax M3 Triton DCP currently supports decode-only "
+                    "batches; sparse prefill DCP is not implemented."
+                )
             p = index_md.prefill
             assert p is not None
             score = minimax_m3_index_score(
@@ -489,6 +722,22 @@ def select_indexer_impl_cls(
             f"indexer_kv_dtype={indexer_kv_dtype!r} needs the (not-yet-added) "
             "CuteDSL indexer impl."
         )
+    dcp_world_size = (
+        get_current_vllm_config().parallel_config.decode_context_parallel_size
+    )
+    if dcp_world_size > 1:
+        if indexer_kv_dtype != "bf16":
+            raise NotImplementedError(
+                "MiniMax M3 DCP requires the BF16 Triton indexer, got "
+                f"indexer_kv_dtype={indexer_kv_dtype!r}."
+            )
+        logger.info_once(
+            "MiniMax M3 indexer: selected Triton for DCP "
+            "[topk_blocks=%d, dcp_world_size=%d]",
+            topk_blocks,
+            dcp_world_size,
+        )
+        return MiniMaxM3IndexerTritonImpl
     is_sm100 = (
         current_platform.is_cuda() and current_platform.is_device_capability_family(100)
     )

--- a/vllm/models/minimax_m3/common/ops/index_topk.py
+++ b/vllm/models/minimax_m3/common/ops/index_topk.py
@@ -298,6 +298,7 @@ def _decode_index_score_kernel(
     score_ptr,  # [num_idx_heads, total_q, max_block]
     block_table_ptr,  # [num_reqs, max_blocks]
     seq_lens,  # [num_reqs]
+    kv_lens,  # optional per-query local KV lengths: [total_q]
     num_idx_heads: tl.constexpr,
     head_dim: tl.constexpr,
     init_blocks,
@@ -316,6 +317,7 @@ def _decode_index_score_kernel(
     BLOCK_SIZE_K: tl.constexpr,  # == SPARSE_BLOCK_SIZE (128)
     BLOCK_SIZE_Q: tl.constexpr,
     num_kv_chunks,
+    HAS_KV_LENS: tl.constexpr,
     USE_PDL: tl.constexpr,
 ):
     BLOCK_SIZE_HQ: tl.constexpr = num_idx_heads * BLOCK_SIZE_Q
@@ -331,11 +333,14 @@ def _decode_index_score_kernel(
         tl.extra.cuda.gdc_wait()
         tl.extra.cuda.gdc_launch_dependents()
 
-    seq_len = tl.load(seq_lens + pid_r)
-    query_pos = seq_len - decode_query_len + q_offsets
-    # Full-CG padding uses zero-length request rows. Clamp to an empty
-    # attention range instead of letting padded rows produce negative lengths.
-    kv_len = tl.maximum(query_pos + 1, 0)
+    if HAS_KV_LENS:
+        kv_len = tl.load(kv_lens + q_ids, mask=q_mask, other=0)
+    else:
+        seq_len = tl.load(seq_lens + pid_r)
+        query_pos = seq_len - decode_query_len + q_offsets
+        # Full-CG padding uses zero-length request rows. Clamp to an empty
+        # attention range instead of letting padded rows produce negative lengths.
+        kv_len = tl.maximum(query_pos + 1, 0)
     num_blocks_q = (kv_len + BLOCK_SIZE_K - 1) // BLOCK_SIZE_K
     kv_len_max = tl.max(tl.where(q_mask, kv_len, 0), axis=0)
     num_blocks = (kv_len_max + BLOCK_SIZE_K - 1) // BLOCK_SIZE_K
@@ -769,6 +774,7 @@ def minimax_m3_index_decode_score(
     decode_query_len: int,
     max_decode_query_len: int,
     score_out: torch.Tensor | None = None,
+    kv_lens: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Decode index block-score (split-K, cudagraph-safe); no top-k.
 
@@ -784,6 +790,9 @@ def minimax_m3_index_decode_score(
     )
     assert decode_query_len <= max_decode_query_len
     assert total_q == seq_lens.shape[0] * decode_query_len
+    if kv_lens is not None:
+        assert kv_lens.shape == (total_q,)
+        assert kv_lens.dtype == torch.int32
     max_block = triton.cdiv(max_seq_len, SPARSE_BLOCK_SIZE)
     use_pdl = current_platform.is_arch_support_pdl()
     # `launch_pdl` is a Triton runtime kwarg only some backends accept (CUDA
@@ -824,12 +833,14 @@ def minimax_m3_index_decode_score(
     )
     num_kv_chunks = 1 << (target.bit_length() - 1)
     grid_score = (seq_lens.shape[0], num_kv_chunks)
+    kv_lens_arg = kv_lens if kv_lens is not None else seq_lens
     _decode_index_score_kernel[grid_score](
         idx_q,
         index_kv_cache,
         score,
         block_table,
         seq_lens,
+        kv_lens_arg,
         num_idx_heads,
         head_dim,
         init_blocks,
@@ -848,6 +859,7 @@ def minimax_m3_index_decode_score(
         BLOCK_SIZE_K=SPARSE_BLOCK_SIZE,
         BLOCK_SIZE_Q=BLOCK_SIZE_Q,
         num_kv_chunks=num_kv_chunks,
+        HAS_KV_LENS=kv_lens is not None,
         USE_PDL=use_pdl,
         **score_kwargs,
     )

--- a/vllm/models/minimax_m3/common/ops/sparse_attn.py
+++ b/vllm/models/minimax_m3/common/ops/sparse_attn.py
@@ -44,8 +44,9 @@ _FP8_DTYPES = (
     {
         "BLOCK_SIZE_D": lambda args: triton.next_power_of_2(args["head_dim"]),
         "BLOCK_SIZE_H": lambda args: triton.next_power_of_2(args["gqa_group_size"]),
-        "BLOCK_SIZE_QH": lambda args: args["BLOCK_SIZE_Q"]
-        * triton.next_power_of_2(args["gqa_group_size"]),
+        "BLOCK_SIZE_QH": lambda args: (
+            args["BLOCK_SIZE_Q"] * triton.next_power_of_2(args["gqa_group_size"])
+        ),
     }
 )
 @triton.jit(do_not_specialize_on_alignment=["seq_lens", "prefix_lens"])
@@ -237,10 +238,12 @@ def _gqa_sparse_decode_kernel(
     k_scale_ptr,
     v_scale_ptr,
     t_ptr,  # topk_idx: [num_kv_heads, total_q, topk]
+    topk_valid_counts,  # optional [num_kv_heads, total_q]
     o_ptr,  # partial out: [NUM_TOPK_CHUNKS, total_q, num_heads, head_dim]
     lse_ptr,  # partial lse (log2): [NUM_TOPK_CHUNKS, total_q, num_heads]
     block_table_ptr,  # [num_reqs, max_blocks]
     seq_lens,  # [num_reqs]
+    kv_lens,  # optional per-query local KV lengths: [total_q]
     total_q,
     gqa_group_size,
     head_dim,
@@ -261,6 +264,8 @@ def _gqa_sparse_decode_kernel(
     stride_th,
     stride_tn,
     stride_tk,
+    stride_tvc_h,
+    stride_tvc_n,
     stride_o_c,
     stride_o_b,
     stride_o_h,
@@ -275,6 +280,9 @@ def _gqa_sparse_decode_kernel(
     BLOCK_SIZE_D: tl.constexpr,
     USE_FP8: tl.constexpr,  # fp8 KV cache: dequantize K/V to q.dtype on load
     KV_SCALE_MODE: tl.constexpr,  # 0: none, 1: scalar, 2: [kv_head, token]
+    HAS_KV_LENS: tl.constexpr,
+    HAS_TOPK_VALID_COUNTS: tl.constexpr,
+    ALIGNED_TOPK: tl.constexpr,
     USE_PDL: tl.constexpr,
 ):
     sm_scale_log2e = sm_scale * 1.4426950409
@@ -292,16 +300,26 @@ def _gqa_sparse_decode_kernel(
     if USE_PDL:
         tl.extra.cuda.gdc_wait()
 
-    seq_len = tl.load(seq_lens + req_id)
-    query_pos = seq_len - decode_query_len + q_offset
-    # Full-CG padding uses zero-length request rows. Clamp to an empty
-    # attention range instead of letting padded rows produce negative lengths.
-    kv_len = tl.maximum(query_pos + 1, 0)
+    if HAS_KV_LENS:
+        kv_len = tl.load(kv_lens + pid_b)
+    else:
+        seq_len = tl.load(seq_lens + req_id)
+        query_pos = seq_len - decode_query_len + q_offset
+        # Full-CG padding uses zero-length request rows. Clamp to an empty
+        # attention range instead of letting padded rows produce negative lengths.
+        kv_len = tl.maximum(query_pos + 1, 0)
 
     # Valid block count from seq_len (no sentinel): min(topk, cdiv(kv_len, blk)).
     idx_base = t_ptr + pid_kh * stride_th + pid_b * stride_tn
     num_blocks = (kv_len + BLOCK_SIZE_K - 1) // BLOCK_SIZE_K
     real_topk = tl.minimum(max_topk, num_blocks)
+    if ALIGNED_TOPK:
+        real_topk = max_topk
+    elif HAS_TOPK_VALID_COUNTS:
+        real_topk = tl.minimum(
+            real_topk,
+            tl.load(topk_valid_counts + pid_kh * stride_tvc_h + pid_b * stride_tvc_n),
+        )
     chunk_end_topk = tl.minimum(chunk_end_compiletime, real_topk)
 
     off_n = tl.arange(0, BLOCK_SIZE_K)
@@ -324,12 +342,15 @@ def _gqa_sparse_decode_kernel(
 
     cur_idx_ptr = idx_base + chunk_start_topk * stride_tk
     for _ in tl.range(chunk_start_topk, chunk_end_topk):
-        blk = tl.load(cur_idx_ptr).to(tl.int32)
+        raw_blk = tl.load(cur_idx_ptr).to(tl.int32)
+        valid_blk = raw_blk >= 0
+        blk = tl.maximum(raw_blk, 0)
         cur_idx_ptr = cur_idx_ptr + stride_tk
         c = blk * BLOCK_SIZE_K
         page = tl.load(bt_row + blk).to(tl.int64)
         pos = c + off_n
-        pos_mask = pos < kv_len
+        pos_mask = valid_blk & (pos < kv_len)
+        update_state = valid_blk & (c < kv_len)
         k = tl.load(
             kv_cache_ptr
             + page * stride_kv_blk
@@ -355,10 +376,15 @@ def _gqa_sparse_decode_kernel(
         qk = tl.zeros((BLOCK_SIZE_H, BLOCK_SIZE_K), dtype=tl.float32)
         qk += tl.where(pos_mask[None, :], 0, float("-inf"))
         qk += tl.dot(q, k) * sm_scale_log2e
-        m_ij = tl.maximum(m_i, tl.max(qk, axis=1))
-        p = tl.exp2(qk - m_ij[:, None])
+        m_ij = tl.where(
+            update_state,
+            tl.maximum(m_i, tl.max(qk, axis=1)),
+            m_i,
+        )
+        p = tl.where(update_state, tl.exp2(qk - m_ij[:, None]), 0.0)
         l_ij = tl.sum(p, axis=1)
-        acc_o = acc_o * tl.exp2(m_i - m_ij)[:, None]
+        rescale = tl.where(update_state, tl.exp2(m_i - m_ij), 1.0)
+        acc_o = acc_o * rescale[:, None]
         v = tl.load(
             kv_cache_ptr
             + page * stride_kv_blk
@@ -383,13 +409,13 @@ def _gqa_sparse_decode_kernel(
                 v = (v * v_scale[:, None]).to(q.dtype)
         acc_o += tl.dot(p.to(v.dtype), v)
         m_i = m_ij
-        lse_i = m_ij + tl.log2(tl.exp2(lse_i - m_ij) + l_ij)
+        next_lse = m_ij + tl.log2(tl.exp2(lse_i - m_ij) + l_ij)
+        lse_i = tl.where(update_state, next_lse, lse_i)
 
     if USE_PDL:
         tl.extra.cuda.gdc_launch_dependents()
 
-    # Empty chunks for active rows must store zero output; otherwise the merge
-    # can hit 0 * NaN. All-empty padded rows may still produce NaNs in merge.
+    # Empty chunks store the neutral state: zero output and -inf LSE.
     scale = tl.where(lse_i > float("-inf"), tl.exp2(m_i - lse_i), tl.zeros_like(lse_i))
     acc_o = acc_o * scale[:, None]
     o_ptrs = tl.make_block_ptr(
@@ -420,6 +446,7 @@ def _merge_topk_attn_out_kernel(
     o_ptr,  # partials: [NUM_TOPK_CHUNKS, total_q, num_heads, head_dim]
     lse_ptr,  # partials (log2): [NUM_TOPK_CHUNKS, total_q, num_heads]
     out_ptr,  # merged out: [total_q, num_heads, head_dim]
+    merged_lse_ptr,  # optional merged lse (log2): [total_q, num_heads]
     head_dim,
     stride_o_c,
     stride_o_b,
@@ -431,8 +458,11 @@ def _merge_topk_attn_out_kernel(
     stride_out_n,
     stride_out_h,
     stride_out_d,
+    stride_ml_n,
+    stride_ml_h,
     NUM_TOPK_CHUNKS: tl.constexpr,
     BLOCK_SIZE_D: tl.constexpr,
+    RETURN_LSE: tl.constexpr,
     USE_PDL: tl.constexpr,
 ):
     pid_b, pid_h = tl.program_id(0), tl.program_id(1)
@@ -456,13 +486,21 @@ def _merge_topk_attn_out_kernel(
     o = tl.load(o_ptrs, boundary_check=(0, 1), padding_option="zero")
     lse = tl.load(lse_ptrs)  # empty chunks contribute -inf -> weight 0
     lse_max = tl.max(lse, axis=0)
-    weights = tl.exp2(lse - lse_max)
-    weights = weights / tl.sum(weights, axis=0)
+    has_values = lse_max > float("-inf")
+    weights = tl.where(has_values, tl.exp2(lse - lse_max), 0.0)
+    weights_sum = tl.sum(weights, axis=0)
+    weights = tl.where(has_values, weights / weights_sum, 0.0)
     o_merged = tl.sum(o * weights[:, None], axis=0)
     out_ptrs = (
         out_ptr + pid_b * stride_out_n + pid_h * stride_out_h + off_d * stride_out_d
     )
     tl.store(out_ptrs, o_merged.to(out_ptr.dtype.element_ty), mask=off_d < head_dim)
+    if RETURN_LSE:
+        merged_lse = tl.where(has_values, lse_max + tl.log2(weights_sum), float("-inf"))
+        tl.store(
+            merged_lse_ptr + pid_b * stride_ml_n + pid_h * stride_ml_h,
+            merged_lse,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -610,10 +648,21 @@ def minimax_m3_sparse_attn_decode(
     decode_query_len: int,
     k_scale: torch.Tensor | None = None,
     v_scale: torch.Tensor | None = None,
-) -> None:
+    kv_lens: torch.Tensor | None = None,
+    topk_valid_counts: torch.Tensor | None = None,
+    return_lse: bool = False,
+    return_partials: bool = False,
+    aligned_topk: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor] | None:
     """GQA block-sparse attention for decode (split-K over the top-k blocks)."""
     total_q, num_heads, head_dim = q.shape
     assert total_q == seq_lens.shape[0] * decode_query_len
+    if kv_lens is not None:
+        assert kv_lens.shape == (total_q,)
+        assert kv_lens.dtype == torch.int32
+    if topk_valid_counts is not None:
+        assert topk_valid_counts.shape == (num_kv_heads, total_q)
+        assert topk_valid_counts.dtype == torch.int32
     max_topk = topk_idx.shape[-1]
     gqa_group_size = num_heads // num_kv_heads
     use_fp8 = kv_cache.dtype in _FP8_DTYPES
@@ -649,10 +698,19 @@ def minimax_m3_sparse_attn_decode(
     target = max(1, min(max_topk, TARGET_GRID // max(1, total_q * num_kv_heads)))
     num_topk_chunks = 1 << (target.bit_length() - 1)
     o_partial = torch.empty(
-        num_topk_chunks, total_q, num_heads, head_dim, dtype=q.dtype, device=q.device
+        num_topk_chunks,
+        total_q,
+        num_heads,
+        head_dim,
+        dtype=output.dtype,
+        device=q.device,
     )
     lse_partial = torch.empty(
         num_topk_chunks, total_q, num_heads, dtype=torch.float32, device=q.device
+    )
+    kv_lens_arg = kv_lens if kv_lens is not None else seq_lens
+    topk_valid_counts_arg = (
+        topk_valid_counts if topk_valid_counts is not None else topk_idx
     )
     grid = (total_q * num_topk_chunks, num_kv_heads)
     _gqa_sparse_decode_kernel[grid](
@@ -661,10 +719,12 @@ def minimax_m3_sparse_attn_decode(
         k_scale_arg,
         v_scale_arg,
         topk_idx,
+        topk_valid_counts_arg,
         o_partial,
         lse_partial,
         block_table,
         seq_lens,
+        kv_lens_arg,
         total_q,
         gqa_group_size,
         head_dim,
@@ -685,6 +745,8 @@ def minimax_m3_sparse_attn_decode(
         topk_idx.stride(0),
         topk_idx.stride(1),
         topk_idx.stride(2),
+        topk_valid_counts_arg.stride(0),
+        topk_valid_counts_arg.stride(1),
         o_partial.stride(0),
         o_partial.stride(1),
         o_partial.stride(2),
@@ -697,14 +759,46 @@ def minimax_m3_sparse_attn_decode(
         NUM_TOPK_CHUNKS=num_topk_chunks,
         USE_FP8=use_fp8,
         KV_SCALE_MODE=kv_scale_mode,
+        HAS_KV_LENS=kv_lens is not None,
+        HAS_TOPK_VALID_COUNTS=topk_valid_counts is not None,
+        ALIGNED_TOPK=aligned_topk,
         USE_PDL=use_pdl,
         **pdl_launch,
+    )
+    if return_partials:
+        return o_partial, lse_partial
+    return minimax_m3_merge_sparse_partials(
+        o_partial,
+        lse_partial,
+        output,
+        return_lse=return_lse,
+    )
+
+
+@torch.no_grad()
+def minimax_m3_merge_sparse_partials(
+    o_partial: torch.Tensor,
+    lse_partial: torch.Tensor,
+    output: torch.Tensor,
+    *,
+    return_lse: bool = False,
+) -> torch.Tensor | None:
+    num_topk_chunks, total_q, num_heads, head_dim = o_partial.shape
+    assert lse_partial.shape == (num_topk_chunks, total_q, num_heads)
+    assert output.shape == (total_q, num_heads, head_dim)
+    use_pdl = current_platform.is_arch_support_pdl()
+    pdl_launch = {"launch_pdl": True} if use_pdl else {}
+    merged_lse = (
+        torch.empty((total_q, num_heads), dtype=torch.float32, device=output.device)
+        if return_lse
+        else output
     )
     merge_grid = (total_q, num_heads)
     _merge_topk_attn_out_kernel[merge_grid](
         o_partial,
         lse_partial,
         output,
+        merged_lse,
         head_dim,
         o_partial.stride(0),
         o_partial.stride(1),
@@ -716,7 +810,11 @@ def minimax_m3_sparse_attn_decode(
         output.stride(0),
         output.stride(1),
         output.stride(2),
+        merged_lse.stride(0),
+        merged_lse.stride(1),
         NUM_TOPK_CHUNKS=num_topk_chunks,
+        RETURN_LSE=return_lse,
         USE_PDL=use_pdl,
         **pdl_launch,
     )
+    return merged_lse if return_lse else None

--- a/vllm/models/minimax_m3/common/sparse_attention.py
+++ b/vllm/models/minimax_m3/common/sparse_attention.py
@@ -21,8 +21,9 @@ from typing import ClassVar
 import torch
 
 from vllm._aiter_ops import rocm_aiter_ops
-from vllm.config import VllmConfig
+from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.config.cache import CacheDType
+from vllm.distributed import get_dcp_group
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.models.minimax_m3.common.ops.sparse_attn import SPARSE_BLOCK_SIZE
@@ -37,6 +38,7 @@ if current_platform.is_rocm():
     )
 else:
     from vllm.models.minimax_m3.common.ops.sparse_attn import (
+        minimax_m3_merge_sparse_partials,
         minimax_m3_sparse_attn,
         minimax_m3_sparse_attn_decode,
     )
@@ -51,9 +53,12 @@ from vllm.v1.attention.backend import (
     MultipleOf,
 )
 from vllm.v1.attention.backends.utils import (
+    get_cp_local_seq_lens,
     get_kv_cache_layout,
     split_decodes_and_prefills,
 )
+from vllm.v1.attention.ops.common import cp_lse_ag_out_rs
+from vllm.v1.attention.ops.dcp_alltoall import dcp_a2a_lse_reduce
 from vllm.v1.kv_cache_interface import AttentionSpec, is_quantized_kv_cache
 
 logger = init_logger(__name__)
@@ -177,6 +182,7 @@ class MiniMaxM3SparseDecodeMetadata:
     seq_lens: torch.Tensor  # [num_decodes] int32
     block_table: torch.Tensor
     decode_query_len: int
+    local_kv_lens: torch.Tensor | None = None  # [num_decode_tokens] int32
 
 
 @dataclass
@@ -215,13 +221,34 @@ class MiniMaxM3SparseMetadataBuilder(AttentionMetadataBuilder[MiniMaxM3SparseMet
         device: torch.device,
     ) -> None:
         super().__init__(kv_cache_spec, layer_names, vllm_config, device)
-        self._init_reorder_batch_threshold(1, supports_spec_as_decode=True)
+        self._init_reorder_batch_threshold(
+            1,
+            supports_spec_as_decode=True,
+            supports_dcp_with_varlen=True,
+        )
+        parallel_config = vllm_config.parallel_config
+        self.dcp_world_size = parallel_config.decode_context_parallel_size
+        self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
+        self.cp_kv_cache_interleave_size = parallel_config.cp_kv_cache_interleave_size
+        if self.dcp_world_size > 1:
+            if not current_platform.is_cuda():
+                raise NotImplementedError(
+                    "MiniMax M3 sparse-attention DCP currently supports CUDA only."
+                )
+            if self.cp_kv_cache_interleave_size != SPARSE_BLOCK_SIZE:
+                raise NotImplementedError(
+                    "MiniMax M3 sparse-attention DCP requires block-level KV "
+                    f"interleave ({SPARSE_BLOCK_SIZE}), got "
+                    f"{self.cp_kv_cache_interleave_size}."
+                )
         # Stable context-length buffer for decode cudagraph replays.
         self.context_len_buffer = torch.empty(
             vllm_config.scheduler_config.max_num_batched_tokens,
             dtype=torch.int32,
             device=device,
         )
+        self.global_decode_kv_lens_buffer = torch.empty_like(self.context_len_buffer)
+        self.local_decode_kv_lens_buffer = torch.empty_like(self.context_len_buffer)
 
     def build(
         self,
@@ -290,10 +317,38 @@ class MiniMaxM3SparseMetadataBuilder(AttentionMetadataBuilder[MiniMaxM3SparseMet
                 (query_lens_cpu == decode_query_len) | (query_lens_cpu == 0)
             )
             assert num_decode_tokens == num_decodes * decode_query_len
+            local_kv_lens: torch.Tensor | None = None
+            if self.dcp_world_size > 1:
+                q_offsets = torch.arange(
+                    1,
+                    decode_query_len + 1,
+                    dtype=torch.int32,
+                    device=seq_lens.device,
+                )
+                global_kv_lens = self.global_decode_kv_lens_buffer[:num_decode_tokens]
+                global_kv_lens.copy_(
+                    (
+                        seq_lens[:num_decodes, None]
+                        - decode_query_len
+                        + q_offsets[None, :]
+                    )
+                    .clamp_min(0)
+                    .flatten()
+                )
+                local_kv_lens = self.local_decode_kv_lens_buffer[:num_decode_tokens]
+                local_kv_lens.copy_(
+                    get_cp_local_seq_lens(
+                        global_kv_lens,
+                        self.dcp_world_size,
+                        self.dcp_rank,
+                        self.cp_kv_cache_interleave_size,
+                    )
+                )
             decode_metadata = MiniMaxM3SparseDecodeMetadata(
                 seq_lens=seq_lens[:num_decodes],
                 block_table=block_table[:num_decodes],
                 decode_query_len=decode_query_len,
+                local_kv_lens=local_kv_lens,
             )
 
         return MiniMaxM3SparseMetadata(
@@ -368,6 +423,43 @@ class MiniMaxM3SparseImpl(AttentionImplBase[MiniMaxM3SparseMetadata]):
 class MiniMaxM3SparseTritonImpl(MiniMaxM3SparseImpl):
     """Triton block-sparse attend (``minimax_m3_sparse_attn``) + Triton decode."""
 
+    can_return_lse_for_decode: bool = True
+    lse_base_on_e: bool = False
+    supports_mtp_with_cp_non_trivial_interleave_size: bool = True
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        vllm_config = get_current_vllm_config()
+        parallel_config = vllm_config.parallel_config
+        if (
+            self.dcp_world_size > 1
+            and parallel_config.cp_kv_cache_interleave_size != self.block_size
+        ):
+            raise NotImplementedError(
+                "MiniMax M3 Triton sparse-attention DCP requires block-level "
+                f"KV interleave ({self.block_size}), got "
+                f"{parallel_config.cp_kv_cache_interleave_size}."
+            )
+        self.dcp_combine = (
+            dcp_a2a_lse_reduce
+            if parallel_config.dcp_comm_backend == "a2a"
+            else cp_lse_ag_out_rs
+        )
+        speculative_config = vllm_config.speculative_config
+        target_parity_enabled = bool(
+            speculative_config is not None
+            and getattr(
+                speculative_config,
+                "enable_eagle3_target_dense_full_temporal_kv",
+                False,
+            )
+        )
+        self.dcp_bf16_partials = (
+            self.dcp_world_size == 2
+            and target_parity_enabled
+            and current_platform.is_device_capability(90)
+        )
+
     def forward(
         self,
         layer: AttentionLayer,
@@ -406,22 +498,85 @@ class MiniMaxM3SparseTritonImpl(MiniMaxM3SparseImpl):
         if main_md.num_decodes > 0:
             d = main_md.decode
             assert d is not None
-            minimax_m3_sparse_attn_decode(
-                q[:nd],
-                kv_cache,
-                topk[:, :nd, :],
-                d.block_table,
-                d.seq_lens,
-                self.num_kv_heads,
-                self.scale,
-                out[:nd],
-                d.decode_query_len,
-                k_scale=k_scale,
-                v_scale=v_scale,
-            )
+            if self.dcp_world_size > 1:
+                assert d.local_kv_lens is not None
+                decode_q = get_dcp_group().all_gather(q[:nd].contiguous(), dim=1)
+                local_out = torch.empty(
+                    decode_q.shape,
+                    dtype=(
+                        out.dtype
+                        if getattr(self, "dcp_bf16_partials", False)
+                        else torch.float32
+                    ),
+                    device=decode_q.device,
+                )
+                local_topk = topk[:, :nd, :]
+                partials = minimax_m3_sparse_attn_decode(
+                    decode_q,
+                    kv_cache,
+                    local_topk,
+                    d.block_table,
+                    d.seq_lens,
+                    self.num_kv_heads,
+                    self.scale,
+                    local_out,
+                    d.decode_query_len,
+                    k_scale=k_scale,
+                    v_scale=v_scale,
+                    kv_lens=d.local_kv_lens,
+                    return_partials=True,
+                    aligned_topk=True,
+                )
+                assert isinstance(partials, tuple)
+                local_partials, local_lses = partials
+                num_chunks, total_q, total_heads, head_dim = local_partials.shape
+                combined = self.dcp_combine(
+                    local_partials.reshape(
+                        num_chunks * total_q,
+                        total_heads,
+                        head_dim,
+                    ),
+                    local_lses.reshape(num_chunks * total_q, total_heads),
+                    get_dcp_group(),
+                    return_lse=True,
+                    is_lse_base_on_e=False,
+                )
+                assert isinstance(combined, tuple)
+                combined_partials, combined_lses = combined
+                local_heads = combined_partials.shape[1]
+                minimax_m3_merge_sparse_partials(
+                    combined_partials.reshape(
+                        num_chunks,
+                        total_q,
+                        local_heads,
+                        head_dim,
+                    ),
+                    combined_lses.reshape(num_chunks, total_q, local_heads),
+                    out[:nd],
+                )
+            else:
+                local_topk = topk[:, :nd, :]
+                minimax_m3_sparse_attn_decode(
+                    q[:nd],
+                    kv_cache,
+                    local_topk,
+                    d.block_table,
+                    d.seq_lens,
+                    self.num_kv_heads,
+                    self.scale,
+                    out[:nd],
+                    d.decode_query_len,
+                    k_scale=k_scale,
+                    v_scale=v_scale,
+                )
 
         # Prefill [nd:]: cu_seqlens_q already rebased to 0.
         if main_md.num_prefills > 0:
+            if self.dcp_world_size > 1:
+                raise NotImplementedError(
+                    "MiniMax M3 Triton DCP currently supports decode-only "
+                    "batches; sparse prefill DCP is not implemented."
+                )
             p = main_md.prefill
             assert p is not None
             minimax_m3_sparse_attn(
@@ -456,6 +611,22 @@ def select_main_impl_cls(
     back to Triton. The MSA modules are imported lazily avoid import errors
     on unsupported platforms.
     """
+    dcp_world_size = (
+        get_current_vllm_config().parallel_config.decode_context_parallel_size
+    )
+    if dcp_world_size > 1:
+        if not current_platform.is_cuda():
+            raise NotImplementedError(
+                "MiniMax M3 sparse-attention DCP currently supports CUDA only."
+            )
+        logger.info_once(
+            "MiniMax M3 sparse attention selected Triton for DCP "
+            "(kv_cache_dtype=%s, topk_blocks=%s, dcp_world_size=%s)",
+            kv_cache_dtype,
+            topk_blocks,
+            dcp_world_size,
+        )
+        return MiniMaxM3SparseTritonImpl
     use_aiter_sparse_pa = minimax_m3_use_aiter_sparse_pa(num_kv_heads)
     use_msa = (
         current_platform.is_cuda()

--- a/vllm/models/minimax_m3/common/sparse_attention.py
+++ b/vllm/models/minimax_m3/common/sparse_attention.py
@@ -383,10 +383,14 @@ class MiniMaxM3SparseImpl(AttentionImplBase[MiniMaxM3SparseMetadata]):
         num_kv_heads: int | None = None,
         kv_cache_dtype: str = "auto",
         *,
+        num_query_heads: int | None = None,
         topk_blocks: int,
         sparse_block_size: int,
     ) -> None:
         self.num_heads = num_heads
+        self.num_query_heads = (
+            num_query_heads if num_query_heads is not None else num_heads
+        )
         self.head_size = head_size
         self.scale = scale
         self.num_kv_heads = num_kv_heads if num_kv_heads is not None else num_heads
@@ -486,7 +490,7 @@ class MiniMaxM3SparseTritonImpl(MiniMaxM3SparseImpl):
         )
         assert topk is not None
         hd = self.head_size
-        q = query[:num_tokens].view(-1, self.num_heads, hd)
+        q = query[:num_tokens].view(-1, self.num_query_heads, hd)
         out = output[:num_tokens].view(-1, self.num_heads, hd)
         kv_cache = (
             kv_cache.view(self.kv_cache_fp8_dtype) if self.use_fp8_kv else kv_cache
@@ -500,7 +504,11 @@ class MiniMaxM3SparseTritonImpl(MiniMaxM3SparseImpl):
             assert d is not None
             if self.dcp_world_size > 1:
                 assert d.local_kv_lens is not None
-                decode_q = get_dcp_group().all_gather(q[:nd].contiguous(), dim=1)
+                decode_q = (
+                    get_dcp_group().all_gather(q[:nd].contiguous(), dim=1)
+                    if self.num_query_heads == self.num_heads
+                    else q[:nd].contiguous()
+                )
                 local_out = torch.empty(
                     decode_q.shape,
                     dtype=(

--- a/vllm/models/minimax_m3/nvidia/model.py
+++ b/vllm/models/minimax_m3/nvidia/model.py
@@ -82,6 +82,7 @@ from vllm.models.minimax_m3.common.sparse_attention import (
 )
 from vllm.models.minimax_m3.common.vision_tower import MiniMaxVLVisionModel
 from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.utils.torch_utils import kv_cache_dtype_str_to_dtype
 from vllm.v1.kv_cache_interface import (
@@ -108,6 +109,32 @@ def _is_moe_layer(config: PretrainedConfig, layer_id: int) -> bool:
     if moe_layer_freq is None:
         return True
     return moe_layer_freq[layer_id] != 0
+
+
+def _use_dcp_replicated_q_proj(
+    vllm_config: VllmConfig,
+    *,
+    is_mtp_block: bool,
+) -> bool:
+    parallel_config = vllm_config.parallel_config
+    dcp_size = parallel_config.decode_context_parallel_size
+    if is_mtp_block or dcp_size == 1:
+        return False
+    if not current_platform.is_cuda():
+        raise NotImplementedError(
+            "MiniMax-M3 DCP replicated Q projection currently supports CUDA only."
+        )
+    if (
+        parallel_config.tensor_parallel_size != 8
+        or dcp_size != 2
+        or parallel_config.prefill_context_parallel_size != 1
+        or parallel_config.dcp_comm_backend != "a2a"
+    ):
+        raise NotImplementedError(
+            "MiniMax-M3 DCP replicated Q projection is currently restricted to "
+            "TP8/DCP2/PCP1 with dcp_comm_backend='a2a'."
+        )
+    return True
 
 
 class MiniMAXGemmaRMSNorm(nn.Module):
@@ -409,14 +436,23 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
         prefix: str = "",
         cache_config: CacheConfig | None = None,
         topk_indices_buffer: torch.Tensor | None = None,
+        dcp_q_replicate: bool = False,
     ) -> None:
         super().__init__()
         self.hidden_size = config.hidden_size
+        vllm_config = get_current_vllm_config()
+        parallel_config = vllm_config.parallel_config
         tp_size = get_tensor_model_parallel_world_size()
 
         self.total_num_heads = config.num_attention_heads
         assert self.total_num_heads % tp_size == 0
         self.num_heads = self.total_num_heads // tp_size
+        self.dcp_q_replicate = dcp_q_replicate
+        self.num_query_heads = (
+            self.num_heads * parallel_config.decode_context_parallel_size
+            if self.dcp_q_replicate
+            else self.num_heads
+        )
         self.total_num_kv_heads = config.num_key_value_heads
         if self.total_num_kv_heads >= tp_size:
             assert self.total_num_kv_heads % tp_size == 0
@@ -424,7 +460,8 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
             assert tp_size % self.total_num_kv_heads == 0
         self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
         self.head_dim = config.head_dim
-        self.q_size = self.num_heads * self.head_dim
+        self.q_size = self.num_query_heads * self.head_dim
+        self.out_size = self.num_heads * self.head_dim
         self.kv_size = self.num_kv_heads * self.head_dim
         self.scaling = self.head_dim**-0.5
 
@@ -448,6 +485,8 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
             bias=False,
             quant_config=quant_config,
             prefix=f"{prefix}.qkv_proj",
+            dcp_q_replicate=self.dcp_q_replicate,
+            dcp_world_size=parallel_config.decode_context_parallel_size,
         )
         # reduce_results=False: the attention all-reduce is fused with the
         # following post_attention_layernorm (GemmaRMSNorm) in the decoder layer
@@ -484,7 +523,6 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
         self.index_rotary_emb = self.rotary_emb
 
         # Attention-backend wiring.
-        vllm_config = get_current_vllm_config()
         self.layer_name = f"{prefix}.attn"
         self.kv_cache_dtype = (
             cache_config.cache_dtype if cache_config is not None else "auto"
@@ -519,6 +557,7 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
             self.scaling,
             self.num_kv_heads,
             kv_cache_dtype=self.kv_cache_dtype,
+            num_query_heads=self.num_query_heads,
             topk_blocks=sparse_cfg["sparse_topk_blocks"],
             sparse_block_size=sparse_cfg["sparse_block_size"],
         )
@@ -606,7 +645,7 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
             self.k_norm.weight,
             cos_sin_cache,
             positions,
-            self.num_heads,
+            self.num_query_heads,
             self.num_kv_heads,
             rotary_dim,
             eps,
@@ -623,7 +662,7 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
             self.kv_cache_dtype,
         )
 
-        output = torch.empty_like(q)
+        output = qkv.new_empty((num_tokens, self.out_size))
         attn_output = self._run_attention(q, index_q, output)
         output, _ = self.o_proj(attn_output)
         return output
@@ -675,6 +714,10 @@ class MiniMaxM3DecoderLayer(nn.Module):
         is_sparse_attention_layer = (
             force_sparse_attn or layer_id in _sparse_attention_layer_ids(config)
         )
+        dcp_q_replicate = is_sparse_attention_layer and _use_dcp_replicated_q_proj(
+            vllm_config,
+            is_mtp_block=is_mtp_block,
+        )
 
         if is_sparse_attention_layer:
             self.self_attn = MiniMaxM3SparseAttention(
@@ -684,6 +727,7 @@ class MiniMaxM3DecoderLayer(nn.Module):
                 prefix=f"{prefix}.self_attn",
                 cache_config=cache_config,
                 topk_indices_buffer=topk_indices_buffer,
+                dcp_q_replicate=dcp_q_replicate,
             )
         else:
             self.self_attn = MiniMaxM3Attention(

--- a/vllm/models/minimax_m3/nvidia/model.py
+++ b/vllm/models/minimax_m3/nvidia/model.py
@@ -65,7 +65,6 @@ from vllm.model_executor.models.utils import (
     WeightsMapper,
     init_vllm_registered_model,
     is_pp_missing_parameter,
-    make_empty_intermediate_tensors_factory,
     make_layers,
     maybe_prefix,
 )
@@ -765,6 +764,12 @@ class MiniMaxM3DecoderLayer(nn.Module):
             return self.block_sparse_moe.experts.moe_config.skip_final_all_reduce
         return not self.mlp.down_proj.reduce_results
 
+    def set_ffn_all_reduce_deferred(self, defer: bool) -> None:
+        if self.is_moe_layer:
+            self.block_sparse_moe.experts.moe_config.skip_final_all_reduce = defer
+        else:
+            self.mlp.down_proj.reduce_results = not defer
+
 
 class MiniMaxM3Model(nn.Module, EagleModelMixin):
     fall_back_to_pt_during_load = False
@@ -824,18 +829,73 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
             self.norm = MiniMAXGemmaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         else:
             self.norm = PPMissingLayer()
-        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
-            ["hidden_states", "residual"], config.hidden_size
+        local_layers = self.layers[self.start_layer : self.end_layer]
+        self._original_ffn_all_reduce_deferred = tuple(
+            layer.ffn_all_reduce_deferred for layer in local_layers
         )
+        self._configure_deferred_allreduce(())
 
-        # Configure cross-layer all-reduce/RMSNorm fusion: a layer whose FFN output
-        # is left un-reduced has that all-reduce fused into the next layer's
-        # input_layernorm (or the final norm).
+    def _configure_deferred_allreduce(
+        self,
+        materialized_boundaries: tuple[int, ...],
+    ) -> None:
+        local_layers = self.layers[self.start_layer : self.end_layer]
+        assert len(local_layers) == len(self._original_ffn_all_reduce_deferred)
+        materialized = set(materialized_boundaries)
+
         prev_defers = False
-        for idx, layer in enumerate(self.layers[self.start_layer : self.end_layer]):
+        for idx, (layer, originally_deferred) in enumerate(
+            zip(local_layers, self._original_ffn_all_reduce_deferred)
+        ):
+            layer.set_ffn_all_reduce_deferred(
+                originally_deferred and idx + 1 not in materialized
+            )
             layer.fuse_input_allreduce = idx > 0 and prev_defers
             prev_defers = layer.ffn_all_reduce_deferred
         self.fuse_final_norm_allreduce = prev_defers
+
+    def _set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+        num_hidden_layers = len(self.layers)
+        invalid = [idx for idx in layers if idx < 0 or idx > num_hidden_layers]
+        if invalid:
+            raise ValueError(
+                f"Invalid MiniMax-M3 EAGLE3 auxiliary boundaries: {invalid}."
+            )
+        if tuple(sorted(set(layers))) != layers:
+            raise ValueError(
+                "MiniMax-M3 EAGLE3 auxiliary boundaries must be unique and "
+                "strictly increasing."
+            )
+
+        EagleModelMixin._set_aux_hidden_state_layers(self, layers)
+        local_boundaries = tuple(
+            idx - self.start_layer
+            for idx in layers
+            if self.start_layer < idx <= self.end_layer
+        )
+        self._configure_deferred_allreduce(local_boundaries)
+
+    def make_empty_intermediate_tensors(
+        self,
+        batch_size: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> IntermediateTensors:
+        incoming_aux_keys = [
+            f"aux_hidden_state_{idx}"
+            for idx in self.aux_hidden_state_layers
+            if idx <= self.start_layer
+        ]
+        return IntermediateTensors(
+            {
+                key: torch.zeros(
+                    (batch_size, self.config.hidden_size),
+                    dtype=dtype,
+                    device=device,
+                )
+                for key in ["hidden_states", "residual", *incoming_aux_keys]
+            }
+        )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
@@ -858,18 +918,45 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
 
-        # EAGLE3 is not yet compatible with pipeline parallel
-        aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
+        if get_pp_group().is_first_rank:
+            aux_hidden_states = self._maybe_add_hidden_state(
+                [], 0, hidden_states, residual
+            )
+            if aux_hidden_states:
+                # The first layer aliases its input as the residual and may mutate it.
+                aux_hidden_states[-1] = aux_hidden_states[-1].clone()
+        else:
+            assert intermediate_tensors is not None
+            aux_hidden_states = [
+                intermediate_tensors[f"aux_hidden_state_{idx}"]
+                for idx in self.aux_hidden_state_layers
+                if idx <= self.start_layer
+            ]
         for idx, layer in enumerate(self.layers[self.start_layer : self.end_layer]):
             hidden_states, residual = layer(positions, hidden_states, residual)
             self._maybe_add_hidden_state(
-                aux_hidden_states, idx + 1, hidden_states, residual
+                aux_hidden_states,
+                self.start_layer + idx + 1,
+                hidden_states,
+                residual,
             )
 
         if not get_pp_group().is_last_rank:
-            return IntermediateTensors(
-                {"hidden_states": hidden_states, "residual": residual}
+            tensors = {"hidden_states": hidden_states, "residual": residual}
+            carried_layers = tuple(
+                idx for idx in self.aux_hidden_state_layers if idx <= self.end_layer
             )
+            if len(carried_layers) != len(aux_hidden_states):
+                raise RuntimeError(
+                    "MiniMax-M3 pipeline auxiliary hidden states are incomplete."
+                )
+            tensors.update(
+                {
+                    f"aux_hidden_state_{idx}": value
+                    for idx, value in zip(carried_layers, aux_hidden_states)
+                }
+            )
+            return IntermediateTensors(tensors)
 
         if self.fuse_final_norm_allreduce:
             hidden_states, _ = fused_allreduce_gemma_rms_norm(
@@ -879,6 +966,10 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
             hidden_states, _ = self.norm(hidden_states, residual)
 
         if len(aux_hidden_states) > 0:
+            if len(aux_hidden_states) != len(self.aux_hidden_state_layers):
+                raise RuntimeError(
+                    "MiniMax-M3 pipeline auxiliary hidden states are incomplete."
+                )
             return hidden_states, aux_hidden_states
         return hidden_states
 

--- a/vllm/transformers_utils/configs/minimax_m3.py
+++ b/vllm/transformers_utils/configs/minimax_m3.py
@@ -13,6 +13,7 @@ class MiniMaxM3TextConfig(PretrainedConfig):
 
     model_type = "minimax_m3_text"
     architectures = ["MiniMaxM3SparseForCausalLM"]
+    supports_pp_aux_hidden_state_transport = True
 
     def __init__(
         self,

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -9,6 +9,7 @@ from typing import ClassVar
 import numpy as np
 import torch
 
+from vllm import _custom_ops as ops
 from vllm.model_executor.layers.attention import Attention
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import (
@@ -57,7 +58,7 @@ from vllm.v1.attention.backend import (
     CommonAttentionMetadata,
 )
 from vllm.v1.attention.backends.utils import get_kv_cache_layout
-from vllm.v1.kv_cache_interface import AttentionSpec
+from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheTemporalLayout
 from vllm.v1.worker.cp_utils import (
     run_split_fa2_dcp_context_attention,
     should_skip_dcp_context_attention,
@@ -385,6 +386,9 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
             self.dcp_rank = get_dcp_group().rank_in_group
         except AssertionError:
             # DCP might not be initialized in testing
+            self.dcp_world_size = 1
+            self.dcp_rank = 0
+        if kv_cache_spec.temporal_layout == KVCacheTemporalLayout.FULL_TEMPORAL:
             self.dcp_world_size = 1
             self.dcp_rank = 0
 
@@ -731,6 +735,7 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
 
 class FlashAttentionImpl(AttentionImpl):
     can_return_lse_for_decode: bool = True
+    supports_mtp_with_cp_non_trivial_interleave_size: bool = True
 
     def __init__(
         self,
@@ -918,10 +923,19 @@ class FlashAttentionImpl(AttentionImpl):
             v_descale = layer._v_scale.expand(descale_shape)
 
             if self.dcp_world_size > 1:
+                dcp_query = query[:num_actual_tokens]
+                dcp_key = key[:num_actual_tokens]
+                dcp_value = value[:num_actual_tokens]
+                if (
+                    self.kv_cache_dtype in ("fp8", "fp8_e4m3")
+                    and dcp_query.dtype == current_platform.fp8_dtype()
+                ):
+                    dcp_key = self._quantize_dcp_live_kv(dcp_key, layer._k_scale)
+                    dcp_value = self._quantize_dcp_live_kv(dcp_value, layer._v_scale)
                 self._forward_with_dcp(
-                    query[:num_actual_tokens],
-                    key[:num_actual_tokens],
-                    value[:num_actual_tokens],
+                    dcp_query,
+                    dcp_key,
+                    dcp_value,
                     key_cache,
                     value_cache,
                     output[:num_actual_tokens],
@@ -1067,6 +1081,25 @@ class FlashAttentionImpl(AttentionImpl):
             s_aux=self.sinks,
         )
         return output
+
+    def _quantize_dcp_live_kv(
+        self,
+        tensor: torch.Tensor,
+        scale: torch.Tensor,
+    ) -> torch.Tensor:
+        """Match live K/V to the FP8 query dtype used by FA3 DCP."""
+        if tensor.dtype == current_platform.fp8_dtype():
+            return tensor
+        assert tensor.ndim == 3
+        original_shape = tensor.shape
+        flat = tensor.view(original_shape[0], -1)
+        group_shape = (-1, original_shape[-1]) if scale.numel() > 1 else None
+        quantized, _ = ops.scaled_fp8_quant(
+            flat,
+            scale,
+            group_shape=group_shape,
+        )
+        return quantized.view(original_shape)
 
     def do_kv_cache_update(
         self,

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -25,6 +25,9 @@ if TYPE_CHECKING:
     from vllm.v1.worker.gpu_input_batch import InputBatch
 
 import vllm.envs as envs
+from vllm.distributed.cp_mapping import (
+    get_cp_local_seq_lens as get_canonical_cp_local_seq_lens,
+)
 from vllm.distributed.kv_transfer.kv_connector.utils import (
     get_kv_connector_cache_layout,
 )
@@ -897,37 +900,12 @@ def get_cp_local_seq_lens(
     context-parallel shards and ``cp_rank`` selects one shard. When ``cp_rank``
     is ``None``, the returned tensor contains every rank's local length.
     """
-    seq_lens_i32 = seq_lens.to(torch.int32)
-    if cp_rank is None:
-        rank_offsets = torch.arange(
-            cp_world_size,
-            dtype=torch.int32,
-            device=seq_lens.device,
-        ).view(
-            *((1,) * seq_lens_i32.dim()),
-            cp_world_size,
-        )
-        seq_lens_tiled = seq_lens_i32.unsqueeze(-1)
-    else:
-        rank_offsets = torch.tensor(
-            cp_rank,
-            dtype=torch.int32,
-            device=seq_lens.device,
-        )
-        seq_lens_tiled = seq_lens_i32
-    base = (
-        seq_lens_tiled
-        // cp_kv_cache_interleave_size
-        // cp_world_size
-        * cp_kv_cache_interleave_size
+    return get_canonical_cp_local_seq_lens(
+        seq_lens,
+        cp_world_size=cp_world_size,
+        cp_rank=cp_rank,
+        interleave_size=cp_kv_cache_interleave_size,
     )
-    remainder = seq_lens_tiled - base * cp_world_size
-    remainder = torch.clip(
-        remainder - rank_offsets * cp_kv_cache_interleave_size,
-        0,
-        cp_kv_cache_interleave_size,
-    )
-    return base + remainder
 
 
 def get_dcp_local_seq_lens(

--- a/vllm/v1/attention/ops/common.py
+++ b/vllm/v1/attention/ops/common.py
@@ -15,6 +15,9 @@ def _correct_attn_cp_out_kernel(
     outputs_stride_B,
     outputs_stride_H,
     outputs_stride_D,
+    new_output_stride_B,
+    new_output_stride_H,
+    new_output_stride_D,
     lses_stride_N,
     lses_stride_B,
     lses_stride_H,
@@ -75,6 +78,11 @@ def _correct_attn_cp_out_kernel(
         + head_idx * outputs_stride_H
         + d_offsets * outputs_stride_D
     )
+    new_output_offsets = (
+        batch_idx * new_output_stride_B
+        + head_idx * new_output_stride_H
+        + d_offsets * new_output_stride_D
+    )
 
     # correct output
     lse_offset = (
@@ -92,7 +100,7 @@ def _correct_attn_cp_out_kernel(
     output = output * factor
     output = tl.where(factor == 0.0, 0.0, output)
 
-    tl.store(new_output_ptr + output_offsets, output)
+    tl.store(new_output_ptr + new_output_offsets, output)
 
 
 class CPTritonContext:
@@ -100,10 +108,19 @@ class CPTritonContext:
 
     def __init__(self):
         self.inner_kernel = None
+        self.specialization_key = None
 
-    def call_kernel(self, kernel, grid, *regular_args, **const_args):
-        if self.inner_kernel is None:
+    def call_kernel(
+        self,
+        kernel,
+        grid,
+        *regular_args,
+        specialization_key=None,
+        **const_args,
+    ):
+        if self.inner_kernel is None or self.specialization_key != specialization_key:
             self.inner_kernel = kernel[grid](*regular_args, **const_args)
+            self.specialization_key = specialization_key
         else:
             self.inner_kernel[grid](*regular_args)
 
@@ -114,6 +131,7 @@ def correct_attn_out(
     cp_rank: int,
     ctx: CPTritonContext,
     is_lse_base_on_e: bool = True,
+    corrected_out: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Correct the attention output using the all-gathered lses.
 
@@ -133,6 +151,9 @@ def correct_attn_out(
     if out.ndim == 4 and out.shape[1] == 1:
         out = out.squeeze(1)
     assert out.ndim == 3, f"expected out [B,H,D] or [B,1,H,D], got {tuple(out.shape)}"
+    if corrected_out is not None and corrected_out.ndim == 4:
+        assert corrected_out.shape[1] == 1
+        corrected_out = corrected_out.squeeze(1)
 
     if lses.ndim == 4 and lses.shape[-1] == 1:
         lses = lses.squeeze(-1)
@@ -145,11 +166,16 @@ def correct_attn_out(
 
     B, H, D = out.shape
     N = lses.shape[0]
+    if corrected_out is None:
+        corrected_out = out
+    assert corrected_out.shape == out.shape
+    assert corrected_out.device == out.device
 
     # Strides after we normalized shapes to 3-D views.  The kernel computes
     # offsets for `vlse_ptr` using lses_stride_B/H, so the output buffer must
     # have the same B/H stride layout as a slice of `lses`.
     o_sB, o_sH, o_sD = out.stride()
+    n_sB, n_sH, n_sD = corrected_out.stride()
     l_sN, l_sB, l_sH = lses.stride()
 
     # Allocate LSE with the same B/H strides as `lses` so writes land correctly
@@ -163,20 +189,37 @@ def correct_attn_out(
 
     regular_args = (
         out,
-        out,
+        corrected_out,
         lses,
         lse,
         o_sB,
         o_sH,
         o_sD,
+        n_sB,
+        n_sH,
+        n_sD,
         l_sN,
         l_sB,
         l_sH,
         cp_rank,
     )
     const_args = {"HEAD_DIM": D, "N_ROUNDED": N, "IS_BASE_E": is_lse_base_on_e}
-    ctx.call_kernel(_correct_attn_cp_out_kernel, grid, *regular_args, **const_args)
-    return out, lse
+    specialization_key = (
+        out.dtype,
+        corrected_out.dtype,
+        lses.dtype,
+        D,
+        N,
+        is_lse_base_on_e,
+    )
+    ctx.call_kernel(
+        _correct_attn_cp_out_kernel,
+        grid,
+        *regular_args,
+        specialization_key=specialization_key,
+        **const_args,
+    )
+    return corrected_out, lse
 
 
 def _cp_lse_common(
@@ -185,6 +228,7 @@ def _cp_lse_common(
     cp_group: GroupCoordinator,
     ctx: CPTritonContext | None = None,
     is_lse_base_on_e=True,
+    corrected_out: torch.Tensor | None = None,
 ):
     """
     cp_attn_out: [ B, H, D ]
@@ -206,6 +250,7 @@ def _cp_lse_common(
         cp_group.rank_in_group,
         ctx,
         is_lse_base_on_e=is_lse_base_on_e,
+        corrected_out=corrected_out,
     )
     return out, lse
 
@@ -217,13 +262,19 @@ def cp_lse_ag_out_rs(
     ctx: CPTritonContext | None = None,
     return_lse: bool = False,
     is_lse_base_on_e=True,
+    corrected_out: torch.Tensor | None = None,
 ):
     """
     cp_attn_out: [ B, H, D ]
     cp_attn_lse: [ B, H ]
     """
     out, lse = _cp_lse_common(
-        cp_attn_out, cp_attn_lse, cp_group, ctx=ctx, is_lse_base_on_e=is_lse_base_on_e
+        cp_attn_out,
+        cp_attn_lse,
+        cp_group,
+        ctx=ctx,
+        is_lse_base_on_e=is_lse_base_on_e,
+        corrected_out=corrected_out,
     )
     out = cp_group.reduce_scatter(out, dim=1)
 

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -291,6 +291,7 @@ class KVCacheManager:
         delay_cache_blocks: bool = False,
         num_encoder_tokens: int = 0,
         full_sequence_must_fit: bool = False,
+        full_sequence_num_tokens: int | None = None,
         reserved_blocks: int = 0,
         has_scheduled_reqs: bool = True,
     ) -> KVCacheBlocks | None:
@@ -318,6 +319,8 @@ class KVCacheManager:
                 free blocks to hold the full sequence, accounting for prefix cache hits
                 and sliding window. Used as an admission gate to prevent over-admitting
                 requests when chunked prefill would otherwise only check the first chunk
+            full_sequence_num_tokens: Optional full-sequence token budget for the
+                admission check. Defaults to the request's current token count.
             reserved_blocks: Number of free blocks that must be left available for
                 other in-flight sequences to complete. The actual allocation is only
                 made if it fits within (free blocks - reserved_blocks). Used to gate
@@ -410,7 +413,10 @@ class KVCacheManager:
 
         if full_sequence_must_fit:
             # First check and fail if the full request sequence won't fit.
-            full_num_tokens = min(request.num_tokens, self.max_model_len)
+            full_num_tokens = min(
+                full_sequence_num_tokens or request.num_tokens,
+                self.max_model_len,
+            )
 
             num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(
                 request_id=request.request_id,
@@ -422,7 +428,9 @@ class KVCacheManager:
                 num_tokens_main_model=full_num_tokens,
                 apply_admission_cap=True,
             )
-            required_blocks = num_blocks_to_allocate + watermark_blocks
+            required_blocks = (
+                num_blocks_to_allocate + watermark_blocks + reserved_blocks
+            )
             if required_blocks > self.block_pool.get_num_free_blocks():
                 return None
 

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -27,6 +27,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheSpec,
+    KVCacheTemporalLayout,
     KVCacheTensor,
     MambaSpec,
     MLAAttentionSpec,
@@ -36,6 +37,10 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 from vllm.v1.request import Request
+from vllm.v1.spec_decode.utils import (
+    get_eagle3_draft_attention_layer_name,
+    resolve_minimax_m3_dense_target_attention_layer_names,
+)
 from vllm.v1.utils import tensor_data
 
 # BlockHash represents the hash of a single KV-cache block used for
@@ -985,6 +990,19 @@ def _pool_bytes_per_block(
     `available_memory` into `num_blocks`. Used to compute the effective KV cache
     capacity once `num_gpu_blocks_override` is applied.
     """
+    full_temporal_layers = _get_eagle_full_temporal_layers(vllm_config, kv_cache_groups)
+    if full_temporal_layers:
+        uniform_spec = cast(
+            UniformTypeKVCacheSpecs,
+            kv_cache_groups[0].kv_cache_spec,
+        )
+        extra_full_temporal_bytes = sum(
+            (_get_temporal_page_factor(vllm_config, layer_spec) - 1)
+            * layer_spec.page_size_bytes
+            for layer_name, layer_spec in uniform_spec.kv_cache_specs.items()
+            if layer_name in full_temporal_layers
+        )
+        return uniform_spec.page_size_bytes + extra_full_temporal_bytes
     if len(kv_cache_groups) == 1 and isinstance(
         kv_cache_groups[0].kv_cache_spec, UniformTypeKVCacheSpecs
     ):
@@ -1314,6 +1332,100 @@ def _use_packed_kv_cache_config(
     return is_dsv4 or (enable_cross_layers and len(kv_cache_groups) > 1)
 
 
+def _get_eagle_full_temporal_layers(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> list[str]:
+    spec_config = getattr(vllm_config, "speculative_config", None)
+    decode_enabled = bool(
+        spec_config is not None
+        and getattr(
+            spec_config,
+            "enable_eagle3_replicated_draft_kv",
+            False,
+        )
+    )
+    prefill_enabled = bool(
+        spec_config is not None
+        and getattr(
+            spec_config,
+            "enable_eagle3_prefill_draft_kv",
+            False,
+        )
+    )
+    target_dense_enabled = bool(
+        spec_config is not None
+        and getattr(
+            spec_config,
+            "enable_eagle3_target_dense_full_temporal_kv",
+            False,
+        )
+    )
+    layer_specs = {
+        layer_name: (
+            group.kv_cache_spec.kv_cache_specs[layer_name]
+            if isinstance(group.kv_cache_spec, UniformTypeKVCacheSpecs)
+            else group.kv_cache_spec
+        )
+        for group in kv_cache_groups
+        for layer_name in group.layer_names
+    }
+    full_temporal_layers = [
+        layer_name
+        for layer_name, layer_spec in layer_specs.items()
+        if layer_spec.temporal_layout == KVCacheTemporalLayout.FULL_TEMPORAL
+    ]
+    expected_full_temporal_layers: set[str] = set()
+    if target_dense_enabled:
+        expected_full_temporal_layers.update(
+            resolve_minimax_m3_dense_target_attention_layer_names(layer_specs)
+        )
+    draft_layer: str | None = None
+    if decode_enabled or prefill_enabled:
+        draft_layer = get_eagle3_draft_attention_layer_name(
+            vllm_config.model_config.get_total_num_hidden_layers()
+        )
+        if decode_enabled or draft_layer in layer_specs:
+            expected_full_temporal_layers.add(draft_layer)
+
+    if set(full_temporal_layers) != expected_full_temporal_layers:
+        raise ValueError(
+            "Unexpected FULL_TEMPORAL KV cache layers: "
+            f"expected {sorted(expected_full_temporal_layers)!r}, "
+            f"got {sorted(full_temporal_layers)!r}"
+        )
+
+    if not decode_enabled:
+        return []
+
+    if spec_config is None or spec_config.method != "eagle3":
+        raise ValueError("Replicated draft KV requires EAGLE3 speculative decoding")
+    if vllm_config.parallel_config.decode_context_parallel_size not in (1, 2):
+        raise ValueError(
+            "Replicated draft KV requires decode_context_parallel_size 1 or 2"
+        )
+    if len(kv_cache_groups) != 1 or not isinstance(
+        kv_cache_groups[0].kv_cache_spec, UniformTypeKVCacheSpecs
+    ):
+        raise ValueError(
+            "Replicated draft KV requires one UniformTypeKVCacheSpecs group"
+        )
+    if draft_layer is None or draft_layer not in full_temporal_layers:
+        raise ValueError(
+            f"Replicated draft KV requires a FULL_TEMPORAL layer named {draft_layer!r}"
+        )
+    return full_temporal_layers
+
+
+def _get_temporal_page_factor(
+    vllm_config: VllmConfig,
+    kv_cache_spec: KVCacheSpec,
+) -> int:
+    if kv_cache_spec.temporal_layout == KVCacheTemporalLayout.FULL_TEMPORAL:
+        return vllm_config.parallel_config.decode_context_parallel_size
+    return 1
+
+
 def _get_kv_cache_config_packed(
     vllm_config: VllmConfig,
     kv_cache_groups: list[KVCacheGroupSpec],
@@ -1377,8 +1489,47 @@ def get_kv_cache_config_from_groups(
             kv_cache_groups=kv_cache_groups,
         )
 
+    full_temporal_layers = _get_eagle_full_temporal_layers(vllm_config, kv_cache_groups)
+
     # Determine how model runners should initialize the KV cache tensors.
-    if len(kv_cache_groups) == 1 and isinstance(
+    if full_temporal_layers:
+        uniform_spec = cast(
+            UniformTypeKVCacheSpecs,
+            kv_cache_groups[0].kv_cache_spec,
+        )
+        per_layer_specs = uniform_spec.kv_cache_specs
+        dcp_world_size = vllm_config.parallel_config.decode_context_parallel_size
+        extra_full_temporal_bytes = sum(
+            (_get_temporal_page_factor(vllm_config, layer_spec) - 1)
+            * layer_spec.page_size_bytes
+            for layer_name, layer_spec in per_layer_specs.items()
+            if layer_name in full_temporal_layers
+        )
+        bytes_per_parent_block = (
+            uniform_spec.page_size_bytes + extra_full_temporal_bytes
+        )
+        num_blocks = available_memory // bytes_per_parent_block
+        num_blocks = may_override_num_blocks(vllm_config, num_blocks)
+        kv_cache_tensors = [
+            KVCacheTensor(
+                size=per_layer_specs[layer_name].page_size_bytes
+                * num_blocks
+                * _get_temporal_page_factor(
+                    vllm_config,
+                    per_layer_specs[layer_name],
+                ),
+                shared_by=[layer_name],
+            )
+            for layer_name in kv_cache_groups[0].layer_names
+        ]
+        logger.info_once(
+            "EAGLE full-temporal KV enabled for %s: %d parent blocks, "
+            "%dx physical pages",
+            tuple(full_temporal_layers),
+            num_blocks,
+            dcp_world_size,
+        )
+    elif len(kv_cache_groups) == 1 and isinstance(
         kv_cache_groups[0].kv_cache_spec, UniformTypeKVCacheSpecs
     ):
         # Special case: all layers have the same type of KV cache but with
@@ -1855,6 +2006,18 @@ def _max_memory_usage_bytes_from_groups(
     """
     if not kv_cache_groups:
         return 0
+
+    full_temporal_layers = _get_eagle_full_temporal_layers(vllm_config, kv_cache_groups)
+    if full_temporal_layers:
+        parent_block_size = (
+            kv_cache_groups[0].kv_cache_spec.block_size
+            * vllm_config.parallel_config.decode_context_parallel_size
+        )
+        num_parent_blocks = cdiv(
+            vllm_config.model_config.max_model_len,
+            parent_block_size,
+        )
+        return num_parent_blocks * _pool_bytes_per_block(vllm_config, kv_cache_groups)
 
     if len(kv_cache_groups) == 1 and isinstance(
         kv_cache_groups[0].kv_cache_spec, UniformTypeKVCacheSpecs

--- a/vllm/v1/core/sched/interface.py
+++ b/vllm/v1/core/sched/interface.py
@@ -240,6 +240,11 @@ class SchedulerInterface(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def validate_prefix_cache_reset(self, reset_running_requests: bool = False) -> None:
+        """Raise if the requested prefix-cache reset is unsupported."""
+        raise NotImplementedError
+
+    @abstractmethod
     def reset_encoder_cache(self) -> None:
         """Reset the encoder cache to invalidate all cached encoder outputs.
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -2634,6 +2634,7 @@ class Scheduler(SchedulerInterface):
         Otherwise, this method will only reset the KV prefix cache when there
         is no running requests taking KV cache.
         """
+        self.validate_prefix_cache_reset(reset_running_requests)
         if reset_running_requests:
             # For logging.
             timestamp = time.monotonic()
@@ -2673,6 +2674,17 @@ class Scheduler(SchedulerInterface):
             reset_successful = self.reset_connector_cache() and reset_successful
 
         return reset_successful
+
+    def validate_prefix_cache_reset(self, reset_running_requests: bool = False) -> None:
+        if (
+            reset_running_requests
+            and self._decode_only_dcp_no_preemption
+            and self.running
+        ):
+            raise RuntimeError(
+                "Cannot force-reset the prefix cache while strict DCP decode "
+                "requests are running. Abort or drain them first."
+            )
 
     def reset_connector_cache(self) -> bool:
         if self.connector is None:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -257,6 +257,7 @@ class Scheduler(SchedulerInterface):
         # Grammar compilation failures to finish as per-request errors in
         # update_from_output.
         self.grammar_compile_error_reqs: set[str] = set()
+        self.capacity_error_reqs: set[str] = set()
 
         # Encoder-related.
         # Calculate encoder cache size if applicable
@@ -288,6 +289,15 @@ class Scheduler(SchedulerInterface):
 
         speculative_config = vllm_config.speculative_config
         self.use_eagle = False
+        self._decode_only_dcp_no_preemption = bool(
+            speculative_config is not None
+            and getattr(
+                speculative_config,
+                "enable_eagle3_replicated_draft_kv",
+                False,
+            )
+            and self.dcp_world_size > 1
+        )
         self.num_spec_tokens = vllm_config.num_speculative_tokens
         self.num_lookahead_tokens = 0
         self._dynamic_sd: _DynamicSDSchedulerState | None = None
@@ -580,6 +590,15 @@ class Scheduler(SchedulerInterface):
         padded_num_new_tokens = self.num_sampled_tokens_per_step + candidate_padding_k
         return padded_num_new_tokens, candidate_padding_k
 
+    def _get_full_sequence_admission_tokens(self, request: Request) -> int | None:
+        if not self._decode_only_dcp_no_preemption:
+            return None
+        speculative_tail_slots = max(2 * self.num_lookahead_tokens - 1, 0)
+        return min(
+            request.num_prompt_tokens + request.max_tokens + speculative_tail_slots,
+            self.max_model_len,
+        )
+
     def _get_effective_max_num_scheduled_tokens(self, dynamic_sd_k: int | None) -> int:
         if dynamic_sd_k is None or self._dynamic_sd is None:
             return self.max_num_scheduled_tokens
@@ -770,6 +789,17 @@ class Scheduler(SchedulerInterface):
                         break
 
                     # The request cannot be scheduled.
+                    if self._decode_only_dcp_no_preemption:
+                        logger.error(
+                            "DCP no-preemption admission invariant failed for "
+                            "running request %s; terminating the request instead "
+                            "of recomputing its history",
+                            request.request_id,
+                        )
+                        self.capacity_error_reqs.add(request.request_id)
+                        req_index += 1
+                        break
+
                     # Preempt the lowest-priority request.
                     if self.policy == SchedulingPolicy.PRIORITY:
                         preempted_req = max(
@@ -896,6 +926,15 @@ class Scheduler(SchedulerInterface):
                     request_queue.pop_request()
                     step_skipped_waiting.prepend_request(request)
                     continue
+
+                if self._decode_only_dcp_request_exceeds_capacity(request):
+                    logger.error(
+                        "Request %s needs more KV blocks than the DCP "
+                        "no-preemption pool can provide",
+                        request_id,
+                    )
+                    self.capacity_error_reqs.add(request_id)
+                    break
 
                 # Check that adding the request still respects the max_loras
                 # constraint.
@@ -1135,13 +1174,18 @@ class Scheduler(SchedulerInterface):
                         for i in encoder_inputs_to_schedule
                     )
 
-                reserved_blocks = 0
-                if load_kv_async:
+                if self._decode_only_dcp_no_preemption:
+                    reserved_blocks = self._active_full_sequence_reserved_blocks(
+                        exclude=request
+                    )
+                elif load_kv_async:
                     # An async load holds its blocks for the whole transfer with
                     # no forward progress and isn't preemptible here. Admit it
                     # only if it fits in (free - other in-flight reservations), to
                     # avoid deadlock and predictable preemptions.
                     reserved_blocks = self._inflight_prefill_reserved_blocks()
+                else:
+                    reserved_blocks = 0
 
                 new_blocks = self.kv_cache_manager.allocate_slots(
                     request,
@@ -1152,7 +1196,13 @@ class Scheduler(SchedulerInterface):
                     num_external_computed_tokens=num_external_computed_tokens,
                     delay_cache_blocks=load_kv_async,
                     num_encoder_tokens=num_encoder_tokens,
-                    full_sequence_must_fit=self.scheduler_reserve_full_isl,
+                    full_sequence_must_fit=(
+                        self.scheduler_reserve_full_isl
+                        or self._decode_only_dcp_no_preemption
+                    ),
+                    full_sequence_num_tokens=self._get_full_sequence_admission_tokens(
+                        request
+                    ),
                     reserved_blocks=reserved_blocks,
                     has_scheduled_reqs=bool(self.running),
                 )
@@ -2080,6 +2130,10 @@ class Scheduler(SchedulerInterface):
 
         error_req_ids = set(self.grammar_compile_error_reqs)
         self.grammar_compile_error_reqs.clear()
+        capacity_error_reqs = getattr(self, "capacity_error_reqs", None)
+        if capacity_error_reqs:
+            error_req_ids.update(capacity_error_reqs)
+            capacity_error_reqs.clear()
         if failed_kv_load_req_ids and not self.recompute_kv_load_failures:
             error_req_ids.update(failed_kv_load_req_ids)
 
@@ -2768,7 +2822,9 @@ class Scheduler(SchedulerInterface):
 
     def _request_remaining_blocks(self, request: Request) -> int:
         """Blocks `request` still needs to allocate to hold its full sequence."""
-        full_num_tokens = min(request.num_tokens, self.max_model_len)
+        full_num_tokens = self._get_full_sequence_admission_tokens(request)
+        if full_num_tokens is None:
+            full_num_tokens = min(request.num_tokens, self.max_model_len)
         return self.kv_cache_manager.coordinator.get_num_blocks_to_allocate(
             request_id=request.request_id,
             num_tokens=full_num_tokens,
@@ -2786,6 +2842,28 @@ class Scheduler(SchedulerInterface):
         return sum(
             self._request_remaining_blocks(req) for req in self._inflight_prefills
         )
+
+    def _active_full_sequence_reserved_blocks(
+        self,
+        exclude: Request | None = None,
+    ) -> int:
+        """Blocks active requests still need through their output budget."""
+        active = set(self.running)
+        active.update(self._inflight_prefills)
+        if exclude is not None:
+            active.discard(exclude)
+        return sum(self._request_remaining_blocks(req) for req in active)
+
+    def _decode_only_dcp_request_exceeds_capacity(self, request: Request) -> bool:
+        if not self._decode_only_dcp_no_preemption:
+            return False
+        full_sequence_tokens = self._get_full_sequence_admission_tokens(request)
+        assert full_sequence_tokens is not None
+        required_parent_blocks = (
+            full_sequence_tokens + self.block_size - 1
+        ) // self.block_size
+        usable_parent_blocks = self.kv_cache_manager.block_pool.num_gpu_blocks - 1
+        return required_parent_blocks > usable_parent_blocks
 
     def _update_waiting_for_remote_kv(self, request: Request) -> None:
         """

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -840,6 +840,9 @@ class EngineCore:
         if mode == "wait":
             raise ValueError("'wait' mode can't be used in inproc-engine mode")
 
+        if mode == "keep" and clear_cache:
+            self.scheduler.validate_prefix_cache_reset(reset_running_requests=True)
+
         if mode == "abort":
             self.scheduler.finish_requests(None, RequestStatus.FINISHED_ABORTED)
 
@@ -1783,6 +1786,9 @@ class EngineCoreProc(EngineCore):
         """
         if mode not in ("keep", "abort", "wait"):
             raise ValueError(f"Invalid pause mode: {mode}")
+
+        if mode == "keep" and clear_cache:
+            self.scheduler.validate_prefix_cache_reset(reset_running_requests=True)
 
         def engine_idle_callback(engine: "EngineCoreProc", future: Future[Any]) -> None:
             if clear_cache:

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import copy
 from collections import Counter
-from dataclasses import dataclass, fields, replace
+from dataclasses import dataclass, field, fields, replace
 from enum import Enum, IntEnum
 from math import prod
 from typing import TYPE_CHECKING
@@ -96,6 +96,47 @@ class KVCacheSpecKind(str, Enum):
     UNKNOWN = "unknown"
 
 
+class KVCacheTemporalLayout(str, Enum):
+    """How one KV region is distributed over context-parallel ranks."""
+
+    SHARDED_DCP = "sharded_dcp"
+    FULL_TEMPORAL = "full_temporal"
+
+
+class KVCacheChildPageMapping(str, Enum):
+    """How scheduler parent pages map to one region's physical pages."""
+
+    IDENTITY = "identity"
+    GLOBAL_PAGE_MODULO = "global_page_modulo"
+
+
+@dataclass(frozen=True)
+class KVCacheRegionIdentity:
+    """Stable transfer identity for a layer and its temporal layout."""
+
+    layer_name: str
+    temporal_layout: KVCacheTemporalLayout
+    protocol_version: int
+    child_page_mapping: KVCacheChildPageMapping
+    child_page_factor: int
+
+    def __post_init__(self) -> None:
+        if self.protocol_version <= 0:
+            raise ValueError("protocol_version must be positive")
+        if self.child_page_factor <= 0:
+            raise ValueError("child_page_factor must be positive")
+
+    @property
+    def protocol_key(self) -> tuple[str, str, int, str, int]:
+        return (
+            self.layer_name,
+            self.temporal_layout.value,
+            self.protocol_version,
+            self.child_page_mapping.value,
+            self.child_page_factor,
+        )
+
+
 @dataclass(frozen=True)
 class KVCacheSpec:
     """
@@ -104,6 +145,10 @@ class KVCacheSpec:
 
     # number of tokens in a block
     block_size: int
+    temporal_layout: KVCacheTemporalLayout = field(
+        default=KVCacheTemporalLayout.SHARDED_DCP,
+        kw_only=True,
+    )
 
     @property
     def page_size_bytes(self) -> int:
@@ -297,6 +342,7 @@ class FullAttentionSpec(AttentionSpec):
         )
         merged_spec = cls(
             block_size=specs[0].block_size,
+            temporal_layout=specs[0].temporal_layout,
             num_kv_heads=specs[0].num_kv_heads,
             head_size=specs[0].head_size,
             head_size_v=specs[0].head_size_v,
@@ -424,18 +470,21 @@ class MLAAttentionSpec(FullAttentionSpec):
         compress_ratio_set = set(spec.compress_ratio for spec in specs)
         model_version_set = set(spec.model_version for spec in specs)
         block_stride_set = set(spec.indexes_kv_by_block_stride for spec in specs)
+        temporal_layout_set = set(spec.temporal_layout for spec in specs)
         assert (
             len(cache_dtype_str_set) == 1
             and len(compress_ratio_set) == 1
             and len(model_version_set) == 1
             and len(block_stride_set) == 1
+            and len(temporal_layout_set) == 1
         ), (
             "All attention layers in the same KV cache group must use the same "
-            "quantization method, compress ratio, model version, and KV block "
-            "stride indexing."
+            "quantization method, compress ratio, model version, KV block "
+            "stride indexing, and temporal layout."
         )
         return cls(
             block_size=specs[0].block_size,
+            temporal_layout=specs[0].temporal_layout,
             num_kv_heads=specs[0].num_kv_heads,
             head_size=specs[0].head_size,
             dtype=specs[0].dtype,
@@ -481,6 +530,7 @@ class RSWASpec(FullAttentionSpec):
         base = FullAttentionSpec.merge(specs)  # type: ignore[arg-type]
         return cls(
             block_size=base.block_size,
+            temporal_layout=base.temporal_layout,
             num_kv_heads=base.num_kv_heads,
             head_size=base.head_size,
             head_size_v=base.head_size_v,
@@ -652,19 +702,22 @@ class SlidingWindowMLASpec(SlidingWindowSpec):
         model_version_set = set(spec.model_version for spec in specs)
         sliding_window_set = set(spec.sliding_window for spec in specs)
         block_stride_set = set(spec.indexes_kv_by_block_stride for spec in specs)
+        temporal_layout_set = set(spec.temporal_layout for spec in specs)
         assert (
             len(cache_dtype_str_set) == 1
             and len(compress_ratio_set) == 1
             and len(model_version_set) == 1
             and len(sliding_window_set) == 1
             and len(block_stride_set) == 1
+            and len(temporal_layout_set) == 1
         ), (
             "All attention layers in the same KV cache group must use the same "
             "quantization method, compress ratio, model version, sliding "
-            "window size, and KV block stride indexing."
+            "window size, KV block stride indexing, and temporal layout."
         )
         return cls(
             block_size=specs[0].block_size,
+            temporal_layout=specs[0].temporal_layout,
             num_kv_heads=specs[0].num_kv_heads,
             head_size=specs[0].head_size,
             dtype=specs[0].dtype,
@@ -786,6 +839,7 @@ class SinkFullAttentionSpec(FullAttentionSpec):
         )
         merged_spec = cls(
             block_size=specs[0].block_size,
+            temporal_layout=specs[0].temporal_layout,
             num_kv_heads=specs[0].num_kv_heads,
             head_size=specs[0].head_size,
             head_size_v=specs[0].head_size_v,

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from vllm.v1.spec_decode.vocab_mapping import VocabMapping
 
 from vllm.distributed.eplb.eplb_state import EplbState
-from vllm.distributed.parallel_state import get_pp_group
+from vllm.distributed.parallel_state import get_dcp_group, get_pp_group
 from vllm.forward_context import set_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
@@ -39,7 +39,12 @@ from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.backends.triton_attn import TritonAttentionMetadata
 from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
-from vllm.v1.kv_cache_interface import KVCacheConfig, UniformTypeKVCacheSpecs
+from vllm.v1.kv_cache_interface import (
+    HiddenStateCacheSpec,
+    KVCacheConfig,
+    KVCacheTemporalLayout,
+    UniformTypeKVCacheSpecs,
+)
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.topk_topp_sampler import (
     empty_exponential_noise_like,
@@ -49,16 +54,20 @@ from vllm.v1.sample.sampler import _SAMPLING_EPS
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm.v1.spec_decode.utils import (
     PADDING_SLOT_ID,
+    _advance_cpu_sequence_metadata,
     compute_new_slot_mapping,
     copy_and_expand_eagle_inputs_kernel,
     eagle_prepare_inputs_padded_kernel,
     eagle_prepare_next_token_padded_kernel,
     eagle_step_update_slot_mapping_and_metadata,
+    expand_dcp_parent_block_table,
     extend_all_queries_by_N,
+    get_eagle3_draft_attention_layer_name,
     next_power_of_2,
 )
 from vllm.v1.utils import CpuGpuBuffer
 from vllm.v1.worker.dp_utils import coordinate_batch_across_dp
+from vllm.v1.worker.gpu.cp_utils import prepare_dcp_local_seq_lens
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm.v1.worker.utils import AttentionGroup
 
@@ -85,6 +94,21 @@ class SpecDecodeBaseProposer:
         self.dtype = vllm_config.model_config.dtype
         self.max_model_len = vllm_config.model_config.max_model_len
         self.dp_rank = vllm_config.parallel_config.data_parallel_rank
+        parallel_config = vllm_config.parallel_config
+        self.dcp_world_size = parallel_config.decode_context_parallel_size
+        self.dcp_rank = get_dcp_group().rank_in_group if self.dcp_world_size > 1 else 0
+        self.replicated_draft_kv = bool(
+            getattr(
+                self.speculative_config,
+                "enable_eagle3_replicated_draft_kv",
+                False,
+            )
+        )
+        self.draft_dcp_world_size = (
+            1 if self.replicated_draft_kv else self.dcp_world_size
+        )
+        self.draft_dcp_rank = 0 if self.replicated_draft_kv else self.dcp_rank
+        self.cp_kv_cache_interleave_size = parallel_config.cp_kv_cache_interleave_size
         self.eplb_state: EplbState | None = None
         self.num_speculative_tokens = self.speculative_config.num_speculative_tokens
 
@@ -114,6 +138,7 @@ class SpecDecodeBaseProposer:
             1 if (self.pass_hidden_states_to_model and self.method != "dflash") else 0
         )
         self.needs_extra_input_slots = self.net_num_new_slots_per_request > 0
+        self._validate_replicated_draft_kv_config()
 
         # When True, all draft steps reuse the same position as the
         # first step instead of advancing by one each iteration.
@@ -151,6 +176,9 @@ class SpecDecodeBaseProposer:
 
         self.draft_attn_groups: list[AttentionGroup] = []
         self.kv_cache_gid: int = -1
+        self._replicated_draft_impl: Any | None = None
+        self._replicated_draft_block_table: torch.Tensor | None = None
+        self._replicated_draft_reject_mask: torch.Tensor | None = None
         self.eagle3_use_aux_hidden_state: bool = (
             self._get_eagle3_use_aux_hidden_state_from_config()
         )
@@ -317,6 +345,88 @@ class SpecDecodeBaseProposer:
 
             self.allowed_attn_types = tuple(rocm_types)
 
+    def _validate_replicated_draft_kv_config(self) -> None:
+        if not self.replicated_draft_kv:
+            return
+
+        parallel_config = self.vllm_config.parallel_config
+        draft_hf_config = self.draft_model_config.hf_config
+        target_architectures = self.vllm_config.model_config.architectures or []
+        errors = []
+        if self.method != "eagle3":
+            errors.append("speculative method must be eagle3")
+        if not any("MiniMaxM3" in str(arch) for arch in target_architectures):
+            errors.append("target architecture must be MiniMaxM3")
+        if self.vllm_config.model_config.get_num_layers(parallel_config) != 60:
+            errors.append("target model must contain exactly 60 layers")
+        if parallel_config.tensor_parallel_size != 8:
+            errors.append("tensor_parallel_size must be 8")
+        if (
+            self.replicated_draft_kv
+            and parallel_config.decode_context_parallel_size not in (1, 2)
+        ):
+            errors.append("decode_context_parallel_size must be 1 or 2")
+        if parallel_config.pipeline_parallel_size != 1:
+            errors.append("pipeline_parallel_size must be 1")
+        if parallel_config.prefill_context_parallel_size != 1:
+            errors.append("prefill_context_parallel_size must be 1")
+        if parallel_config.data_parallel_size != 1:
+            errors.append("data_parallel_size must be 1")
+        if parallel_config.use_ubatching:
+            errors.append("ubatching must be disabled")
+        cudagraph_mode = self.vllm_config.compilation_config.cudagraph_mode
+        if (
+            self.vllm_config.model_config.enforce_eager
+            and cudagraph_mode != CUDAGraphMode.NONE
+        ):
+            errors.append("eager execution requires cudagraph_mode=NONE")
+        elif (
+            not self.vllm_config.model_config.enforce_eager
+            and cudagraph_mode != CUDAGraphMode.FULL_DECODE_ONLY
+        ):
+            errors.append(
+                "non-eager execution requires cudagraph_mode=FULL_DECODE_ONLY"
+            )
+        if self.vllm_config.scheduler_config.async_scheduling:
+            errors.append("async scheduling must be disabled")
+        if self.vllm_config.cache_config.kv_offloading_size is not None:
+            errors.append("KV offloading must be disabled")
+        kv_transfer_config = self.vllm_config.kv_transfer_config
+        if kv_transfer_config is not None:
+            mooncake_consumer = (
+                kv_transfer_config.kv_connector == "MooncakeConnector"
+                and kv_transfer_config.kv_role == "kv_consumer"
+                and kv_transfer_config.kv_connector_module_path is None
+                and kv_transfer_config.kv_load_failure_policy == "fail"
+            )
+            if not mooncake_consumer:
+                errors.append(
+                    "KV transfer requires the built-in Mooncake consumer in fail mode"
+                )
+        if self.parallel_drafting:
+            errors.append("parallel drafting must be disabled")
+        if self.needs_extra_input_slots:
+            errors.append("extra-input-slot drafting is not supported")
+        if self.vllm_config.cache_config.block_size != 128:
+            errors.append("KV cache block size must be 128")
+        if (
+            self.replicated_draft_kv
+            and parallel_config.cp_kv_cache_interleave_size != 128
+        ):
+            errors.append("DCP KV cache interleave size must be 128")
+        if getattr(draft_hf_config, "num_hidden_layers", None) != 1:
+            errors.append("draft model must contain exactly one layer")
+        if getattr(draft_hf_config, "num_attention_heads", None) != 64:
+            errors.append("draft model must have 64 attention heads")
+        if getattr(draft_hf_config, "num_key_value_heads", None) != 64:
+            errors.append("draft model must have 64 KV heads")
+        if getattr(draft_hf_config, "head_dim", None) != 128:
+            errors.append("draft model head_dim must be 128")
+        if errors:
+            raise ValueError(
+                "EAGLE3 replicated draft-KV requirements not met: " + "; ".join(errors)
+            )
+
     def _raise_if_padded_drafter_batch_disabled(self):
         if self.speculative_config.disable_padded_drafter_batch:
             raise NotImplementedError(
@@ -399,6 +509,12 @@ class SpecDecodeBaseProposer:
 
         If slot_mapping is provided, copies it into the buffer first.
         """
+        if self.replicated_draft_kv:
+            impl = self._replicated_draft_impl
+            if impl is None or impl.dcp_world_size != 1 or impl.dcp_rank != 0:
+                raise RuntimeError(
+                    "Replicated draft KV requires effective DCP1 attention"
+                )
         if slot_mapping is not None:
             num_actual = slot_mapping.shape[0]
             self._slot_mapping_buffer[:num_actual].copy_(slot_mapping)
@@ -499,6 +615,52 @@ class SpecDecodeBaseProposer:
     def take_last_draft_probs(self) -> torch.Tensor | None:
         return self._last_draft_probs
 
+    def _build_replicated_draft_metadata(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        num_tokens: int,
+    ) -> CommonAttentionMetadata:
+        expanded_block_table = expand_dcp_parent_block_table(
+            common_attn_metadata.block_table_tensor,
+            dcp_world_size=self.dcp_world_size,
+            max_model_len=self.max_model_len,
+            kernel_block_size=self.block_size,
+        )
+        block_table_buffer = self._replicated_draft_block_table
+        if block_table_buffer is None:
+            raise RuntimeError("Replicated draft KV metadata is not initialized")
+        num_reqs, num_blocks = expanded_block_table.shape
+        block_table = block_table_buffer[:num_reqs, :num_blocks]
+        block_table.copy_(expanded_block_table)
+        block_table_buffer[:num_reqs, num_blocks:].zero_()
+        draft_metadata = common_attn_metadata.replace(
+            block_table_tensor=block_table,
+            dcp_local_seq_lens=None,
+            dcp_local_seq_lens_cpu=None,
+        )
+        positions = self._get_positions(num_tokens)
+        if positions.ndim > 1:
+            positions = positions[0]
+        reject_mask = self._replicated_draft_reject_mask
+        if reject_mask is None:
+            raise RuntimeError("Replicated draft KV reject mask is not initialized")
+        reject_mask[:num_tokens].zero_()
+        computed_slot_mapping = compute_new_slot_mapping(
+            cad=draft_metadata,
+            new_positions=positions,
+            is_rejected_token_mask=reject_mask[:num_tokens],
+            block_size=self.block_size,
+            num_new_tokens=0,
+            max_model_len=self.max_model_len,
+            dcp_world_size=1,
+            dcp_rank=0,
+            cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
+        )
+        slot_mapping = self._slot_mapping_buffer[:num_tokens]
+        slot_mapping.copy_(computed_slot_mapping)
+        draft_metadata.slot_mapping = slot_mapping
+        return draft_metadata
+
     def propose(
         self,
         num_speculative_tokens,
@@ -553,6 +715,11 @@ class SpecDecodeBaseProposer:
                 num_rejected_tokens_gpu=num_rejected_tokens_gpu,
             )
         )
+        if self.replicated_draft_kv:
+            common_attn_metadata = self._build_replicated_draft_metadata(
+                common_attn_metadata,
+                num_tokens,
+            )
 
         per_group_attn_metadata, per_layer_attn_metadata = (
             self.build_per_group_and_layer_attn_metadata(common_attn_metadata)
@@ -676,6 +843,10 @@ class SpecDecodeBaseProposer:
             # Invalidate the CPU-side shadows to avoid H<>D sync.
             common_attn_metadata._seq_lens_cpu = None
             common_attn_metadata._num_computed_tokens_cpu = None
+            self._refresh_dcp_local_seq_lens(
+                common_attn_metadata,
+                batch_size,
+            )
 
         block_size = self.block_size
         assert block_size > 0, "block_size has not been initialized."
@@ -792,6 +963,9 @@ class SpecDecodeBaseProposer:
             out_clamped_positions=out_pos,
             out_slot_mapping=self._slot_mapping_buffer[:input_batch_size],
             input_batch_size=input_batch_size,
+            dcp_world_size=self.draft_dcp_world_size,
+            dcp_rank=self.draft_dcp_rank,
+            cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
         )
         common_attn_metadata.slot_mapping = self._slot_mapping_buffer[:batch_size]
         if self.uses_mrope:
@@ -809,14 +983,38 @@ class SpecDecodeBaseProposer:
             self.max_model_len,
         )
 
-        if common_attn_metadata._seq_lens_cpu is not None:
-            common_attn_metadata._seq_lens_cpu += 1
-        if common_attn_metadata._num_computed_tokens_cpu is not None:
-            common_attn_metadata._num_computed_tokens_cpu += 1
-        if common_attn_metadata.seq_lens_cpu_upper_bound is not None:
-            common_attn_metadata.seq_lens_cpu_upper_bound += 1
+        _advance_cpu_sequence_metadata(
+            common_attn_metadata,
+            self.max_model_len,
+        )
 
+        self._refresh_dcp_local_seq_lens(common_attn_metadata, batch_size)
         return positions
+
+    def _refresh_dcp_local_seq_lens(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        num_reqs: int,
+    ) -> None:
+        local_seq_lens = common_attn_metadata.dcp_local_seq_lens
+        if self.replicated_draft_kv:
+            common_attn_metadata.dcp_local_seq_lens = None
+            common_attn_metadata.dcp_local_seq_lens_cpu = None
+            return
+        if self.dcp_world_size == 1 or local_seq_lens is None:
+            return
+
+        prepare_dcp_local_seq_lens(
+            local_seq_lens,
+            common_attn_metadata.seq_lens,
+            num_reqs,
+            self.dcp_world_size,
+            self.dcp_rank,
+            self.cp_kv_cache_interleave_size,
+        )
+        # This view aliases the runner's pinned H2D staging buffer. Do not
+        # overwrite it while its non-blocking copy may still be in flight.
+        common_attn_metadata.dcp_local_seq_lens_cpu = None
 
     def set_inputs_first_pass(
         self,
@@ -947,6 +1145,9 @@ class SpecDecodeBaseProposer:
                 block_size=self.block_size,
                 num_new_tokens=self.net_num_new_slots_per_request,
                 max_model_len=self.max_model_len,
+                dcp_world_size=self.draft_dcp_world_size,
+                dcp_rank=self.draft_dcp_rank,
+                cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
             )
 
             # 3. Update the common attention metadata with the new (meta)data
@@ -956,6 +1157,7 @@ class SpecDecodeBaseProposer:
                 arange=self.arange,
                 new_slot_mapping=new_slot_mapping,
             )
+            self._refresh_dcp_local_seq_lens(new_cad, new_cad.num_reqs)
 
             return total_num_output_tokens, token_indices_to_sample, new_cad
 
@@ -1154,6 +1356,10 @@ class SpecDecodeBaseProposer:
             causal=True,
             dcp_local_seq_lens=common_attn_metadata.dcp_local_seq_lens,
         )
+        self._refresh_dcp_local_seq_lens(
+            spec_common_attn_metadata,
+            spec_common_attn_metadata.num_reqs,
+        )
 
         return (
             spec_common_attn_metadata,
@@ -1265,6 +1471,10 @@ class SpecDecodeBaseProposer:
             causal=True,
             dcp_local_seq_lens=common_attn_metadata.dcp_local_seq_lens,
         )
+        self._refresh_dcp_local_seq_lens(
+            spec_common_attn_metadata,
+            spec_common_attn_metadata.num_reqs,
+        )
 
         return spec_common_attn_metadata, token_indices
 
@@ -1327,6 +1537,81 @@ class SpecDecodeBaseProposer:
             )
         return model
 
+    def _configure_replicated_draft_attention(
+        self,
+        all_attn_layers: dict[str, AttentionLayerBase],
+    ) -> None:
+        if not self.replicated_draft_kv:
+            return
+
+        expected_layer = get_eagle3_draft_attention_layer_name(
+            self.vllm_config.model_config.get_total_num_hidden_layers()
+        )
+        if self._draft_attn_layer_names != {expected_layer}:
+            raise ValueError(
+                "Replicated draft KV requires exactly "
+                f"{expected_layer!r}, got {sorted(self._draft_attn_layer_names)!r}"
+            )
+
+        draft_layer = all_attn_layers[expected_layer]
+        backend_name = draft_layer.get_attn_backend().get_name()
+        if backend_name != AttentionBackendEnum.FLASH_ATTN.name:
+            raise ValueError(
+                f"Replicated draft KV requires FLASH_ATTN, got {backend_name}"
+            )
+        if (
+            getattr(draft_layer, "num_heads", None) != 8
+            or getattr(draft_layer, "num_kv_heads", None) != 8
+            or getattr(draft_layer, "head_size", None) != 128
+        ):
+            raise ValueError(
+                "Replicated draft KV requires TP-local Q/KV/head_dim = 8/8/128"
+            )
+
+        impl = draft_layer.impl
+        impl.dcp_world_size = 1
+        impl.dcp_rank = 0
+        impl.total_cp_world_size = impl.pcp_world_size
+        impl.total_cp_rank = impl.pcp_rank
+        self._replicated_draft_impl = impl
+        logger.info_once(
+            "Enabled replicated temporal KV and DCP1-equivalent attention for %s",
+            expected_layer,
+        )
+
+    def _validate_prefill_draft_kv_layers(
+        self,
+        all_attn_layers: dict[str, AttentionLayerBase],
+    ) -> None:
+        if not getattr(
+            self.speculative_config,
+            "enable_eagle3_prefill_draft_kv",
+            False,
+        ):
+            return
+        expected_layer = get_eagle3_draft_attention_layer_name(
+            self.vllm_config.model_config.get_total_num_hidden_layers()
+        )
+        if self._draft_attn_layer_names != {expected_layer}:
+            raise ValueError(
+                "EAGLE3 Prefill draft-KV requires exactly "
+                f"{expected_layer!r}, got {sorted(self._draft_attn_layer_names)!r}"
+            )
+        hidden_layers = [
+            name
+            for name, layer in all_attn_layers.items()
+            if isinstance(
+                layer.get_kv_cache_spec(self.vllm_config),
+                HiddenStateCacheSpec,
+            )
+            or name.startswith("cache_only_layers.")
+        ]
+        if hidden_layers:
+            raise ValueError(
+                "EAGLE3 Prefill draft-KV must not allocate hidden-state cache "
+                f"layers, got {sorted(hidden_layers)!r}"
+            )
+
     def load_model(self, target_model: nn.Module) -> None:
         target_attn_layer_names = set(
             get_layers_from_vllm_config(
@@ -1348,6 +1633,8 @@ class SpecDecodeBaseProposer:
             for name in (set(all_attn_layers.keys()) - target_attn_layer_names)
             if all_attn_layers[name].get_kv_cache_spec(self.vllm_config) is not None
         }
+        self._validate_prefill_draft_kv_layers(all_attn_layers)
+        self._configure_replicated_draft_attention(all_attn_layers)
 
         if self.supports_mm_inputs:
             # Even if the target model is multimodal, we can also use
@@ -1763,14 +2050,79 @@ class SpecDecodeBaseProposer:
                         self.device,
                         kernel_block_size=kernel_block_size,
                     )
+                    if self.replicated_draft_kv:
+                        builder = attn_group.get_metadata_builder()
+                        if not hasattr(builder, "dcp_world_size"):
+                            raise ValueError(
+                                "Replicated draft KV requires a "
+                                "DCP-aware attention metadata builder"
+                            )
+                        builder.dcp_world_size = 1
+                        builder.dcp_rank = 0
                     attention_groups[backend_key] = attn_group
                 else:
                     attention_groups[backend_key].layer_names.append(layer_name)
 
         self.draft_attn_groups = list(attention_groups.values())
+        if getattr(
+            self.speculative_config,
+            "enable_eagle3_prefill_draft_kv",
+            False,
+        ):
+            if len(self.draft_attn_groups) != 1:
+                raise ValueError(
+                    "EAGLE3 Prefill draft-KV requires one draft attention group"
+                )
+            if isinstance(
+                self.draft_attn_groups[0].kv_cache_spec,
+                HiddenStateCacheSpec,
+            ):
+                raise ValueError(
+                    "EAGLE3 Prefill draft-KV requires an attention KV cache"
+                )
+        if self.replicated_draft_kv:
+            draft_layer = next(iter(self._draft_attn_layer_names))
+            draft_tensors = [
+                tensor
+                for tensor in kv_cache_config.kv_cache_tensors
+                if draft_layer in tensor.shared_by
+            ]
+            if len(draft_tensors) != 1 or draft_tensors[0].shared_by != [draft_layer]:
+                raise ValueError(
+                    "Replicated draft KV requires a dedicated draft KV tensor"
+                )
+            draft_spec = self.draft_attn_groups[0].kv_cache_spec
+            if draft_spec.temporal_layout != KVCacheTemporalLayout.FULL_TEMPORAL:
+                raise ValueError(
+                    "Replicated draft KV requires a FULL_TEMPORAL draft spec"
+                )
+            expected_size = (
+                kv_cache_config.num_blocks
+                * self.dcp_world_size
+                * draft_spec.page_size_bytes
+            )
+            if draft_tensors[0].size != expected_size:
+                raise ValueError(
+                    "Replicated draft KV allocation mismatch: expected "
+                    f"{expected_size} bytes, got {draft_tensors[0].size}"
+                )
         self.block_size = (
             self.draft_attn_groups[0].get_metadata_builder().kv_cache_spec.block_size
         )
+        if self.replicated_draft_kv:
+            max_child_blocks = (
+                self.max_model_len + self.block_size - 1
+            ) // self.block_size
+            self._replicated_draft_block_table = torch.zeros(
+                (self.max_batch_size, max_child_blocks),
+                dtype=torch.int32,
+                device=self.device,
+            )
+            self._replicated_draft_reject_mask = torch.zeros(
+                self.max_num_tokens,
+                dtype=torch.bool,
+                device=self.device,
+            )
         logger.debug("Using block size %d for drafting layers", self.block_size)
 
     def _determine_batch_execution_and_padding(

--- a/vllm/v1/spec_decode/utils.py
+++ b/vllm/v1/spec_decode/utils.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections.abc import Collection
+from dataclasses import dataclass
+
 import torch
 
+from vllm.distributed.cp_mapping import map_cp_positions
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.utils import (
@@ -9,6 +13,142 @@ from vllm.v1.attention.backends.utils import (
 )
 
 PADDING_SLOT_ID = -1
+MINIMAX_M3_TARGET_LAYER_COUNT = 60
+MINIMAX_M3_DENSE_TARGET_LAYER_IDS = (0, 1, 2)
+MINIMAX_M3_TARGET_LAYER_PREFIXES = ("language_model.model", "model")
+
+
+def get_minimax_m3_target_attention_layer_name(layer_index: int) -> str:
+    """Return the global attention-layer identity for a MiniMax-M3 layer."""
+    if not 0 <= layer_index < MINIMAX_M3_TARGET_LAYER_COUNT:
+        raise ValueError(
+            "MiniMax-M3 target layer index must be in "
+            f"[0, {MINIMAX_M3_TARGET_LAYER_COUNT})"
+        )
+    return f"language_model.model.layers.{layer_index}.self_attn.attn"
+
+
+def get_minimax_m3_dense_target_attention_layer_names() -> tuple[str, ...]:
+    """Return target layers requiring DCP1-equivalent EAGLE-visible parity."""
+    return tuple(
+        get_minimax_m3_target_attention_layer_name(layer_index)
+        for layer_index in MINIMAX_M3_DENSE_TARGET_LAYER_IDS
+    )
+
+
+def resolve_minimax_m3_dense_target_attention_layer_names(
+    available_layer_names: Collection[str],
+) -> tuple[str, ...]:
+    """Resolve the complete dense target layer set for either model wrapper."""
+    resolved: list[tuple[str, ...]] = []
+    available = set(available_layer_names)
+    for prefix in MINIMAX_M3_TARGET_LAYER_PREFIXES:
+        candidates = tuple(
+            f"{prefix}.layers.{layer_index}.self_attn.attn"
+            for layer_index in MINIMAX_M3_DENSE_TARGET_LAYER_IDS
+        )
+        present = set(candidates) & available
+        if present and len(present) != len(candidates):
+            raise ValueError(
+                "MiniMax-M3 dense target attention layers are incomplete: "
+                f"expected {list(candidates)!r}, got {sorted(present)!r}"
+            )
+        if present:
+            resolved.append(candidates)
+    if len(resolved) > 1:
+        raise ValueError(
+            "Multiple MiniMax-M3 dense target attention layer prefixes found"
+        )
+    return resolved[0] if resolved else ()
+
+
+def get_eagle3_draft_attention_layer_name(
+    total_target_layers: int,
+    draft_layer_index: int = 0,
+) -> str:
+    """Return the global MiniMax-M3 layer identity for an EAGLE3 draft layer."""
+    if total_target_layers != MINIMAX_M3_TARGET_LAYER_COUNT:
+        raise ValueError("MiniMax-M3 EAGLE3 requires exactly 60 global target layers")
+    if draft_layer_index < 0:
+        raise ValueError("draft_layer_index must be non-negative")
+    layer_index = total_target_layers + draft_layer_index
+    return f"model.layers.{layer_index}.self_attn.attn"
+
+
+@dataclass(frozen=True)
+class PromptDraftKVCoverage:
+    """Logical prompt draft-KV handoff between Prefill and Decode."""
+
+    prompt_tokens: int
+    target_prefix_tokens: int
+    compatible_draft_prefix_tokens: int
+    transfer_start_token: int
+    transfer_end_token_exclusive: int
+    decode_recompute_position: int
+
+    @property
+    def transfer_token_count(self) -> int:
+        return self.transfer_end_token_exclusive - self.transfer_start_token
+
+
+def get_prompt_draft_kv_coverage(
+    prompt_tokens: int,
+    target_prefix_tokens: int,
+    compatible_draft_prefix_tokens: int,
+) -> PromptDraftKVCoverage:
+    """Freeze the half-open prompt draft-KV transfer and handoff contract."""
+    if prompt_tokens <= 0:
+        raise ValueError("prompt_tokens must be positive")
+    if not 0 <= target_prefix_tokens <= prompt_tokens:
+        raise ValueError("target_prefix_tokens must be within the prompt")
+    if not 0 <= compatible_draft_prefix_tokens <= target_prefix_tokens:
+        raise ValueError(
+            "compatible_draft_prefix_tokens must be within the target prefix"
+        )
+
+    decode_recompute_position = prompt_tokens - 1
+    transfer_start_token = min(
+        compatible_draft_prefix_tokens,
+        decode_recompute_position,
+    )
+    return PromptDraftKVCoverage(
+        prompt_tokens=prompt_tokens,
+        target_prefix_tokens=target_prefix_tokens,
+        compatible_draft_prefix_tokens=compatible_draft_prefix_tokens,
+        transfer_start_token=transfer_start_token,
+        transfer_end_token_exclusive=decode_recompute_position,
+        decode_recompute_position=decode_recompute_position,
+    )
+
+
+def expand_dcp_parent_block_table(
+    parent_block_table: torch.Tensor,
+    dcp_world_size: int,
+    max_model_len: int,
+    kernel_block_size: int,
+) -> torch.Tensor:
+    """Expand each DCP parent block into full-temporal physical child pages."""
+    if dcp_world_size <= 1:
+        return parent_block_table
+    if max_model_len <= 0 or kernel_block_size <= 0:
+        raise ValueError("max_model_len and kernel_block_size must be positive")
+
+    child_offsets = torch.arange(
+        dcp_world_size,
+        dtype=parent_block_table.dtype,
+        device=parent_block_table.device,
+    )
+    children = parent_block_table.unsqueeze(-1) * dcp_world_size + child_offsets
+    # Block zero is the null block. Keep all children of padding entries null.
+    children.masked_fill_(parent_block_table.unsqueeze(-1) == 0, 0)
+    max_child_blocks = (max_model_len + kernel_block_size - 1) // kernel_block_size
+    expanded = children.flatten(1)
+    if expanded.shape[1] < max_child_blocks:
+        raise ValueError(
+            "DCP parent block table is too short for full-temporal KV: "
+            f"{expanded.shape[1]} child blocks < {max_child_blocks}"
+        )
+    return expanded[:, :max_child_blocks].contiguous()
 
 
 def next_power_of_2(n: int) -> int:
@@ -25,6 +165,39 @@ def next_power_of_2(n: int) -> int:
     return n + 1
 
 
+def _advance_cpu_sequence_metadata(
+    metadata: CommonAttentionMetadata,
+    max_model_len: int,
+) -> None:
+    seq_lens = metadata._seq_lens_cpu
+    upper_bound = metadata.seq_lens_cpu_upper_bound
+    exceeds_max = None
+    if seq_lens is not None:
+        exceeds_max = seq_lens >= max_model_len
+        seq_lens.add_(1)
+        seq_lens.masked_fill_(exceeds_max, 1)
+    elif upper_bound is not None:
+        exceeds_max = upper_bound >= max_model_len
+
+    num_computed_tokens = metadata._num_computed_tokens_cpu
+    if num_computed_tokens is not None:
+        num_computed_tokens.add_(1)
+        if exceeds_max is not None:
+            num_computed_tokens.masked_fill_(exceeds_max, 0)
+
+    upper_bound_aliases_seq_lens = (
+        upper_bound is not None
+        and seq_lens is not None
+        and upper_bound.data_ptr() == seq_lens.data_ptr()
+        and upper_bound.shape == seq_lens.shape
+        and upper_bound.stride() == seq_lens.stride()
+    )
+    if upper_bound is not None and not upper_bound_aliases_seq_lens:
+        exceeds_upper_bound = upper_bound >= max_model_len
+        upper_bound.add_(1)
+        upper_bound.masked_fill_(exceeds_upper_bound, 1)
+
+
 @triton.jit
 def eagle_step_slot_mapping_metadata_kernel(
     positions_ptr,  # [batch_size] - current positions (1D view for M-RoPE)
@@ -33,6 +206,9 @@ def eagle_step_slot_mapping_metadata_kernel(
     seq_lens_ptr,  # [batch_size] - read and write
     out_clamped_positions_ptr,  # [batch_size] (output)
     out_slot_mapping_ptr,  # [input_batch_size] (output)
+    dcp_world_size,
+    dcp_rank,
+    cp_kv_cache_interleave_size,
     block_size: tl.constexpr,
     max_model_len: tl.constexpr,
     n_blocks_per_req: tl.constexpr,
@@ -65,14 +241,25 @@ def eagle_step_slot_mapping_metadata_kernel(
     exceeds_max = new_position >= max_model_len
     clamped_position = tl.where(exceeds_max, 0, new_position)
 
-    # Block table lookup: block_number = position // block_size
+    cp_cycle = dcp_world_size * cp_kv_cache_interleave_size
+    owner_rank = (clamped_position % cp_cycle) // cp_kv_cache_interleave_size
+    local_position = (
+        clamped_position // cp_cycle * cp_kv_cache_interleave_size
+        + clamped_position % cp_kv_cache_interleave_size
+    )
+
+    # The block table is compacted to this DCP rank's local token space.
     # Clamp block_number to avoid OOB when position is at max
-    block_number = clamped_position // block_size
+    block_number = local_position // block_size
     block_number = tl.minimum(block_number, n_blocks_per_req - 1)
 
     block_id = tl.load(block_table_ptr + req_idx * block_table_stride + block_number)
-    slot_id = block_id * block_size + (clamped_position % block_size)
-    slot_id = tl.where(exceeds_max, PAD_ID, slot_id)
+    slot_id = block_id * block_size + (local_position % block_size)
+    slot_id = tl.where(
+        exceeds_max | (owner_rank != dcp_rank),
+        PAD_ID,
+        slot_id,
+    )
 
     # Update seq_lens: +1 normally, or 1 if exceeded
     seq_len = tl.load(seq_lens_ptr + req_idx)
@@ -94,6 +281,9 @@ def eagle_step_update_slot_mapping_and_metadata(
     out_clamped_positions: torch.Tensor,
     out_slot_mapping: torch.Tensor,
     input_batch_size: int | None = None,
+    dcp_world_size: int = 1,
+    dcp_rank: int = 0,
+    cp_kv_cache_interleave_size: int = 1,
 ) -> None:
     """
     Fused update of slot mapping and metadata for one EAGLE autoregressive step.
@@ -125,6 +315,9 @@ def eagle_step_update_slot_mapping_and_metadata(
         seq_lens,
         out_clamped_positions,
         out_slot_mapping,
+        dcp_world_size,
+        dcp_rank,
+        cp_kv_cache_interleave_size,
         block_size=block_size,
         max_model_len=max_model_len,
         n_blocks_per_req=n_blocks_per_req,
@@ -239,6 +432,52 @@ def eagle_prepare_next_token_padded_kernel(
         tl.store(valid_sampled_tokens_count_ptr + req_idx, valid_count)
 
 
+def compute_slot_mapping_from_block_table(
+    query_start_loc: torch.Tensor,
+    block_table_tensor: torch.Tensor,
+    positions: torch.Tensor,
+    block_size: int,
+    max_model_len: int,
+    *,
+    num_new_tokens: int = 0,
+    dcp_world_size: int = 1,
+    dcp_rank: int = 0,
+    cp_kv_cache_interleave_size: int = 1,
+    is_rejected_token_mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Map global token positions through an explicit block table."""
+    batch_size, n_blocks_per_req = block_table_tensor.shape
+    req_indices = torch.arange(batch_size, device=query_start_loc.device)
+    req_indices = torch.repeat_interleave(
+        req_indices,
+        query_start_loc[1:] - query_start_loc[:-1] + num_new_tokens,
+        output_size=len(positions),
+    )
+    # Clamp the positions to prevent an out-of-bounds error when indexing
+    # into block_table_tensor.
+    clamped_positions = torch.clamp(positions, max=max_model_len - 1)
+    owner_ranks, local_positions = map_cp_positions(
+        clamped_positions,
+        cp_world_size=dcp_world_size,
+        interleave_size=cp_kv_cache_interleave_size,
+    )
+    block_table_indices = req_indices * n_blocks_per_req + local_positions // block_size
+    block_nums = block_table_tensor.view(-1)[block_table_indices]
+    block_offsets = local_positions % block_size
+    new_slot_mapping = block_nums * block_size + block_offsets
+    # Mask out the position ids that exceed the max model length.
+    exceeds_max_model_len = positions >= max_model_len
+    new_slot_mapping.masked_fill_(exceeds_max_model_len, PADDING_SLOT_ID)
+    new_slot_mapping.masked_fill_(owner_ranks != dcp_rank, PADDING_SLOT_ID)
+    # Mask out rejected tokens to prevent saves to the KV cache.
+    if is_rejected_token_mask is not None:
+        new_slot_mapping.masked_fill_(
+            is_rejected_token_mask,
+            PADDING_SLOT_ID,
+        )
+    return new_slot_mapping
+
+
 def compute_new_slot_mapping(
     cad: CommonAttentionMetadata,
     new_positions: torch.Tensor,
@@ -246,29 +485,22 @@ def compute_new_slot_mapping(
     block_size: int,
     num_new_tokens: int,
     max_model_len: int,
+    dcp_world_size: int = 1,
+    dcp_rank: int = 0,
+    cp_kv_cache_interleave_size: int = 1,
 ):
-    batch_size, n_blocks_per_req = cad.block_table_tensor.shape
-    req_indices = torch.arange(batch_size, device=cad.query_start_loc.device)
-    req_indices = torch.repeat_interleave(
-        req_indices,
-        cad.naive_query_lens() + num_new_tokens,
-        output_size=len(new_positions),
+    return compute_slot_mapping_from_block_table(
+        query_start_loc=cad.query_start_loc,
+        block_table_tensor=cad.block_table_tensor,
+        positions=new_positions,
+        block_size=block_size,
+        max_model_len=max_model_len,
+        num_new_tokens=num_new_tokens,
+        dcp_world_size=dcp_world_size,
+        dcp_rank=dcp_rank,
+        cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
+        is_rejected_token_mask=is_rejected_token_mask,
     )
-    # Clamp the positions to prevent an out-of-bounds error when indexing
-    # into block_table_tensor.
-    clamped_positions = torch.clamp(new_positions, max=max_model_len - 1)
-    block_table_indices = (
-        req_indices * n_blocks_per_req + clamped_positions // block_size
-    )
-    block_nums = cad.block_table_tensor.view(-1)[block_table_indices]
-    block_offsets = clamped_positions % block_size
-    new_slot_mapping = block_nums * block_size + block_offsets
-    # Mask out the position ids that exceed the max model length.
-    exceeds_max_model_len = new_positions >= max_model_len
-    new_slot_mapping.masked_fill_(exceeds_max_model_len, PADDING_SLOT_ID)
-    # Mask out rejected tokens to prevent saves to the KV cache.
-    new_slot_mapping.masked_fill_(is_rejected_token_mask, PADDING_SLOT_ID)
-    return new_slot_mapping
 
 
 def extend_all_queries_by_N(
@@ -290,6 +522,12 @@ def extend_all_queries_by_N(
     new_query_start_loc_cpu = cad.query_start_loc_cpu + N * torch.arange(
         len(cad.query_start_loc_cpu), dtype=torch.int32
     )
+    new_seq_lens_cpu = cad._seq_lens_cpu + N if cad._seq_lens_cpu is not None else None
+    new_seq_lens_cpu_upper_bound = (
+        cad.seq_lens_cpu_upper_bound + N
+        if cad.seq_lens_cpu_upper_bound is not None
+        else None
+    )
     new_cad = cad.replace(
         query_start_loc=new_query_start_loc,
         query_start_loc_cpu=new_query_start_loc_cpu,
@@ -300,6 +538,9 @@ def extend_all_queries_by_N(
         max_query_len=cad.max_query_len + N,
         max_seq_len=cad.max_seq_len + N,
         slot_mapping=new_slot_mapping,
+        _seq_lens_cpu=new_seq_lens_cpu,
+        seq_lens_cpu_upper_bound=new_seq_lens_cpu_upper_bound,
+        dcp_local_seq_lens_cpu=None,
     )
     return new_cad
 

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -408,7 +408,7 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
                     "MTP with cp_kv_cache_interleave_size > 1 is not "
                     f"supported in {layer_impl.__class__.__name__}."
                 )
-            if dcp_size > 1:
+            if dcp_size > 1 and layer_impl.dcp_world_size > 1:
                 assert layer_impl.need_to_return_lse_for_decode, (
                     "Decode Context Parallelism (DCP) requires attention "
                     "implementations to return the softmax LSE during decode, "

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -164,6 +164,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     KVCacheSpec,
     KVCacheSpecKind,
+    KVCacheTemporalLayout,
     KVQuantMode,
     MambaSpec,
     SlidingWindowSpec,
@@ -209,7 +210,13 @@ from vllm.v1.spec_decode.ngram_proposer_gpu import (
 )
 from vllm.v1.spec_decode.step3p5 import Step3p5MTPProposer
 from vllm.v1.spec_decode.suffix_decoding import SuffixDecodingProposer
-from vllm.v1.spec_decode.utils import update_num_computed_tokens_for_batch_change
+from vllm.v1.spec_decode.utils import (
+    compute_slot_mapping_from_block_table,
+    expand_dcp_parent_block_table,
+    get_eagle3_draft_attention_layer_name,
+    resolve_minimax_m3_dense_target_attention_layer_names,
+    update_num_computed_tokens_for_batch_change,
+)
 from vllm.v1.structured_output.utils import apply_grammar_bitmask
 from vllm.v1.utils import CpuGpuBuffer, record_function_or_nullcontext
 from vllm.v1.worker import mamba_utils
@@ -252,6 +259,7 @@ if TYPE_CHECKING:
     from vllm.v1.worker.encoder_cudagraph import EncoderCudaGraphManager
 
 logger = init_logger(__name__)
+
 
 AttnMetadataDict: TypeAlias = dict[str, AttentionMetadata]
 # list when ubatching is enabled
@@ -471,15 +479,13 @@ class GPUModelRunner(
         self.parallel_config = vllm_config.parallel_config
         self.scheduler_config = vllm_config.scheduler_config
         self.speculative_config = vllm_config.speculative_config
+        self._target_speculative_config = self.speculative_config
+        self.num_spec_tokens = 0
+        self.prev_num_spec_tokens = 0
+        self.use_aux_hidden_state_outputs = False
+        self._producer_aux_hidden_state_layers: tuple[int, ...] = ()
+        self._configure_kv_producer_speculation()
         self.observability_config = vllm_config.observability_config
-        if (
-            self.speculative_config is not None
-            and self.speculative_config.method in ("eagle3", "dflash", "dspark")
-            and self._is_kv_producer_only_instance()
-        ):
-            # A pure prefill producer does not draft. Treat the runner as
-            # non-speculative while preserving the shared VllmConfig.
-            self.speculative_config = None
 
         model_config = self.model_config
         cache_config = self.cache_config
@@ -517,6 +523,9 @@ class GPUModelRunner(
         self.dcp_rank = 0 if self.dcp_world_size <= 1 else get_dcp_group().rank_in_group
         self.pcp_rank = 0 if self.pcp_world_size <= 1 else get_pcp_group().rank_in_group
         self.cp_rank = self.pcp_rank * self.dcp_world_size + self.dcp_rank
+        self._full_temporal_target_layers: set[str] = set()
+        self._full_temporal_block_tables: dict[int, torch.Tensor] = {}
+        self._full_temporal_slot_mappings: dict[int, torch.Tensor] = {}
         self.max_num_tokens = scheduler_config.max_num_batched_tokens
         self.max_buffer_num_tokens = get_pcp_max_buffer_num_tokens(vllm_config)
         self.max_num_reqs = scheduler_config.max_num_seqs
@@ -591,7 +600,6 @@ class GPUModelRunner(
         # Encoder CUDA graph manager (initialized after model load if enabled)
         self.encoder_cudagraph_manager: EncoderCudaGraphManager | None = None
 
-        self.use_aux_hidden_state_outputs = False
         # Set up speculative decoding.
         # NOTE(Jiayi): currently we put the entire draft model on
         # the last PP rank. This is not ideal if there are many
@@ -673,19 +681,22 @@ class GPUModelRunner(
                 self.sampler, self.speculative_config, self.device
             )
 
-        self.num_spec_tokens = 0
-        self.prev_num_spec_tokens = 0
         self.valid_sampled_token_count_gpu: torch.Tensor | None = None
-        if self.speculative_config:
-            self.num_spec_tokens = self.speculative_config.num_speculative_tokens
+        if self._target_speculative_config:
+            self.num_spec_tokens = (
+                self._target_speculative_config.num_speculative_tokens
+            )
             self.prev_num_spec_tokens = self.num_spec_tokens
+        if self.speculative_config:
             draft_config = self.speculative_config.draft_model_config
             if draft_config is not None and draft_config.max_model_len is not None:
                 self.effective_drafter_max_model_len = draft_config.max_model_len
             else:
                 self.effective_drafter_max_model_len = self.max_model_len
         self.use_async_spec_decode = (
-            self.use_async_scheduling and self.num_spec_tokens > 0
+            self.use_async_scheduling
+            and self.speculative_config is not None
+            and self.num_spec_tokens > 0
         )
 
         # Request states.
@@ -998,6 +1009,129 @@ class GPUModelRunner(
             and kv_transfer_config.is_kv_producer
             and not kv_transfer_config.is_kv_consumer
         )
+
+    def _configure_kv_producer_speculation(self) -> None:
+        self._producer_aux_hidden_state_layers = ()
+        speculative_config = self.speculative_config
+        self._target_speculative_config = speculative_config
+        self.num_spec_tokens = (
+            0
+            if speculative_config is None
+            else speculative_config.num_speculative_tokens
+        )
+        self.prev_num_spec_tokens = self.num_spec_tokens
+        if speculative_config is None:
+            return
+
+        prefill_draft_kv = bool(
+            getattr(
+                speculative_config,
+                "enable_eagle3_prefill_draft_kv",
+                False,
+            )
+        )
+        if prefill_draft_kv:
+            self._configure_eagle3_prefill_draft_kv(speculative_config)
+            return
+
+        if not self._is_kv_producer_only_instance():
+            return
+
+        if speculative_config.method in ("eagle3", "dflash", "dspark"):
+            # A pure prefill producer does not draft. Treat the runner as
+            # non-speculative while preserving the shared VllmConfig.
+            self.speculative_config = None
+            self._target_speculative_config = None
+            self.num_spec_tokens = 0
+            self.prev_num_spec_tokens = 0
+            return
+
+        if not speculative_config.uses_extract_hidden_states():
+            return
+
+        pp_group = get_pp_group()
+        if pp_group.world_size > 1 and pp_group.world_size != 2:
+            raise ValueError(
+                "extract_hidden_states producer pipeline transport currently "
+                "supports pipeline_parallel_size=2 only."
+            )
+        if pp_group.is_last_rank:
+            return
+
+        draft_model_config = speculative_config.draft_model_config
+        assert draft_model_config is not None
+        layer_ids = getattr(
+            draft_model_config.hf_config,
+            "eagle_aux_hidden_state_layer_ids",
+            None,
+        )
+        if not layer_ids:
+            raise ValueError(
+                "eagle_aux_hidden_state_layer_ids must be set for "
+                "extract_hidden_states producer pipeline transport."
+            )
+        self._producer_aux_hidden_state_layers = tuple(layer_ids)
+        self.use_aux_hidden_state_outputs = True
+        self.speculative_config = None
+
+    def _configure_eagle3_prefill_draft_kv(
+        self,
+        speculative_config: Any,
+    ) -> None:
+        kv_transfer_config = self.vllm_config.kv_transfer_config
+        errors: list[str] = []
+        if speculative_config.method != "eagle3":
+            errors.append("method must be eagle3")
+        if speculative_config.num_speculative_tokens != 1:
+            errors.append("num_speculative_tokens must be 1")
+        if not current_platform.is_cuda():
+            errors.append("CUDA is required")
+        if not any(
+            "MiniMaxM3" in str(arch) for arch in (self.model_config.architectures or [])
+        ):
+            errors.append("target architecture must be MiniMaxM3")
+        if self.model_config.get_total_num_hidden_layers() != 60:
+            errors.append("target model must contain exactly 60 layers")
+        if self.parallel_config.pipeline_parallel_size != 2:
+            errors.append("pipeline_parallel_size must be 2")
+        if self.parallel_config.tensor_parallel_size != 4:
+            errors.append("tensor_parallel_size must be 4")
+        if self.parallel_config.decode_context_parallel_size != 1:
+            errors.append("decode_context_parallel_size must be 1")
+        if (
+            kv_transfer_config is None
+            or kv_transfer_config.kv_connector != "MooncakeConnector"
+            or kv_transfer_config.kv_role != "kv_producer"
+            or kv_transfer_config.kv_connector_module_path is not None
+            or kv_transfer_config.kv_load_failure_policy != "fail"
+        ):
+            errors.append("built-in Mooncake pure producer in fail mode is required")
+        draft_model_config = speculative_config.draft_model_config
+        layer_ids = (
+            None
+            if draft_model_config is None
+            else getattr(
+                draft_model_config.hf_config,
+                "eagle_aux_hidden_state_layer_ids",
+                None,
+            )
+        )
+        if layer_ids is None:
+            layer_ids = (2, 30, 57)
+        if tuple(layer_ids or ()) != (2, 30, 57):
+            errors.append("auxiliary hidden-state layers must be (2, 30, 57)")
+        if errors:
+            raise ValueError(
+                "EAGLE3 Prefill draft-KV runner requirements not met: "
+                + "; ".join(errors)
+            )
+
+        pp_group = get_pp_group()
+        if pp_group.is_last_rank:
+            return
+        self._producer_aux_hidden_state_layers = (2, 30, 57)
+        self.use_aux_hidden_state_outputs = True
+        self.speculative_config = None
 
     def update_max_model_len(self, max_model_len: int) -> None:
         self.max_model_len = max_model_len
@@ -2732,6 +2866,27 @@ class GPUModelRunner(
             if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
                 kv_cache_spec = kv_cache_spec.kv_cache_specs[attn_group.layer_names[0]]
             cache_key = (kv_cache_spec, type(builder))
+            group_attn_metadata = common_attn_metadata
+            if (
+                kv_cache_spec.temporal_layout == KVCacheTemporalLayout.FULL_TEMPORAL
+                and set(attn_group.layer_names) & self._full_temporal_target_layers
+                and self.dcp_world_size > 1
+            ):
+                if ubid is not None:
+                    raise ValueError(
+                        "EAGLE3 target dense full-temporal KV does not "
+                        "support ubatching"
+                    )
+                group_attn_metadata = common_attn_metadata.replace(
+                    block_table_tensor=self._full_temporal_block_tables[kv_cache_gid][
+                        : common_attn_metadata.num_reqs
+                    ],
+                    slot_mapping=self._full_temporal_slot_mappings[kv_cache_gid][
+                        : common_attn_metadata.num_actual_tokens
+                    ],
+                    dcp_local_seq_lens=None,
+                    dcp_local_seq_lens_cpu=None,
+                )
 
             cascade_attn_prefix_len = (
                 cascade_attn_prefix_lens[kv_cache_gid][attn_gid]
@@ -2767,7 +2922,7 @@ class GPUModelRunner(
 
             if for_cudagraph_capture:
                 attn_metadata_i = builder.build_for_cudagraph_capture(
-                    common_attn_metadata
+                    group_attn_metadata
                 )
             elif (
                 cache_key in cached_attn_metadata
@@ -2775,13 +2930,13 @@ class GPUModelRunner(
             ):
                 attn_metadata_i = builder.update_block_table(
                     cached_attn_metadata[cache_key],
-                    common_attn_metadata.block_table_tensor,
-                    common_attn_metadata.slot_mapping,
+                    group_attn_metadata.block_table_tensor,
+                    group_attn_metadata.slot_mapping,
                 )
             else:
                 attn_metadata_i = builder.build(
                     common_prefix_len=cascade_attn_prefix_len,
-                    common_attn_metadata=common_attn_metadata,
+                    common_attn_metadata=group_attn_metadata,
                     **extra_attn_metadata_args,
                 )
                 if builder.supports_update_block_table:
@@ -3795,9 +3950,7 @@ class GPUModelRunner(
         is_first_rank = get_pp_group().is_first_rank
         is_encoder_decoder = self.model_config.is_encoder_decoder
 
-        # Clamp speculative scheduler placeholders (-1) before embedding lookup.
-        if self.speculative_config is not None:
-            self.input_ids.gpu[:num_input_tokens].clamp_(min=0)
+        self._clamp_speculative_input_ids(num_input_tokens)
 
         # _prepare_inputs may reorder the batch, so we must gather multi
         # modal outputs after that to ensure the correct order
@@ -3928,6 +4081,17 @@ class GPUModelRunner(
             model_kwargs,
             ec_connector_output,
         )
+
+    def _clamp_speculative_input_ids(self, num_input_tokens: int) -> None:
+        target_speculative_config = getattr(
+            self,
+            "_target_speculative_config",
+            None,
+        )
+        if target_speculative_config is None:
+            target_speculative_config = getattr(self, "speculative_config", None)
+        if target_speculative_config is not None:
+            self.input_ids.gpu[:num_input_tokens].clamp_(min=0)
 
     def _sample(
         self,
@@ -4336,12 +4500,70 @@ class GPUModelRunner(
                 pyt_hooks.register_hooks(self.model, self.model.__class__.__name__)
                 self.layerwise_nvtx_hooks_registered = True
 
+    def _get_full_temporal_target_mapping(
+        self,
+        kv_cache_gid: int,
+        num_tokens_padded: int,
+        num_reqs_padded: int,
+        num_tokens_unpadded: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        parent_table = self.input_batch.block_table[kv_cache_gid].get_device_tensor(
+            num_reqs_padded
+        )
+        kernel_block_size = self.input_batch.block_table[kv_cache_gid].block_size
+        expanded = expand_dcp_parent_block_table(
+            parent_table,
+            dcp_world_size=self.dcp_world_size,
+            max_model_len=self.max_model_len,
+            kernel_block_size=kernel_block_size,
+        )
+        block_buffer = self._full_temporal_block_tables.get(kv_cache_gid)
+        if block_buffer is None:
+            max_num_reqs = self.input_batch.block_table[
+                kv_cache_gid
+            ].block_table.gpu.shape[0]
+            block_buffer = torch.empty(
+                (max_num_reqs, expanded.shape[1]),
+                dtype=expanded.dtype,
+                device=self.device,
+            )
+            self._full_temporal_block_tables[kv_cache_gid] = block_buffer
+        block_table = block_buffer[:num_reqs_padded]
+        block_table.copy_(expanded)
+
+        slot_buffer = self._full_temporal_slot_mappings.get(kv_cache_gid)
+        if slot_buffer is None:
+            slot_buffer = torch.empty(
+                self.max_num_tokens,
+                dtype=torch.int64,
+                device=self.device,
+            )
+            self._full_temporal_slot_mappings[kv_cache_gid] = slot_buffer
+        slot_mapping = slot_buffer[:num_tokens_padded]
+        computed_slot_mapping = compute_slot_mapping_from_block_table(
+            query_start_loc=self.query_start_loc.gpu[: num_reqs_padded + 1],
+            block_table_tensor=block_table,
+            positions=self.positions[:num_tokens_unpadded],
+            block_size=kernel_block_size,
+            max_model_len=self.max_model_len,
+        )
+        slot_mapping[:num_tokens_unpadded].copy_(computed_slot_mapping)
+        slot_mapping[num_tokens_unpadded:num_tokens_padded].fill_(-1)
+        return block_table, slot_mapping
+
+    def _clear_full_temporal_target_mappings(self) -> None:
+        if hasattr(self, "_full_temporal_block_tables"):
+            self._full_temporal_block_tables.clear()
+        if hasattr(self, "_full_temporal_slot_mappings"):
+            self._full_temporal_slot_mappings.clear()
+
     def _get_slot_mappings(
         self,
         num_tokens_padded: int,
         num_reqs_padded: int,
         num_tokens_unpadded: int,
         ubatch_slices: "UBatchSlices | None" = None,
+        skip_full_temporal_mapping: bool = False,
     ) -> tuple[
         dict[int, torch.Tensor] | None,
         dict[str, torch.Tensor] | list[dict[str, torch.Tensor]] | None,
@@ -4398,6 +4620,22 @@ class GPUModelRunner(
             slot_mapping = slot_mappings_by_gid[gid]
             for layer_name in kv_cache_group.layer_names:
                 slot_mappings_by_layer[layer_name] = slot_mapping
+            full_temporal_target_layers = self._full_temporal_target_layers & set(
+                kv_cache_group.layer_names
+            )
+            if (
+                full_temporal_target_layers
+                and self.dcp_world_size > 1
+                and not skip_full_temporal_mapping
+            ):
+                _, full_temporal_slot_mapping = self._get_full_temporal_target_mapping(
+                    gid,
+                    num_tokens_padded,
+                    num_reqs_padded,
+                    num_tokens_unpadded,
+                )
+                for layer_name in full_temporal_target_layers:
+                    slot_mappings_by_layer[layer_name] = full_temporal_slot_mapping
 
         if ubatch_slices is not None:
             result: list[dict[str, torch.Tensor]] = []
@@ -4731,7 +4969,7 @@ class GPUModelRunner(
             )
 
         with record_function_or_nullcontext("gpu_model_runner: postprocess"):
-            if self.use_aux_hidden_state_outputs:
+            if self.use_aux_hidden_state_outputs and get_pp_group().is_last_rank:
                 # True when EAGLE 3 is used.
                 hidden_states, aux_hidden_states = model_output
             else:
@@ -5779,7 +6017,10 @@ class GPUModelRunner(
             )
         # Try to get auxiliary layers from speculative config,
         # otherwise use model's default layers
-        aux_layers = self._get_eagle3_aux_layers_from_config()
+        aux_layers = (
+            self._producer_aux_hidden_state_layers
+            or self._get_eagle3_aux_layers_from_config()
+        )
         if aux_layers:
             logger.info(
                 "Using auxiliary layers from speculative config: %s", aux_layers
@@ -6278,19 +6519,11 @@ class GPUModelRunner(
         )
 
         attn_metadata: PerLayerAttnMetadata | None = None
-
-        slot_mappings_by_group, slot_mappings = self._get_slot_mappings(
-            num_tokens_padded=num_tokens_padded,
-            num_reqs_padded=num_reqs_padded,
-            num_tokens_unpadded=num_tokens_unpadded,
-            ubatch_slices=ubatch_slices_padded,
+        slot_mappings_by_group = None
+        slot_mappings = None
+        build_attention_metadata = (
+            force_attention or cudagraph_runtime_mode == CUDAGraphMode.FULL
         )
-
-        # Dummy runs have no real slot assignments — fill with -1 so
-        # concat_and_cache kernels skip the KV write.
-        if slot_mappings_by_group is not None:
-            for sm in slot_mappings_by_group.values():
-                sm.fill_(-1)
 
         # _dummy_run shares pinned CPU buffers (seq_lens, query_start_loc,
         # etc.) with execute_model.  It must participate in the same event
@@ -6299,7 +6532,7 @@ class GPUModelRunner(
         with self.synchronize_input_prep():
             # If force_attention is True, we always capture attention.
             # Otherwise, it only happens for cudagraph_runtime_mode=FULL.
-            if force_attention or cudagraph_runtime_mode == CUDAGraphMode.FULL:
+            if build_attention_metadata:
                 if profile_seq_lens is not None:
                     seq_lens = profile_seq_lens  # type: ignore[assignment]
                 elif create_mixed_batch:
@@ -6351,6 +6584,23 @@ class GPUModelRunner(
                 # requests can corrupt Mamba state.
                 self.input_batch.block_table.commit_block_table(num_reqs_padded)
 
+            slot_mappings_by_group, slot_mappings = self._get_slot_mappings(
+                num_tokens_padded=num_tokens_padded,
+                num_reqs_padded=num_reqs_padded,
+                num_tokens_unpadded=num_tokens_unpadded,
+                ubatch_slices=ubatch_slices_padded,
+                skip_full_temporal_mapping=not build_attention_metadata,
+            )
+
+            # Dummy runs have no real slot assignments — fill with -1 so
+            # concat_and_cache kernels skip the KV write.
+            if slot_mappings_by_group is not None:
+                for sm in slot_mappings_by_group.values():
+                    sm.fill_(-1)
+                for sm in self._full_temporal_slot_mappings.values():
+                    sm.fill_(-1)
+
+            if build_attention_metadata:
                 pad_attn = cudagraph_runtime_mode == CUDAGraphMode.FULL
                 attn_metadata, _ = self._build_attention_metadata(
                     num_tokens=num_tokens_unpadded,
@@ -6442,7 +6692,7 @@ class GPUModelRunner(
                     **model_kwargs,
                 )
 
-            if self.use_aux_hidden_state_outputs:
+            if self.use_aux_hidden_state_outputs and get_pp_group().is_last_rank:
                 hidden_states, _ = outputs
             else:
                 hidden_states = outputs
@@ -6857,6 +7107,7 @@ class GPUModelRunner(
 
     def _cleanup_profiling_kv_cache(self) -> None:
         torch.accelerator.synchronize()
+        self._clear_full_temporal_target_mappings()
         if hasattr(self, "kv_caches") and self.kv_caches:
             for i in range(len(self.kv_caches)):
                 self.kv_caches[i] = None  # type: ignore
@@ -7478,6 +7729,7 @@ class GPUModelRunner(
             max_num_reqs=self.max_num_reqs,
             is_profiling=is_profiling,
         )
+        self._validate_replicated_draft_cudagraph_mode(cudagraph_mode)
         # Trigger cudagraph dispatching keys initialization after
         # resolved cudagraph mode.
         self.cudagraph_dispatcher.initialize_cudagraph_keys(
@@ -7499,6 +7751,28 @@ class GPUModelRunner(
                 | Gemma4Proposer,
             )
             self.drafter.initialize_cudagraph_keys(cudagraph_mode)
+
+    def _validate_replicated_draft_cudagraph_mode(
+        self,
+        cudagraph_mode: CUDAGraphMode,
+    ) -> None:
+        speculative_config = self.speculative_config
+        if speculative_config is None or not getattr(
+            speculative_config,
+            "enable_eagle3_replicated_draft_kv",
+            False,
+        ):
+            return
+        expected_mode = (
+            CUDAGraphMode.NONE
+            if self.model_config.enforce_eager
+            else CUDAGraphMode.FULL_DECODE_ONLY
+        )
+        if cudagraph_mode != expected_mode:
+            raise ValueError(
+                "EAGLE3 replicated draft KV resolved an unsupported CUDA Graph "
+                f"mode: expected {expected_mode.name}, got {cudagraph_mode.name}"
+            )
 
     def calculate_reorder_batch_threshold(self) -> None:
         """
@@ -7927,6 +8201,7 @@ class GPUModelRunner(
             cache size of each layer
         """
         kv_cache_config = deepcopy(kv_cache_config)
+        self._clear_full_temporal_target_mappings()
         self.kv_cache_config = kv_cache_config
         self._mamba_bufs = None
         self.may_add_encoder_only_layers_to_kv_cache_config()
@@ -8084,6 +8359,37 @@ class GPUModelRunner(
         kv_cache_spec: dict[str, KVCacheSpec] = {}
         layer_type = cast(type[Any], AttentionLayerBase)
         attn_layers = get_layers_from_vllm_config(self.vllm_config, layer_type)
+        target_speculative_config = getattr(
+            self,
+            "_target_speculative_config",
+            self.speculative_config,
+        )
+        full_temporal_target_layers = (
+            set(resolve_minimax_m3_dense_target_attention_layer_names(set(attn_layers)))
+            if target_speculative_config is not None
+            and getattr(
+                target_speculative_config,
+                "enable_eagle3_target_dense_full_temporal_kv",
+                False,
+            )
+            else set()
+        )
+        full_temporal_draft_layer = None
+        if self.speculative_config is not None and (
+            getattr(
+                self.speculative_config,
+                "enable_eagle3_prefill_draft_kv",
+                False,
+            )
+            or getattr(
+                self.speculative_config,
+                "enable_eagle3_replicated_draft_kv",
+                False,
+            )
+        ):
+            full_temporal_draft_layer = get_eagle3_draft_attention_layer_name(
+                self.model_config.get_total_num_hidden_layers()
+            )
         for layer_name, attn_module in attn_layers.items():
             if isinstance(attn_module, Attention) and (
                 kv_tgt_layer := attn_module.kv_sharing_target_layer_name
@@ -8106,8 +8412,38 @@ class GPUModelRunner(
                     with set_current_vllm_config(self.vllm_config):
                         indexes = backend.indexes_kv_by_block_stride()
                     spec = replace(spec, indexes_kv_by_block_stride=indexes)
+                if (
+                    layer_name == full_temporal_draft_layer
+                    or layer_name in full_temporal_target_layers
+                ):
+                    spec = replace(
+                        spec,
+                        temporal_layout=KVCacheTemporalLayout.FULL_TEMPORAL,
+                    )
+                if (
+                    layer_name in full_temporal_target_layers
+                    and self.dcp_world_size > 1
+                ):
+                    if attn_module.get_attn_backend().get_name() != "FLASH_ATTN":
+                        raise ValueError(
+                            "EAGLE3 target dense full-temporal KV requires FLASH_ATTN"
+                        )
+                    impl = attn_module.impl
+                    impl.dcp_world_size = 1
+                    impl.dcp_rank = 0
+                    impl.total_cp_world_size = impl.pcp_world_size
+                    impl.total_cp_rank = impl.pcp_rank
+                    impl.need_to_return_lse_for_decode = False
                 kv_cache_spec[layer_name] = spec
 
+        self._full_temporal_target_layers = full_temporal_target_layers
+        if full_temporal_draft_layer is not None and full_temporal_draft_layer not in (
+            kv_cache_spec
+        ):
+            raise ValueError(
+                "EAGLE3 full-temporal draft-KV layer is missing from the KV cache "
+                f"spec: {full_temporal_draft_layer}"
+            )
         return kv_cache_spec
 
     def _to_list(self, sampled_token_ids: torch.Tensor) -> list[list[int]]:


### PR DESCRIPTION
## Summary
- Add canonical DCP page/slot mapping utilities and MiniMax-M3 sparse DCP support.
- Preserve MiniMax-M3 EAGLE3 acceptance under TP8+DCP2 by using full-temporal KV for Draft60 and EAGLE-sensitive target dense layers, while keeping target sparse layers sharded.
- Add Mooncake region-aware transfer, replicated draft KV handling, scheduler capacity/no-preemption hardening, and lifecycle safeguards.
- Add focused tests for DCP mapping, Mooncake transfer contracts, scheduler behavior, EAGLE3 draft KV, and MiniMax-M3 DCP contracts.

## Validation
- Clean rebuild candidate: fix/dcp-production-clean@610392b528.
- R5 workload completed 320/320: weighted acceptance 76.0399%, output throughput 775.96 tok/s, mean TPOT 70.27 ms.
- GSM8K full 0-shot: 1276/1319 = 96.74%.
- AIME25 repeat4: 99/120 = 82.50%.
- Lifecycle coverage included prefix miss/full/partial/shared hit, C64, max_num_seqs=512, abort, 100-cycle reuse, restart, and FULL_DECODE_ONLY CUDA Graph.

## Notes
- The PR contains the 7 clean commits rebuilt on iaas_main. Local uncommitted formatting-only changes were not included in the pushed branch.